### PR TITLE
Add attention category and hover legend tooltip

### DIFF
--- a/public_html/map.html
+++ b/public_html/map.html
@@ -178,6 +178,22 @@ body, html {
           box-shadow: 0px 0px 3px rgba(0,0,0,0.3);
         }
 
+        /* Link inside popups pointing to full legend */
+        .risk-link {
+          color: var(--link-color);
+          text-decoration: underline;
+        }
+
+        /* Larger color squares for legend items */
+        .legend-square {
+          display: inline-block;
+          width: 12px;
+          height: 12px;
+          margin-right: 6px;
+          border: var(--legend-border);
+          border-radius: 2px;
+        }
+
         /* Container for upload button */
         .upload-btn-container {
           position: absolute;
@@ -667,10 +683,11 @@ body, html {
     <strong>{{translate "legend_title"}}</strong><br>
     <div><span style="color:#000000;">■</span> >100 µR/h</div>
     <div><span style="color:#FF4500;">■</span> 30–100 µR/h</div>
-    <div><span style="color:#FFD700;">■</span> 11–30 µR/h</div>
-    <div><span style="color:#008000;">■</span> 0–11 µR/h</div>
+  <div><span style="color:#FFD700;">■</span> 11–30 µR/h</div>
+   <div><span style="color:#008000;">■</span> 0–11 µR/h</div>
   </div>
 </div>
+<div id="legendTooltip" class="custom-tooltip" style="display:none; position:fixed; max-width:260px; padding:10px; font-size:12px; line-height:1.4em; z-index:1001;"></div>
 <!--
   Compact 4-bin legend (µR/h) with vertical gradient bar (green→yellow→orange→red→black).
   White labels mark safe at the bottom and danger at the top.
@@ -792,28 +809,16 @@ function getFillOpacity(speed) {
   }
 }
 
-// Build tooltip content for a marker
-function getTooltipContent(marker) {
-  var date = new Date(marker.date * 1000);
-  var formattedDate = date.toLocaleString();
-
-  return `
-    <div class="custom-tooltip">
-    <div class="tooltip-row">
-    <strong>${translate('radiation_dose')}:</strong>
-    <span>${(marker.doseRate * 100).toFixed(2)} µR/h (${marker.doseRate.toFixed(2)} µSv/h)</span>
-    </div>
-    <div class="tooltip-row">
-    <strong>${translate('speed')}:</strong>
-    <span>${(marker.speed * 3.6).toFixed(1)} km/h</span>
-    </div>
-    <div class="tooltip-row">
-    <strong>${translate('track_id')}:</strong>
-    <span>${marker.trackID}</span>
-    </div>
-    </div>
-    `;
+// Decide a translation key for safety based on dose rate (µSv/h).
+// Using legend thresholds keeps UI consistent and avoids extra strings.
+function doseCategory(doseRate) {
+  // Map dose rate to safety words using legend thresholds
+  if (doseRate <= 0.11) return 'legend_safe';
+  if (doseRate <= 0.30) return 'legend_attention';
+  return 'legend_danger';
 }
+
+
 
 // Get current URL params from map state
 function getCurrentUrlParams() {
@@ -1311,22 +1316,35 @@ function createDateRangeSlider(){
 
 // Function definitions
 
-// ---------- Popup linking to track ----------
-function getPopupContent(marker) {
-  const dateStr = new Date(marker.date * 1000).toLocaleString();
+// ---------- Marker popups and tooltips ----------
+// Build HTML once so popups and tooltips share identical content.
+function buildMarkerContent(marker) {
   return `
     <div class="custom-tooltip">
-    <div><strong>${translate('radiation_dose')}:</strong>
-  ${(marker.doseRate * 100).toFixed(2)} µR/h (${marker.doseRate.toFixed(2)} µSv/h)
-    </div>
-    <div><strong>${translate('speed')}:</strong> ${(marker.speed * 3.6).toFixed(1)} km/h</div>
-    <div style="margin-top:4px">
-    <!-- clicking the link switches to track mode -->
-    <a href="javascript:viewTrack('${marker.trackID}')" style="font-weight:bold;">
-  ${translate('track_id')}: ${marker.trackID}
-    </a>
-    </div>
+      <div><strong>${translate('radiation_dose')}:</strong><br>
+        ${(marker.doseRate * 100).toFixed(2)} µR/h (${marker.doseRate.toFixed(2)} µSv/h)
+        (<a href="#" class="risk-link" onclick="openLegendModal(); return false;">
+          ${translate(doseCategory(marker.doseRate))}
+        </a>)
+      </div>
+      <div><strong>${translate('speed')}:</strong> ${(marker.speed * 3.6).toFixed(1)} km/h</div>
+      <div style="margin-top:4px">
+        <!-- clicking the link switches to track mode -->
+        <a href="javascript:viewTrack('${marker.trackID}')" style="font-weight:bold;">
+          ${translate('track_id')}: ${marker.trackID}
+        </a>
+      </div>
     </div>`;
+}
+
+// Popup reuses shared builder to stay in sync with tooltips.
+function getPopupContent(marker) {
+  return buildMarkerContent(marker);
+}
+
+// Tooltip uses the same builder for hover previews.
+function getTooltipContent(marker) {
+  return buildMarkerContent(marker);
 }
 
 
@@ -1379,7 +1397,7 @@ function updateMarkers(){
     })
     .addTo(map)
     .bindTooltip(getTooltipContent(m),
-        { direction:'top', className:'custom-tooltip', offset:[0,-8] })
+        { direction:'top', className:'custom-tooltip', offset:[0,-8], interactive:true })
     .bindPopup(getPopupContent(m));
 
     circleMarkers[m.id || m.trackID] = cm;
@@ -1695,32 +1713,69 @@ function centerMapToLocation() {
     • Show modal; close on backdrop click for convenience.
 -->
 <script>
-  // Open the modal with full legend text in the current language.
+  // Build legend HTML with color squares for tooltip and modal.
+  function buildLegendHTML(lang) {
+    var key = 'legend_full_' + lang;
+    var txt = translate(key);
+    var parts = txt.split('\n\n');
+    function stripBullet(line) {
+      return line.replace(/^■\s*/, '');
+    }
+    function square(color) {
+      return '<span class="legend-square" style="background:' + color + ';"></span>';
+    }
+    return parts.map(function(p){
+      var lines = p.split('\n').map(function(line){
+        if (line.includes('0–11')) return square('#008000') + stripBullet(line);
+        if (line.includes('11–30')) return square('#FFD700') + stripBullet(line);
+        if (line.includes('30–100')) return square('#FF4500') + stripBullet(line);
+        if (line.includes('>100')) return square('#000000') + stripBullet(line);
+        return line;
+      }).join('<br>');
+      return '<p style="margin:0 0 1em 0;">' + lines + '</p>';
+    }).join('');
+  }
+
+  // Display the full legend text in current language.
+  // Exposed so marker popups reuse the same modal.
+  function openLegendModal() {
+    hideLegendTooltip(); // avoid overlap
+    var lang = (typeof currentLang !== 'undefined') ? currentLang : 'en';
+    var html = buildLegendHTML(lang);
+    var box = document.getElementById('legendText');
+    if (box) box.innerHTML = html;
+    var modal = document.getElementById('legendModal');
+    if (modal) modal.style.display = 'flex';
+  }
+
+  // Show legend explanation on hover using same HTML as modal
+  function showLegendTooltip() {
+    var lang = (typeof currentLang !== 'undefined') ? currentLang : 'en';
+    var tip = document.getElementById('legendTooltip');
+    if (!tip) return;
+    tip.innerHTML = buildLegendHTML(lang);
+    tip.style.display = 'block';
+    var leg = document.getElementById('legend');
+    if (leg) {
+      var rect = leg.getBoundingClientRect();
+      tip.style.left = rect.left + 'px';
+      tip.style.top = (rect.top - tip.offsetHeight - 8) + 'px';
+    }
+  }
+
+  // Hide the hover tooltip
+  function hideLegendTooltip() {
+    var tip = document.getElementById('legendTooltip');
+    if (tip) tip.style.display = 'none';
+  }
+
   (function(){
     var el = document.getElementById('legend');
-    if (!el) return;
-    el.addEventListener('click', function(){
-      // Choose full text key dynamically for any supported language
-      var lang = (typeof currentLang !== 'undefined') ? currentLang : 'en';
-      var key = 'legend_full_' + lang;
-      var txt = translate(key);
-      // Build pretty paragraphs and add colored markers
-      var parts = txt.split('\n\n');
-      var html = parts.map(function(p){
-        var lines = p.split('\n').map(function(line){
-          if (line.includes('0–11')) return '<span style=\"color:#008000;\">■</span> ' + line;
-          if (line.includes('11–30')) return '<span style=\"color:#FFD700;\">■</span> ' + line;
-          if (line.includes('30–100')) return '<span style=\"color:#FF4500;\">■</span> ' + line;
-          if (line.includes('>100')) return '<span style=\"color:#000000;\">■</span> ' + line;
-          return line;
-        }).join('<br>');
-        return '<p style=\"margin:0 0 1em 0;\">' + lines + '</p>';
-      }).join('');
-      var box = document.getElementById('legendText');
-      if (box) box.innerHTML = html;
-      var modal = document.getElementById('legendModal');
-      if (modal) modal.style.display = 'flex';
-    });
+    if (el) {
+      el.addEventListener('click', openLegendModal);
+      el.addEventListener('mouseenter', showLegendTooltip);
+      el.addEventListener('mouseleave', hideLegendTooltip);
+    }
     // Close on backdrop click (UX nicety)
     var modal = document.getElementById('legendModal');
     if (modal) {

--- a/public_html/translations.json
+++ b/public_html/translations.json
@@ -27,8 +27,9 @@
     "track_id": "ID трека",
     "back_to_all_tracks": "Назад к общей карте треков.",
     "legend_title": "Легенда",
-    "legend_full_ru": "Эта шкала показывает, насколько место *скорее всего* безопасно для жизни, воды и пищи.\nНужно помнить: измерения могут быть неполными, а радиация выше или скрыта. Поэтому данные — лишь ориентир.\n\nЗелёная (0–11 µR/h)\nФон близок к естественному.\n• Вода из скважин и колодцев считается безопасной.\n• Выращивание растений допустимо без проверок.\n\nЖёлтая (11–30 µR/h)\nПовышенный фон, требуется внимание.\n• Воду и почву нужно проверять.\n• Любые продукты этой земли (овощи, грибы и т. д.) следует тестировать перед употреблением.\n\nКрасная (30–100 µR/h)\nСерьёзное загрязнение.\n• Воду пить нельзя.\n• Выращивать и есть продукты с этой территории опасно; обязательны лабораторные проверки.\n\nЧёрная (>100 µR/h)\nКритическая зона.\n• Вода и пища непригодны.\n• Постоянное проживание исключено; пребывание только кратковременно с защитой.",
+    "legend_full_ru": "Эта шкала показывает, насколько место безопасно для людей, воды и еды.\nПомните: измерения могут быть неполными, радиация может быть выше или скрыта. Относитесь к числам как к ориентиру.\n\nЗеленая (0–11 µR/h)\nФон близок к естественному.\n• Вода из скважин обычно безопасна.\n• Можно выращивать растения без проверок.\n\nЖелтая (11–30 µR/h)\nФон повышен; будьте осторожны.\n• Проверяйте воду и почву.\n• Тестируйте овощи, грибы и другие продукты перед употреблением.\n\nКрасная (30–100 µR/h)\nСерьёзное загрязнение.\n• Воду пить нельзя.\n• Выращивать или есть продукты отсюда рискованно; нужны анализы.\n\nЧёрная (>100 µR/h)\nКритическая зона.\n• Воду и пищу использовать нельзя.\n• Долгое пребывание исключено; только короткие визиты с защитой.",
     "legend_safe": "Безопасно",
+    "legend_attention": "Внимание",
     "legend_danger": "Опасно"
   },
   "en": {
@@ -59,8 +60,9 @@
     "track_id": "Track ID",
     "back_to_all_tracks": "Back to the combined track map.",
     "legend_title": "Legend",
-    "legend_full_en": "This scale shows how likely a spot is safe for folk, water, and food.\nMind: the readings might no' be complete, and some rays could be higher or hiding. Treat these numbers as guidance only.\n\nGreen (0–11 µR/h)\nBackground near natural.\n• Water from wells is generally safe.\n• You can grow plants without checks.\n\nYellow (11–30 µR/h)\nRaised background; take care.\n• Check water and soil.\n• Test any veg, mushrooms, or other produce before you eat.\n\nRed (30–100 µR/h)\nSerious contamination.\n• Dinna drink the water.\n• Growing or eating produce from here is risky; lab tests are a must.\n\nBlack (>100 µR/h)\nCritical zone.\n• Water and food cannae be used.\n• Staying long-term is out; only short visits with protection.\n",
+    "legend_full_en": "This scale shows how likely a spot is safe for folk, water, and food.\nMind: the readings might not be complete, and some rays could be higher or hiding. Treat these numbers as guidance only.\n\nGreen (0–11 µR/h)\nBackground near natural.\n• Water from wells is generally safe.\n• You can grow plants without checks.\n\nYellow (11–30 µR/h)\nRaised background; take care.\n• Check water and soil.\n• Test any veg, mushrooms, or other produce before you eat.\n\nRed (30–100 µR/h)\nSerious contamination.\n• Don't drink the water.\n• Growing or eating produce from here is risky; lab tests are a must.\n\nBlack (>100 µR/h)\nCritical zone.\n• Water and food cannot be used.\n• Staying long-term is out; only short visits with protection.\n",
     "legend_safe": "Safe",
+    "legend_attention": "Attention",
     "legend_danger": "Danger"
   },
   "es": {
@@ -92,6 +94,7 @@
     "back_to_all_tracks": "Volver al mapa combinado de trayectorias.",
     "legend_title": "Leyenda",
     "legend_safe": "Seguro",
+    "legend_attention": "Atención",
     "legend_danger": "Peligro",
     "legend_full_es": "Esta escala indica cuán seguro es un lugar para vivir, beber y comer.\nRecuerda: las mediciones pueden estar incompletas; úsala solo como guía.\n\nVerde (0–11 µR/h)\nFondo natural.\n• Agua de pozo segura.\n• Se puede cultivar sin pruebas.\n\nAmarillo (11–30 µR/h)\nFondo elevado.\n• Revisa agua y suelo.\n• Analiza cualquier alimento antes de comer.\n\nRojo (30–100 µR/h)\nContaminación grave.\n• No bebas el agua.\n• Cultivar o comer de aquí es arriesgado; requiere pruebas de laboratorio.\n\nNegro (>100 µR/h)\nZona crítica.\n• Agua y comida inutilizables.\n• Sólo estancias breves con protección.\n"
   },
@@ -124,6 +127,7 @@
     "back_to_all_tracks": "Retour à la carte combinée des pistes.",
     "legend_title": "Légende",
     "legend_safe": "Sûr",
+    "legend_attention": "Attention",
     "legend_danger": "Danger",
     "legend_full_fr": "Cette échelle indique à quel point un lieu est sûr pour la vie, l’eau et la nourriture.\nSouviens‑toi : les mesures peuvent être incomplètes ; n’en fais qu’un guide.\n\nVert (0–11 µR/h)\nFond naturel.\n• L’eau de puits est généralement potable.\n• On peut cultiver sans tests.\n\nJaune (11–30 µR/h)\nFond élevé.\n• Vérifie l’eau et le sol.\n• Analyse toute nourriture avant de la consommer.\n\nRouge (30–100 µR/h)\nContamination sérieuse.\n• Ne bois pas l’eau.\n• Cultiver ou manger ici est risqué ; analyses en laboratoire obligatoires.\n\nNoir (>100 µR/h)\nZone critique.\n• Eau et nourriture inutilisables.\n• Séjour prolongé impossible ; visites courtes avec protection.\n"
   },
@@ -156,6 +160,7 @@
     "back_to_all_tracks": "Zurück zur kombinierten Track-Karte.",
     "legend_title": "Legende",
     "legend_safe": "Sicher",
+    "legend_attention": "Achtung",
     "legend_danger": "Gefahr",
     "legend_full_de": "Diese Skala zeigt, wie sicher ein Ort für Menschen, Wasser und Nahrung ist.\nDenk daran: Messungen können unvollständig sein; nutze sie nur als Richtwert.\n\nGrün (0–11 µR/h)\nNatürliche Hintergrundstrahlung.\n• Brunnenwasser meist sicher.\n• Pflanzen können ohne Tests wachsen.\n\nGelb (11–30 µR/h)\nErhöhte Werte.\n• Wasser und Boden prüfen.\n• Jede Ernte vor dem Essen testen.\n\nRot (30–100 µR/h)\nStarke Belastung.\n• Wasser nicht trinken.\n• Anbau oder Verzehr hier gefährlich; Laborprüfungen nötig.\n\nSchwarz (>100 µR/h)\nKritische Zone.\n• Wasser und Nahrung unbrauchbar.\n• Längerer Aufenthalt verboten; nur kurz mit Schutz.\n"
   },
@@ -188,6 +193,7 @@
     "back_to_all_tracks": "返回到合并轨迹的地图。",
     "legend_title": "图例",
     "legend_safe": "安全",
+    "legend_attention": "注意",
     "legend_danger": "危险",
     "legend_full_zh": "此刻度展示一个地点对生命、水和食物的安全程度。\n请记住：读数可能不完整；仅作参考。\n\n绿色 (0–11 µR/h)\n背景接近自然。\n• 井水通常安全。\n• 可放心种植。\n\n黄色 (11–30 µR/h)\n背景升高。\n• 检查水和土。\n• 食物食用前需检测。\n\n红色 (30–100 µR/h)\n严重污染。\n• 不可饮用水。\n• 种植或食用此地产品危险；需实验室检测。\n\n黑色 (>100 µR/h)\n危急区域。\n• 水和食物不可用。\n• 仅短暂停留且需防护。\n"
   },
@@ -220,6 +226,7 @@
     "back_to_all_tracks": "すべてのトラックの地図に戻る。",
     "legend_title": "凡例",
     "legend_safe": "安全",
+    "legend_attention": "注意",
     "legend_danger": "危険",
     "legend_full_ja": "この尺度は、場所が生活・水・食べ物にどれほど安全かを示します。\n測定値は不完全な場合があるので、参考程度に。\n\n緑 (0–11 µR/h)\nほぼ自然背景。\n• 井戸水は概ね安全。\n• 植物は検査なしで栽培可。\n\n黄 (11–30 µR/h)\n背景上昇。\n• 水と土を確認。\n• 食べ物は食前に検査を。\n\n赤 (30–100 µR/h)\n深刻な汚染。\n• 水は飲めない。\n• ここでの栽培・摂取は危険；検査が必須。\n\n黒 (>100 µR/h)\n極めて危険。\n• 水も食料も使えない。\n• 長期滞在は禁止；短時間で防護が必要。\n"
   },
@@ -252,6 +259,7 @@
     "back_to_all_tracks": "모든 트랙 지도로 돌아가기.",
     "legend_title": "범례",
     "legend_safe": "안전",
+    "legend_attention": "주의",
     "legend_danger": "위험",
     "legend_full_ko": "이 척도는 장소가 사람, 물, 음식에 얼마나 안전한지 보여줍니다.\n측정값은 불완전할 수 있으니 참고용으로만 쓰세요.\n\n초록 (0–11 µR/h)\n자연에 가까운 배경.\n• 우물물은 대체로 안전.\n• 검사 없이 재배 가능.\n\n노랑 (11–30 µR/h)\n배경 상승.\n• 물과 토양을 확인.\n• 음식은 먹기 전 검사.\n\n빨강 (30–100 µR/h)\n심각한 오염.\n• 물을 마시지 마세요.\n• 여기서 재배·섭취는 위험; 실험실 검사 필요.\n\n검정 (>100 µR/h)\n치명적 구역.\n• 물과 음식 사용 불가.\n• 보호장비로 짧게만 머무르세요.\n"
   },
@@ -284,6 +292,7 @@
     "back_to_all_tracks": "Voltar ao mapa combinado de trilhas.",
     "legend_title": "Legenda",
     "legend_safe": "Seguro",
+    "legend_attention": "Atenção",
     "legend_danger": "Perigo",
     "legend_full_pt": "Esta escala mostra quão seguro é um lugar para viver, beber e comer.\nLembre: as leituras podem estar incompletas; use apenas como guia.\n\nVerde (0–11 µR/h)\nFundo natural.\n• Água de poço geralmente segura.\n• Pode-se plantar sem testes.\n\nAmarelo (11–30 µR/h)\nFundo elevado.\n• Verifique água e solo.\n• Analise qualquer alimento antes de comer.\n\nVermelho (30–100 µR/h)\nContaminação séria.\n• Não beba a água.\n• Cultivar ou comer aqui é arriscado; exames laboratoriais obrigatórios.\n\nPreto (>100 µR/h)\nZona crítica.\n• Água e comida inutilizáveis.\n• Ficar muito tempo é impossível; apenas visitas breves com proteção.\n"
   },
