### PR TITLE
Sort streamed markers by timestamp

### DIFF
--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -571,6 +571,7 @@ func (db *Database) GetMarkersByZoomAndBounds(zoom int, minLat, minLon, maxLat, 
 }
 
 // GetMarkersByTrackID retrieves markers filtered by trackID.
+// Results are ordered by timestamp to preserve the track direction.
 func (db *Database) GetMarkersByTrackID(trackID string, dbType string) ([]Marker, error) {
 	var query string
 
@@ -578,16 +579,18 @@ func (db *Database) GetMarkersByTrackID(trackID string, dbType string) ([]Marker
 	switch dbType {
 	case "pgx":
 		query = `
-		SELECT id, doseRate, date, lon, lat, countRate, zoom, speed, trackID
-		FROM markers
-		WHERE trackID = $1;
-		`
+                SELECT id, doseRate, date, lon, lat, countRate, zoom, speed, trackID
+                FROM markers
+                WHERE trackID = $1
+                ORDER BY date ASC;
+                `
 	default:
 		query = `
-		SELECT id, doseRate, date, lon, lat, countRate, zoom, speed, trackID
-		FROM markers
-		WHERE trackID = ?;
-		`
+                SELECT id, doseRate, date, lon, lat, countRate, zoom, speed, trackID
+                FROM markers
+                WHERE trackID = ?
+                ORDER BY date ASC;
+                `
 	}
 
 	// Execute the query
@@ -618,6 +621,7 @@ func (db *Database) GetMarkersByTrackID(trackID string, dbType string) ([]Marker
 }
 
 // GetMarkersByTrackIDAndBounds retrieves markers filtered by trackID and geographical bounds.
+// Markers are ordered by timestamp to render the track sequentially.
 func (db *Database) GetMarkersByTrackIDAndBounds(trackID string, minLat, minLon, maxLat, maxLon float64, dbType string) ([]Marker, error) {
 	var query string
 
@@ -625,16 +629,18 @@ func (db *Database) GetMarkersByTrackIDAndBounds(trackID string, minLat, minLon,
 	switch dbType {
 	case "pgx":
 		query = `
-		SELECT id, doseRate, date, lon, lat, countRate, zoom, speed, trackID
-		FROM markers
-		WHERE trackID = $1 AND lat BETWEEN $2 AND $3 AND lon BETWEEN $4 AND $5;
-		`
+                SELECT id, doseRate, date, lon, lat, countRate, zoom, speed, trackID
+                FROM markers
+                WHERE trackID = $1 AND lat BETWEEN $2 AND $3 AND lon BETWEEN $4 AND $5
+                ORDER BY date ASC;
+                `
 	default:
 		query = `
-		SELECT id, doseRate, date, lon, lat, countRate, zoom, speed, trackID
-		FROM markers
-		WHERE trackID = ? AND lat BETWEEN ? AND ? AND lon BETWEEN ? AND ?;
-		`
+                SELECT id, doseRate, date, lon, lat, countRate, zoom, speed, trackID
+                FROM markers
+                WHERE trackID = ? AND lat BETWEEN ? AND ? AND lon BETWEEN ? AND ?
+                ORDER BY date ASC;
+                `
 	}
 
 	// Execute the query
@@ -665,7 +671,8 @@ func (db *Database) GetMarkersByTrackIDAndBounds(trackID string, minLat, minLon,
 	return markers, nil
 }
 
-// GetMarkersByTrackIDZoomAndBounds исправленный вариант
+// GetMarkersByTrackIDZoomAndBounds returns markers for a track within bounds at a given zoom.
+// Sorting by timestamp keeps the visual trace in chronological order.
 func (db *Database) GetMarkersByTrackIDZoomAndBounds(
 	trackID string,
 	zoom int,
@@ -682,7 +689,8 @@ func (db *Database) GetMarkersByTrackIDZoomAndBounds(
         WHERE  trackID = $1
           AND  zoom     = $2
           AND  lat BETWEEN $3 AND $4
-          AND  lon BETWEEN $5 AND $6;`
+          AND  lon BETWEEN $5 AND $6
+        ORDER BY date ASC;`
 	default: // SQLite / Genji
 		query = `
         SELECT id, doseRate, date, lon, lat, countRate, zoom, speed, trackID
@@ -690,7 +698,8 @@ func (db *Database) GetMarkersByTrackIDZoomAndBounds(
         WHERE  trackID = ?
           AND  zoom     = ?
           AND  lat BETWEEN ? AND ?
-          AND  lon BETWEEN ? AND ?;`
+          AND  lon BETWEEN ? AND ?
+        ORDER BY date ASC;`
 	}
 
 	rows, err := db.DB.Query(query,

--- a/pkg/database/stream.go
+++ b/pkg/database/stream.go
@@ -7,6 +7,7 @@ import (
 
 // StreamMarkersByZoomAndBounds streams markers row by row through a channel.
 // It avoids loading large result sets into memory and stops when the context is done.
+// Markers are sorted by timestamp so the track is drawn from start to finish.
 func (db *Database) StreamMarkersByZoomAndBounds(ctx context.Context, zoom int, minLat, minLon, maxLat, maxLon float64, dbType string) (<-chan Marker, <-chan error) {
 	out := make(chan Marker)
 	errCh := make(chan error, 1)
@@ -21,13 +22,15 @@ func (db *Database) StreamMarkersByZoomAndBounds(ctx context.Context, zoom int, 
 			query = `
                 SELECT id, doseRate, date, lon, lat, countRate, zoom, speed, trackID
                 FROM markers
-                WHERE zoom = $1 AND lat BETWEEN $2 AND $3 AND lon BETWEEN $4 AND $5;
+                WHERE zoom = $1 AND lat BETWEEN $2 AND $3 AND lon BETWEEN $4 AND $5
+                ORDER BY date ASC;
             `
 		default:
 			query = `
                 SELECT id, doseRate, date, lon, lat, countRate, zoom, speed, trackID
                 FROM markers
-                WHERE zoom = ? AND lat BETWEEN ? AND ? AND lon BETWEEN ? AND ?;
+                WHERE zoom = ? AND lat BETWEEN ? AND ? AND lon BETWEEN ? AND ?
+                ORDER BY date ASC;
             `
 		}
 


### PR DESCRIPTION
## Summary
- ensure streamed markers are ordered chronologically by adding `ORDER BY date ASC`
- return track markers sorted by time for all track queries to draw tracks from start to finish

## Testing
- `go test ./...` *(fails: aggregateMarkers redeclared in chicha-isotope-map.go and streaming.go)*

------
https://chatgpt.com/codex/tasks/task_e_68c06319170083328b2cd9a565593fb3