### PR TITLE
Move back button below QR control

### DIFF
--- a/public_html/map.html
+++ b/public_html/map.html
@@ -207,10 +207,11 @@ body, html {
           opacity: 1;
         }
 
-        /* "Back to all tracks" button */
+        /* "Back to all tracks" button container.
+           Positioned below the QR button to prevent overlap. */
         .back-to-all-container {
           position: absolute;
-          top: 120px;
+          top: 170px; /* place under geolocation+QR stack */
           right: 20px;
           z-index: 1000;
           display: none;


### PR DESCRIPTION
## Summary
- avoid overlapping the "back to all tracks" and QR buttons by positioning the back button lower

## Testing
- `go vet ./...`
- `go test ./...` *(failed: command produced no output)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe43c87dc833281439adcfccd082a