@@ -316,6 +325,7 @@
     "back_to_all_tracks": "Torna alla mappa combinata delle tracce.",
     "legend_title": "Legenda",
     "legend_safe": "Sicuro",
+    "legend_attention": "Attenzione",
     "legend_danger": "Pericolo",
     "legend_full_it": "Questa scala indica quanto un luogo è sicuro per vita, acqua e cibo.\nRicorda: le misurazioni possono essere incomplete; usala solo come guida.\n\nVerde (0–11 µR/h)\nFondo naturale.\n• L’acqua di pozzo è generalmente sicura.\n• Si possono coltivare piante senza test.\n\nGiallo (11–30 µR/h)\nFondo elevato.\n• Controlla acqua e terreno.\n• Verifica ogni alimento prima di mangiare.\n\nRosso (30–100 µR/h)\nContaminazione seria.\n• Non bere l’acqua.\n• Coltivare o mangiare qui è rischioso; servono esami di laboratorio.\n\nNero (>100 µR/h)\nZona critica.\n• Acqua e cibo inutilizzabili.\n• Permanenza lunga vietata; solo brevi visite con protezione.\n"
   },
@@ -348,6 +358,7 @@
     "back_to_all_tracks": "العودة إلى خريطة المسارات الموحّدة.",
     "legend_title": "مفتاح",
     "legend_safe": "آمن",
