### PR TITLE
Adapt upload overlay to system theme

### DIFF
--- a/public_html/map.html
+++ b/public_html/map.html
@@ -20,6 +20,25 @@ body, html {
   overflow: hidden; /* Hide scrollbars */
 }
 
+        /* Color variables adapt to system theme */
+        :root {
+          --overlay-bg: rgba(255, 255, 255, 0.7);
+          --progress-bg: #ffffff;
+          --progress-color: #333333;
+          --progress-bar-bg: #f4f4f4;
+          --progress-shadow: 0 0 15px rgba(0, 0, 0, 0.3);
+        }
+
+        @media (prefers-color-scheme: dark) {
+          :root {
+            --overlay-bg: rgba(0, 0, 0, 0.7);
+            --progress-bg: #2b2b2b;
+            --progress-color: #f4f4f4;
+            --progress-bar-bg: #555555;
+            --progress-shadow: 0 0 15px rgba(255, 255, 255, 0.1);
+          }
+        }
+
         /* Map container */
         #map {
           height: 100vh; /* Map takes full viewport height */
@@ -62,7 +81,7 @@ body, html {
           left: 0;
           width: 100%;
           height: 100%;
-          background-color: rgba(0, 0, 0, 0.7);
+          background-color: var(--overlay-bg);
           z-index: 10000;
           display: flex;
           justify-content: center;
@@ -71,12 +90,15 @@ body, html {
 
         /* Upload progress container */
         #fileProgressContainer {
-          background-color: white;
+          background-color: var(--progress-bg);
+          color: var(--progress-color);
           padding: 20px;
           border-radius: 10px;
           max-width: 600px;
           width: 100%;
-          box-shadow: 0 0 15px rgba(0, 0, 0, 0.3);
+          box-shadow: var(--progress-shadow);
+          max-height: 80vh;
+          overflow-y: auto; /* Allow scrolling for many uploads */
         }
 
         /* Individual file upload progress */
@@ -93,7 +115,7 @@ body, html {
         .progress-bar {
           width: 100%;
           height: 10px;
-          background-color: #f4f4f4;
+          background-color: var(--progress-bar-bg);
           border-radius: 5px;
           overflow: hidden;
         }


### PR DESCRIPTION
## Summary
- use CSS variables and prefers-color-scheme to honor system dark/light mode
- allow scrolling through long upload queues

## Testing
- `go test -run TestNonExistent ./...` *(fails: command produced no output and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd1d70f1483328f3d902afe810c76