### PR TITLE
Stream markers asynchronously with SSE

### DIFF
--- a/chicha-isotope-map.go
+++ b/chicha-isotope-map.go
@@ -2027,6 +2027,7 @@ func main() {
 	http.HandleFunc("/", mapHandler)
 	http.HandleFunc("/upload", uploadHandler)
 	http.HandleFunc("/get_markers", getMarkersHandler)
+	http.HandleFunc("/stream_markers", streamMarkersHandler)
 	http.HandleFunc("/trackid/", trackHandler)
 	http.HandleFunc("/qrpng", qrPngHandler)
 

--- a/pkg/database/stream.go
+++ b/pkg/database/stream.go
@@ -1,0 +1,61 @@
+package database
+
+import (
+	"context"
+	"fmt"
+)
+
+// StreamMarkersByZoomAndBounds streams markers row by row through a channel.
+// It avoids loading large result sets into memory and stops when the context is done.
+func (db *Database) StreamMarkersByZoomAndBounds(ctx context.Context, zoom int, minLat, minLon, maxLat, maxLon float64, dbType string) (<-chan Marker, <-chan error) {
+	out := make(chan Marker)
+	errCh := make(chan error, 1)
+
+	go func() {
+		defer close(out)
+		defer close(errCh)
+
+		var query string
+		switch dbType {
+		case "pgx":
+			query = `
+                SELECT id, doseRate, date, lon, lat, countRate, zoom, speed, trackID
+                FROM markers
+                WHERE zoom = $1 AND lat BETWEEN $2 AND $3 AND lon BETWEEN $4 AND $5;
+            `
+		default:
+			query = `
+                SELECT id, doseRate, date, lon, lat, countRate, zoom, speed, trackID
+                FROM markers
+                WHERE zoom = ? AND lat BETWEEN ? AND ? AND lon BETWEEN ? AND ?;
+            `
+		}
+
+		rows, err := db.DB.QueryContext(ctx, query, zoom, minLat, maxLat, minLon, maxLon)
+		if err != nil {
+			errCh <- fmt.Errorf("query markers: %w", err)
+			return
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var m Marker
+			if err := rows.Scan(&m.ID, &m.DoseRate, &m.Date, &m.Lon, &m.Lat, &m.CountRate, &m.Zoom, &m.Speed, &m.TrackID); err != nil {
+				errCh <- fmt.Errorf("scan marker: %w", err)
+				return
+			}
+			select {
+			case out <- m:
+			case <-ctx.Done():
+				errCh <- ctx.Err()
+				return
+			}
+		}
+
+		if err := rows.Err(); err != nil {
+			errCh <- fmt.Errorf("iterate markers: %w", err)
+		}
+	}()
+
+	return out, errCh
+}

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -654,7 +654,7 @@ var trackBounds;
 var currentTrackID = null;
 
 // New controller to cancel previous request
-var markerFetchController = null;
+var markerStreamSource = null;
 
 
 /**
@@ -1148,8 +1148,7 @@ function updateMarkers(){
   const loadingEl = document.getElementById('loadingOverlay');
   if (loadingEl) loadingEl.style.display='block';
 
-  if (markerFetchController) markerFetchController.abort();
-  markerFetchController = new AbortController();
+  if (markerStreamSource) markerStreamSource.close();
 
   const zoom   = map.getZoom();
   const bounds = map.getBounds();
@@ -1162,95 +1161,62 @@ function updateMarkers(){
     maxLon: bounds.getNorthEast().lng
   };
 
-  // speed filter (global view only)
-  if (!isTrackView) {
-    const sp = loadSpeedFilterState();
-    const speeds = [];
-    if (sp.plane) speeds.push('plane');
-    if (sp.car)   speeds.push('car');
-    if (sp.ped)   speeds.push('ped');
-    if (speeds.length && speeds.length !== 3){
-      params.speeds = speeds.join(',');
+  const savedRange = loadDateRangeState();
+
+  for (const key in circleMarkers) map.removeLayer(circleMarkers[key]);
+  circleMarkers = {};
+
+  const tracks = new Set();
+  let minTs = Infinity, maxTs = -Infinity;
+
+  const es = new EventSource('/stream_markers?' + new URLSearchParams(params));
+  markerStreamSource = es;
+
+  es.onmessage = e => {
+    let m; try { m = JSON.parse(e.data); } catch { return; }
+    if (m.trackID) tracks.add(m.trackID);
+    minTs = Math.min(minTs, m.date);
+    maxTs = Math.max(maxTs, m.date);
+    if (savedRange && (m.date < savedRange[0] || m.date > savedRange[1])) return;
+    if (!shouldDisplayBySpeed(m.speed)) return;
+    const cm = L.circleMarker([m.lat, m.lon], {
+      radius      : getRadius(m.doseRate, zoom),
+      fillColor   : getGradientColor(m.doseRate),
+      color       : getGradientColor(m.doseRate),
+      weight      : 1,
+      opacity     : getFillOpacity(m.speed) + 0.1,
+      fillOpacity : getFillOpacity(m.speed)
+    })
+    .addTo(map)
+    .bindTooltip(getTooltipContent(m),
+        { direction:'top', className:'custom-tooltip', offset:[0,-8] })
+    .bindPopup(getPopupContent(m));
+
+    circleMarkers[m.id || m.trackID] = cm;
+  };
+
+  es.addEventListener('done', () => {
+    const dateSpanMonths = (isFinite(minTs) && isFinite(maxTs))
+                            ? monthsApart(minTs, maxTs) : 0;
+    const needSlider = !isTrackView && tracks.size > 1 && dateSpanMonths > 1;
+    if (window.__setDateSliderVisibility){
+      window.__setDateSliderVisibility(needSlider);
     }
-  }
+    if (needSlider && window.__initSliderOnce && isFinite(minTs) && isFinite(maxTs)){
+      window.__initSliderOnce(minTs, maxTs);
+      window.__initSliderOnce = null;
+    }
+    if (needSlider && window.__syncDateSliders && isFinite(minTs) && isFinite(maxTs)){
+      window.__syncDateSliders(minTs, maxTs);
+    }
+    if (loadingEl) loadingEl.style.display='none';
+    es.close();
+  });
 
-  if (isTrackView && currentTrackID){
-    params.trackID = currentTrackID;
-  }
-
-  fetch('/get_markers?' + new URLSearchParams(params),
-        { signal: markerFetchController.signal })
-    .then(r => { if(!r.ok) throw new Error(`HTTP ${r.status}`); return r.json(); })
-    .then(data => {
-      if (!Array.isArray(data)) data = [];
-
-      // compute tracks count & time span for this viewport
-      const tracks = new Set();
-      let minTs = Infinity, maxTs = -Infinity;
-      data.forEach(m=>{
-        if (m.trackID) tracks.add(m.trackID);
-        minTs = Math.min(minTs, m.date);
-        maxTs = Math.max(maxTs, m.date);
-      });
-      const dateSpanMonths = (isFinite(minTs) && isFinite(maxTs))
-                              ? monthsApart(minTs, maxTs) : 0;
-
-      const needSlider = !isTrackView && tracks.size > 1 && dateSpanMonths > 1;
-
-      if (window.__setDateSliderVisibility){
-        window.__setDateSliderVisibility(needSlider);
-      }
-
-      // Build sliders first time
-      if (needSlider && window.__initSliderOnce && isFinite(minTs) && isFinite(maxTs)){
-        window.__initSliderOnce(minTs, maxTs);
-        window.__initSliderOnce = null; // one-shot
-      }
-
-      // Always keep sliders’ bounds/labels in sync with viewport
-      if (needSlider && window.__syncDateSliders && isFinite(minTs) && isFinite(maxTs)){
-        window.__syncDateSliders(minTs, maxTs);
-      }
-
-      // Apply time filter ONLY when user selected a custom range
-      if (!isTrackView && needSlider){
-        const saved = loadDateRangeState();
-        // We need full-range of current viewport → ask sync to decide;
-        // __syncDateSliders saved [minTs,maxTs] as "no filter".
-        if (saved && !(saved[0] === minTs && saved[1] === maxTs)){
-          data = data.filter(m => m.date >= saved[0] && m.date <= saved[1]);
-        }
-      }
-
-      // Render markers
-      for (const key in circleMarkers) map.removeLayer(circleMarkers[key]);
-      circleMarkers = {};
-
-      data.forEach(m=>{
-        if (!shouldDisplayBySpeed(m.speed)) return;
-
-        const cm = L.circleMarker([m.lat, m.lon], {
-          radius      : getRadius(m.doseRate, zoom),
-          fillColor   : getGradientColor(m.doseRate),
-          color       : getGradientColor(m.doseRate),
-          weight      : 1,
-          opacity     : getFillOpacity(m.speed) + 0.1,
-          fillOpacity : getFillOpacity(m.speed)
-        })
-        .addTo(map)
-        .bindTooltip(getTooltipContent(m),
-            { direction:'top', className:'custom-tooltip', offset:[0,-8] })
-        .bindPopup(getPopupContent(m));
-
-        circleMarkers[m.id || m.trackID] = cm;
-      });
-    })
-    .catch(err=>{
-      if (err.name !== 'AbortError') console.error('fetch:', err);
-    })
-    .finally(()=>{
-      if (loadingEl) loadingEl.style.display='none';
-    });
+  es.onerror = () => {
+    if (loadingEl) loadingEl.style.display='none';
+    es.close();
+  };
 }
 
 

--- a/streaming.go
+++ b/streaming.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"strconv"
+
+	"chicha-isotope-map/pkg/database"
+)
+
+// aggregateMarkers chooses the most radioactive marker per grid cell.
+// Cells shrink with higher zoom to preserve detail.
+func aggregateMarkers(ctx context.Context, in <-chan database.Marker, zoom int) <-chan database.Marker {
+	out := make(chan database.Marker)
+	go func() {
+		defer close(out)
+		cells := make(map[string]database.Marker)
+		scale := math.Pow(2, float64(zoom))
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case m, ok := <-in:
+				if !ok {
+					return
+				}
+				key := fmt.Sprintf("%d:%d", int(m.Lat*scale), int(m.Lon*scale))
+				if prev, ok := cells[key]; !ok || m.DoseRate > prev.DoseRate {
+					cells[key] = m
+					out <- m
+				}
+			}
+		}
+	}()
+	return out
+}
+
+// streamMarkersHandler streams markers via Server-Sent Events.
+// Markers are emitted as soon as they are read and aggregated.
+func streamMarkersHandler(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	zoom, _ := strconv.Atoi(q.Get("zoom"))
+	minLat, _ := strconv.ParseFloat(q.Get("minLat"), 64)
+	minLon, _ := strconv.ParseFloat(q.Get("minLon"), 64)
+	maxLat, _ := strconv.ParseFloat(q.Get("maxLat"), 64)
+	maxLon, _ := strconv.ParseFloat(q.Get("maxLon"), 64)
+
+	ctx := r.Context()
+	src, errCh := db.StreamMarkersByZoomAndBounds(ctx, zoom, minLat, minLon, maxLat, maxLon, *dbType)
+	agg := aggregateMarkers(ctx, src, zoom)
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "Streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case err := <-errCh:
+			if err != nil {
+				fmt.Fprintf(w, "event: done\ndata: %v\n\n", err)
+			} else {
+				fmt.Fprint(w, "event: done\ndata: end\n\n")
+			}
+			flusher.Flush()
+			return
+		case m, ok := <-agg:
+			if !ok {
+				fmt.Fprint(w, "event: done\ndata: end\n\n")
+				flusher.Flush()
+				return
+			}
+			b, _ := json.Marshal(m)
+			fmt.Fprintf(w, "data: %s\n\n", b)
+			flusher.Flush()
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- stream markers directly from the database row-by-row using channels
- aggregate markers by grid cell keeping only the highest dose rate
- expose `/stream_markers` SSE endpoint and consume it from the map for incremental rendering

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c056dc281c833292d5cc162208da9f