+    "legend_attention": "انتباه",
     "legend_danger": "خطر",
     "legend_full_ar": "هذا المقياس يوضح مدى أمان المكان للحياة والماء والطعام.\nتذكّر: قد تكون القياسات ناقصة؛ استخدمها كدليل فقط.\n\nأخضر (0–11 µR/h)\nخلفية طبيعية.\n• ماء الآبار غالبًا آمن.\n• يمكن الزراعة دون فحص.\n\nأصفر (11–30 µR/h)\nخلفية مرتفعة.\n• افحص الماء والتربة.\n• اختبر أي طعام قبل تناوله.\n\nأحمر (30–100 µR/h)\nتلوث خطير.\n• لا تشرب الماء.\n• الزراعة أو الأكل هنا خطر؛ الفحوص المخبرية ضرورية.\n\nأسود (>100 µR/h)\nمنطقة حرجة.\n• الماء والطعام غير صالحين.\n• الإقامة الطويلة ممنوعة؛ الزيارة القصيرة مع حماية فقط.\n"
   },
@@ -380,6 +391,7 @@
     "back_to_all_tracks": "सभी ट्रैकों के संयुक्त मानचित्र पर वापस जाएँ।",
     "legend_title": "दिशा-सूचक",
     "legend_safe": "सुरक्षित",
