### PR TITLE
feat: auto light and dark map themes

### DIFF
--- a/public_html/map.html
+++ b/public_html/map.html
@@ -333,6 +333,28 @@ body, html {
         .qr-btn svg { width: 22px; height: 22px; display: block; }
 
 
+        /* Dark theme overrides */
+        @media (prefers-color-scheme: dark) {
+          body, html {
+            background-color: #000;
+            color: #ddd;
+          }
+          .custom-tooltip {
+            background-color: #333;
+            color: #ddd;
+          }
+          .upload-btn, .locate-btn, .back-to-all-btn, .qr-btn, .slider-reset-btn, .slider-toggle button {
+            background-color: #333;
+            border: 1px solid #555;
+            color: #eee;
+          }
+          .upload-btn:hover, .locate-btn:hover, .back-to-all-btn:hover, .qr-btn:hover, .slider-reset-btn:hover {
+            background-color: #444;
+          }
+          .program-info { color: #ccc; }
+          .program-info a { color: #90caf9; }
+        }
+
     </style>
 
     <!-- Скрипт переводов -->
@@ -643,15 +665,26 @@ document.addEventListener('DOMContentLoaded', function () {
     var backBox = document.querySelector('.back-to-all-container');
     if (backBox) backBox.style.display = 'block';
   }
-  // Инициализация слоёв карты
-  osmLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  // Инициализация слоёв карты с автоматическим выбором темы
+  const media = window.matchMedia('(prefers-color-scheme: dark)');
+  const osmLight = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+  const osmDark  = 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png';
+  const googleLight = 'https://mt1.google.com/vt/lyrs=m&x={x}&y={y}&z={z}';
+  const googleDark  = 'https://mt1.google.com/vt/lyrs=y&x={x}&y={y}&z={z}';
+
+  osmLayer = L.tileLayer(media.matches ? osmDark : osmLight, {
     maxZoom: 18,
     attribution: '&copy; OpenStreetMap contributors'
   });
 
-  googleSatellite = L.tileLayer('https://mt1.google.com/vt/lyrs=s&x={x}&y={y}&z={z}', {
+  googleSatellite = L.tileLayer(media.matches ? googleDark : googleLight, {
     maxZoom: 20,
     attribution: '&copy; Google'
+  });
+
+  media.addEventListener('change', e => {
+    osmLayer.setUrl(e.matches ? osmDark : osmLight);
+    googleSatellite.setUrl(e.matches ? googleDark : googleLight);
   });
 
   // сразу после создания osmLayer и googleSatellite


### PR DESCRIPTION
## Summary
- Automatically load dark or light map tiles for OSM and Google based on user theme
- Apply dark mode colors to site buttons and tooltips

## Testing
- ⚠️ `go build ./...` (command hung due to network, aborted)


------
https://chatgpt.com/codex/tasks/task_e_68bfc59c80388332aaa06d09d12aa077