### PR TITLE
Remove border from map layer selector

### DIFF
--- a/public_html/map.html
+++ b/public_html/map.html
@@ -383,6 +383,16 @@ body, html {
           .program-info a { color: #90caf9; }
         }
 
+        /* ===== Leaflet layer control ===== */
+        /* Remove border and shadow around map type selector to blend into map */
+        .leaflet-control-layers,
+        .leaflet-control-layers-expanded,
+        .leaflet-control-layers-list {
+          background: none;
+          border: none;
+          box-shadow: none;
+        }
+
     </style>
 
     <!-- Translation script -->


### PR DESCRIPTION
## Summary
- polish map layer selector by stripping border, shadow and background for the Google/OSM switch

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bfd69d217c8332813184bad2a93167