+    "legend_attention": "ध्यान",
     "legend_danger": "खतरा",
     "legend_full_hi": "यह पैमाना बताता है कि कोई जगह जीवन, पानी और भोजन के लिए कितनी सुरक्षित है।\nयाद रखें: माप अधूरे हो सकते हैं; इसे केवल मार्गदर्शक मानें।\n\nहरा (0–11 µR/h)\nलगभग प्राकृतिक पृष्ठभूमि।\n• कुएँ का पानी आम तौर पर सुरक्षित।\n• बिना जाँच के खेती संभव।\n\nपीला (11–30 µR/h)\nपृष्ठभूमि बढ़ी हुई।\n• पानी और मिट्टी जाँचें।\n• किसी भी खाद्य पदार्थ को खाने से पहले जाँचें।\n\nलाल (30–100 µR/h)\nगंभीर प्रदूषण।\n• पानी न पिएँ।\n• यहाँ उगाना या खाना जोखिम भरा; प्रयोगशाला जाँच आवश्यक।\n\nकाला (>100 µR/h)\nअत्यंत खतरनाक।\n• पानी और खाना उपयोगी नहीं।\n• लंबे समय तक रहना मना; सिर्फ थोड़ी देर सुरक्षा के साथ।\n"
   },
@@ -412,6 +424,7 @@
     "back_to_all_tracks": "Tüm izlerin birleşik haritasına geri dön.",
     "legend_title": "Lejant",
     "legend_safe": "Güvenli",
+    "legend_attention": "Dikkat",
     "legend_danger": "Tehlike",
     "legend_full_tr": "Bu ölçek, bir yerin yaşam, su ve gıda için ne kadar güvenli olduğunu gösterir.\nUnutma: ölçümler eksik olabilir; yalnızca rehber olarak kullan.\n\nYeşil (0–11 µR/h)\nDoğal arka plan.\n• Kuyu suyu genelde güvenlidir.\n• Test olmadan bitki yetiştirilebilir.\n\nSarı (11–30 µR/h)\nYükselmiş arka plan.\n• Su ve toprağı kontrol et.\n• Her gıdayı yemeden önce test et.\n\nKırmızı (30–100 µR/h)\nCiddi kirlilik.\n• Suyu içme.\n• Burada yetiştirmek veya yemek riskli; lab testleri şart.\n\nSiyah (>100 µR/h)\nKritik bölge.\n• Su ve yiyecek kullanılamaz.\n• Uzun süre kalmak yasak; sadece kısa süre korumayla kal.\n"
   },
@@ -444,6 +457,7 @@
     "back_to_all_tracks": "Terug naar de gecombineerde sporenkaart.",
     "legend_title": "Legenda",
     "legend_safe": "Veilig",
+    "legend_attention": "Let op",
     "legend_danger": "Gevaar",
     "legend_full_nl": "Deze schaal laat zien hoe veilig een plek is voor leven, water en eten.\nOnthoud: metingen kunnen onvolledig zijn; gebruik het alleen als richtlijn.\n\nGroen (0–11 µR/h)\nBijna natuurlijke achtergrond.\n• Pompwater is meestal veilig.\n• Je kunt zonder tests planten kweken.\n\nGeel (11–30 µR/h)\nVerhoogde achtergrond.\n• Controleer water en bodem.\n• Test voedsel voordat je het eet.\n\nRood (30–100 µR/h)\nErnstige besmetting.\n• Drink het water niet.\n• Telen of eten van hier is riskant; labtests nodig.\n\nZwart (>100 µR/h)\nKritieke zone.\n• Water en voedsel onbruikbaar.\n• Alleen kort verblijf met bescherming.\n"
   },
@@ -476,6 +490,7 @@
     "back_to_all_tracks": "Επιστροφή στον συνδυαστικό χάρτη διαδρομών.",
     "legend_title": "Υπόμνημα",
     "legend_safe": "Ασφαλές",
+    "legend_attention": "Προσοχή",
     "legend_danger": "Κίνδυνος",
     "legend_full_el": "Αυτή η κλίμακα δείχνει πόσο ασφαλής είναι μια περιοχή για ζωή, νερό και τροφή.\nΘυμήσου: οι μετρήσεις μπορεί να μην είναι πλήρεις· χρησιμοποίησέ τες μόνο ως οδηγό.\n\nΠράσινο (0–11 µR/h)\nΣχεδόν φυσικό υπόβαθρο.\n• Το νερό πηγών είναι γενικά ασφαλές.\n• Μπορείς να καλλιεργείς χωρίς έλεγχο.\n\nΚίτρινο (11–30 µR/h)\nΑυξημένο υπόβαθρο.\n• Έλεγξε νερό και έδαφος.\n• Εξέτασε κάθε τρόφιμο πριν το φας.\n\nΚόκκινο (30–100 µR/h)\nΣοβαρή ρύπανση.\n• Μην πίνεις το νερό.\n• Η καλλιέργεια ή κατανάλωση εδώ είναι επικίνδυνη· απαιτούνται εργαστηριακοί έλεγχοι.\n\nΜαύρο (>100 µR/h)\nΚρίσιμη ζώνη.\n• Νερό και τροφή ακατάλληλα.\n• Μόνο σύντομη παραμονή με προστασία.\n"
   },
@@ -508,6 +523,7 @@
     "back_to_all_tracks": "Powrót do łączonej mapy tras.",
     "legend_title": "Legenda",
     "legend_safe": "Bezpieczne",
+    "legend_attention": "Uwaga",
     "legend_danger": "Zagrożenie",
     "legend_full_pl": "Ta skala pokazuje, na ile miejsce jest bezpieczne dla życia, wody i jedzenia.\nPamiętaj: pomiary mogą być niepełne; traktuj je jedynie orientacyjnie.\n\nZielony (0–11 µR/h)\nTło prawie naturalne.\n• Woda ze studni zazwyczaj bezpieczna.\n• Można uprawiać bez testów.\n\nŻółty (11–30 µR/h)\nTło podwyższone.\n• Sprawdź wodę i glebę.\n• Zbadaj żywność przed spożyciem.\n\nCzerwony (30–100 µR/h)\nPoważne skażenie.\n• Wody nie pij.\n• Uprawa lub jedzenie stąd jest ryzykowne; konieczne badania lab.\n\nCzarny (>100 µR/h)\nStrefa krytyczna.\n• Woda i jedzenie bezużyteczne.\n• Tylko krótki pobyt z ochroną.\n"
   },
@@ -540,6 +556,7 @@
     "back_to_all_tracks": "Повернутися до об’єднаної карти треків.",
     "legend_title": "Легенда",
     "legend_safe": "Безпечно",
+    "legend_attention": "Увага",
     "legend_danger": "Небезпека",
     "legend_full_uk": "Ця шкала показує, наскільки місце безпечне для життя, води й їжі.\nПам’ятайте: вимірювання можуть бути неповними; користуйтеся лише як орієнтиром.\n\nЗелений (0–11 µR/h)\nМайже природний фон.\n• Кринична вода здебільшого безпечна.\n• Рослини можна вирощувати без перевірок.\n\nЖовтий (11–30 µR/h)\nПідвищений фон.\n• Перевіряйте воду й ґрунт.\n• Тестуйте будь-яку їжу перед споживанням.\n\nЧервоний (30–100 µR/h)\nСерйозне забруднення.\n• Воду пити не можна.\n• Вирощування чи вживання продуктів тут небезпечно; потрібні лабораторні дослідження.\n\nЧорний (>100 µR/h)\nКритична зона.\n• Вода й їжа непридатні.\n• Лише коротке перебування з захистом.\n"
   },
@@ -600,6 +617,7 @@
     "back_to_all_tracks": "Takaisin yhdistettyyn reittikarttaan.",
     "legend_title": "Selite",
     "legend_safe": "Turvallinen",
+    "legend_attention": "Huomio",
     "legend_danger": "Vaara",
     "legend_full_fi": "Tämä asteikko kertoo, kuinka turvallinen paikka on elämälle, vedelle ja ruoalle.\nMuista: mittaukset voivat olla puutteellisia; käytä vain ohjeena.\n\nVihreä (0–11 µR/h)\nLähes luonnollinen tausta.\n• Kaivovesi yleensä turvallista.\n• Voit kasvattaa kasveja ilman testejä.\n\nKeltainen (11–30 µR/h)\nKohonnut tausta.\n• Tarkista vesi ja maa.\n• Tutki ruoka ennen syömistä.\n\nPunainen (30–100 µR/h)\nVakava saastuminen.\n• Älä juo vettä.\n• Täällä viljely tai syöminen on riskialtista; laboratoriotestit pakollisia.\n\nMusta (>100 µR/h)\nKriittinen alue.\n• Vesi ja ruoka käyttökelvottomia.\n• Pitkä oleskelu mahdoton; vain lyhyet käynnit suojassa.\n"
   },
@@ -632,6 +650,7 @@
     "back_to_all_tracks": "Tillbaka till den kombinerade spårkartan.",
     "legend_title": "Förklaring",
     "legend_safe": "Säker",
+    "legend_attention": "Observera",
     "legend_danger": "Fara",
     "legend_full_sv": "Denna skala visar hur säker en plats är för liv, vatten och mat.\nKom ihåg: mätningar kan vara ofullständiga; använd den bara som vägledning.\n\nGrön (0–11 µR/h)\nNästan naturlig bakgrund.\n• Brunnsvatten oftast säkert.\n• Växter kan odlas utan tester.\n\nGul (11–30 µR/h)\nFörhöjd bakgrund.\n• Kontrollera vatten och jord.\n• Undersök all mat innan du äter.\n\nRöd (30–100 µR/h)\nAllvarlig förorening.\n• Drick inte vattnet.\n• Odling eller konsumtion här är riskabelt; labbtester krävs.\n\nSvart (>100 µR/h)\nKritisk zon.\n• Vatten och mat oanvändbara.\n• Endast korta besök med skydd.\n"
   },
@@ -664,6 +683,7 @@
     "back_to_all_tracks": "Tilbake til det kombinerte sporkartet.",
     "legend_title": "Forklaring",
     "legend_safe": "Trygt",
+    "legend_attention": "Merk!",
     "legend_danger": "Fare",
     "legend_full_no": "Denne skalaen viser hvor trygg et sted er for liv, vann og mat.\nHusk: målingene kan være ufullstendige; bruk den kun som veiledning.\n\nGrønn (0–11 µR/h)\nNær naturlig bakgrunn.\n• Brønnvann er vanligvis trygt.\n• Planter kan dyrkes uten tester.\n\nGul (11–30 µR/h)\nBakgrunn økt.\n• Sjekk vann og jord.\n• Test all mat før du spiser.\n\nRød (30–100 µR/h)\nAlvorlig forurensning.\n• Ikke drikk vannet.\n• Dyrking eller spising her er farlig; laboratorietester må til.\n\nSvart (>100 µR/h)\nKritisk sone.\n• Vann og mat ubrukelige.\n• Bare korte besøk med beskyttelse.\n"
   },
@@ -696,6 +716,7 @@
     "back_to_all_tracks": "Tilbage til det kombinerede sporkort.",
     "legend_title": "Forklaring",
     "legend_safe": "Sikker",
+    "legend_attention": "OBS",
     "legend_danger": "Fare",
     "legend_full_da": "Denne skala viser, hvor sikker et sted er for liv, vand og mad.\nHusk: målinger kan være ufuldstændige; brug den kun som vejledning.\n\nGrøn (0–11 µR/h)\nNæsten naturlig baggrund.\n• Brøndvand er som regel sikkert.\n• Planter kan dyrkes uden test.\n\nGul (11–30 µR/h)\nForhøjet baggrund.\n• Tjek vand og jord.\n• Undersøg mad før du spiser.\n\nRød (30–100 µR/h)\nAlvorlig forurening.\n• Drik ikke vandet.\n• Dyrkning eller spisning her er risikabelt; laboratorietest kræves.\n\nSort (>100 µR/h)\nKritisk område.\n• Vand og mad kan ikke bruges.\n• Kun korte ophold med beskyttelse.\n"
   },
@@ -728,6 +749,7 @@
     "back_to_all_tracks": "Vissza az egyesített útvonaltérképhez.",
     "legend_title": "Jelmagyarázat",
     "legend_safe": "Biztonságos",
+    "legend_attention": "Figyelem",
     "legend_danger": "Veszély",
     "legend_full_hu": "Ez a skála megmutatja, mennyire biztonságos egy hely az életre, vízre és élelemre.\nNe feledd: a mérések hiányosak lehetnek; csak iránymutató.\n\nZöld (0–11 µR/h)\nSzinte természetes háttér.\n• A kútvíz többnyire biztonságos.\n• Növényeket vizsgálat nélkül lehet termeszteni.\n\nSárga (11–30 µR/h)\nEmelkedett háttér.\n• Vizsgáld meg a vizet és a talajt.\n• Teszteld az ételt evés előtt.\n\nPiros (30–100 µR/h)\nKomoly szennyezés.\n• Ne igyál a vízből.\n• Itt termelni vagy enni veszélyes; laborvizsgálat kell.\n\nFekete (>100 µR/h)\nKritikus zóna.\n• Víz és élelem használhatatlan.\n• Csak rövid tartózkodás védelemmel.\n"
   },
@@ -760,6 +782,7 @@
     "back_to_all_tracks": "กลับไปยังแผนที่รวมเส้นทาง",
     "legend_title": "คำอธิบาย",
     "legend_safe": "ปลอดภัย",
+    "legend_attention": "ระวัง",
     "legend_danger": "อันตราย",
     "legend_full_th": "สเกลนี้บอกว่าพื้นที่ปลอดภัยต่อชีวิต น้ำ และอาหารแค่ไหน\nจำไว้: การวัดอาจไม่ครบถ้วน ใช้เป็นเพียงแนวทาง\n\nเขียว (0–11 µR/h)\nฉากหลังเกือบธรรมชาติ\n• น้ำบ่อส่วนใหญ่ปลอดภัย\n• ปลูกพืชได้โดยไม่ต้องตรวจ\n\nเหลือง (11–30 µR/h)\nฉากหลังสูงขึ้น\n• ตรวจน้ำและดิน\n• ตรวจอาหารก่อนกิน\n\nแดง (30–100 µR/h)\nปนเปื้อนรุนแรง\n• ห้ามดื่มน้ำ\n• ปลูกหรือกินที่นี่เสี่ยง ต้องตรวจแลบ\n\nดำ (>100 µR/h)\nเขตวิกฤต\n• น้ำและอาหารใช้ไม่ได้\n• อยู่ได้เพียงสั้นๆ พร้อมอุปกรณ์ป้องกัน\n"
   },
@@ -792,6 +815,7 @@
     "back_to_all_tracks": "Quay lại bản đồ tổng hợp các hành trình.",
     "legend_title": "Chú thích",
     "legend_safe": "An toàn",
+    "legend_attention": "Chú ý",
     "legend_danger": "Nguy hiểm",
     "legend_full_vi": "Thang này cho biết mức an toàn của nơi ở đối với đời sống, nước và thực phẩm.\nNhớ rằng: đo đạc có thể chưa đầy đủ; chỉ dùng để tham khảo.\n\nXanh (0–11 µR/h)\nNền gần tự nhiên.\n• Nước giếng thường an toàn.\n• Có thể trồng trọt không cần thử nghiệm.\n\nVàng (11–30 µR/h)\nNền cao.\n• Kiểm tra nước và đất.\n• Thử mọi thực phẩm trước khi ăn.\n\nĐỏ (30–100 µR/h)\nÔ nhiễm nghiêm trọng.\n• Không uống nước.\n• Trồng hoặc ăn ở đây nguy hiểm; cần xét nghiệm.\n\nĐen (>100 µR/h)\nVùng cực nguy.\n• Nước và thức ăn không dùng được.\n• Chỉ ở lại ngắn với bảo hộ.\n"
   },
@@ -824,6 +848,7 @@
     "back_to_all_tracks": "Kembali ke peta lintasan gabungan.",
     "legend_title": "Legenda",
     "legend_safe": "Aman",
+    "legend_attention": "Perhatian",
     "legend_danger": "Bahaya",
     "legend_full_id": "Skala ini menunjukkan seberapa aman suatu tempat bagi hidup, air, dan makanan.\nIngat: pengukuran bisa tidak lengkap; pakai sebagai panduan saja.\n\nHijau (0–11 µR/h)\nLatar mendekati alami.\n• Air sumur umumnya aman.\n• Tanaman bisa ditanam tanpa tes.\n\nKuning (11–30 µR/h)\nLatar meningkat.\n• Periksa air dan tanah.\n• Uji makanan sebelum dimakan.\n\nMerah (30–100 µR/h)\nKontaminasi serius.\n• Jangan minum airnya.\n• Menanam atau makan di sini berbahaya; tes laboratorium wajib.\n\nHitam (>100 µR/h)\nZona kritis.\n• Air dan makanan tak dapat digunakan.\n• Hanya boleh singgah sebentar dengan perlindungan.\n"
   },
@@ -856,6 +881,7 @@
     "back_to_all_tracks": "Kembali ke peta jejak gabungan.",
     "legend_title": "Legenda",
     "legend_safe": "Selamat",
+    "legend_attention": "Perhatian",
     "legend_danger": "Bahaya",
     "legend_full_ms": "Skala ini menunjukkan tahap keselamatan tempat untuk kehidupan, air dan makanan.\nIngat: bacaan mungkin tidak lengkap; guna sebagai panduan sahaja.\n\nHijau (0–11 µR/h)\nLatar hampir semula jadi.\n• Air perigi biasanya selamat.\n• Boleh menanam tanpa ujian.\n\nKuning (11–30 µR/h)\nLatar meningkat.\n• Periksa air dan tanah.\n• Uji makanan sebelum makan.\n\nMerah (30–100 µR/h)\nPencemaran serius.\n• Jangan minum air.\n• Menanam atau makan di sini berbahaya; perlu ujian makmal.\n\nHitam (>100 µR/h)\nZon kritikal.\n• Air dan makanan tidak boleh digunakan.\n• Hanya lawatan singkat dengan perlindungan.\n"
   },
@@ -888,6 +914,7 @@
     "back_to_all_tracks": "بازگشت به نقشهٔ ترکیبی مسیرها.",
     "legend_title": "راهنما",
     "legend_safe": "ایمن",
+    "legend_attention": "توجه",
     "legend_danger": "خطر",
     "legend_full_fa": "این مقیاس نشان می‌دهد یک محل برای زندگی، آب و غذا چقدر امن است.\nبه یاد داشته باشید: اندازه‌گیری‌ها ممکن است ناقص باشد؛ فقط به عنوان راهنما استفاده کنید.\n\nسبز (0–11 µR/h)\nزمینه نزدیک به طبیعی.\n• آب چاه معمولاً امن است.\n• می‌توان بدون آزمایش گیاه کاشت.\n\nزرد (11–30 µR/h)\nزمینه بالا رفته.\n• آب و خاک را بررسی کنید.\n• هر غذایی را پیش از خوردن آزمایش کنید.\n\nقرمز (30–100 µR/h)\nآلودگی شدید.\n• آب را ننوشید.\n• کاشت یا خوردن اینجا خطرناک است؛ آزمایشگاه لازم است.\n\nسیاه (>100 µR/h)\nمنطقه بحرانی.\n• آب و غذا قابل استفاده نیست.\n• فقط توقف کوتاه با حفاظت.\n"
   },
@@ -920,6 +947,7 @@
     "back_to_all_tracks": "חזרה למפת המסלולים המשולבת.",
     "legend_title": "מקרא",
     "legend_safe": "בטוח",
+    "legend_attention": "לתשומת לב",
     "legend_danger": "סכנה",
     "legend_full_he": "סולם זה מראה עד כמה מקום בטוח לחיים, למים ולמזון.\nזכור: המדידות עשויות להיות חלקיות; השתמש בזה כהכוונה בלבד.\n\nירוק (0–11 µR/h)\nרקע כמעט טבעי.\n• מי באר לרוב בטוחים.\n• ניתן לגדל צמחים בלי בדיקות.\n\nצהוב (11–30 µR/h)\nרקע מוגבר.\n• בדוק מים ואדמה.\n• בדוק כל מזון לפני אכילה.\n\nאדום (30–100 µR/h)\nזיהום חמור.\n• אל תשתה את המים.\n• גידול או אכילה כאן מסוכנים; בדיקות מעבדה חובה.\n\nשחור (>100 µR/h)\nאזור קריטי.\n• מים ומזון אינם שימושיים.\n• שהייה ממושכת אסורה; רק ביקור קצר עם הגנה.\n"
   }


### PR DESCRIPTION
## Summary
- Categorize dose rates as safe, attention, or danger and show safety word in marker popups
- Show translated legend description when hovering the map legend
- Localize new "attention" term across all supported languages
- Match marker tooltips with popup content including legend links and danger labels
- Render hover legend tooltip with same formatted HTML as legend modal
- Refine English legend description and update Russian translation accordingly
- Remove extra bullet characters so legend entries show only one square and enlarge the square for clarity

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c4ab9dcd4083328154452f274e5662