### PR TITLE
Fix mobile marker tooltip interaction

### DIFF
--- a/public_html/map.html
+++ b/public_html/map.html
@@ -962,10 +962,7 @@ document.addEventListener('DOMContentLoaded', function () {
   );
 
   // Close any fixed tooltip when clicking on empty map space
-  map.on('click', function(e) {
-    if (e.originalEvent && e.originalEvent.target.closest('.custom-tooltip')) {
-      return; // keep tooltip open if click was inside it
-    }
+  map.on('click', function() {
     closeActiveTooltip();
   });
 
@@ -1362,6 +1359,18 @@ function createDateRangeSlider(){
     }
   }
 
+  // Fix tooltip on tap/click and keep links usable
+  function activateTooltip(e) {
+    if (activeTooltipMarker && activeTooltipMarker !== this) {
+      closeActiveTooltip();
+    }
+    activeTooltipMarker = this;
+    this.openTooltip();
+    this.off('mouseout', this.closeTooltip);
+    L.DomEvent.disableClickPropagation(this.getTooltip().getElement());
+    L.DomEvent.stop(e); // prevent map from also handling this event
+  }
+
 
 /* Request markers for current bounds/zoom, render them,
  * and keep the date sliders in sync with the viewport.
@@ -1413,16 +1422,9 @@ function updateMarkers(){
     .addTo(map)
     .bindTooltip(getTooltipContent(m),
         { direction:'top', className:'custom-tooltip', offset:[0,-8], interactive:true })
-    // Fix tooltip on click and ensure only one stays open across the map
-    .on('click', function (e) {
-      if (activeTooltipMarker && activeTooltipMarker !== this) {
-        closeActiveTooltip();
-      }
-      activeTooltipMarker = this;
-      this.openTooltip();
-      this.off('mouseout', this.closeTooltip);
-      L.DomEvent.stop(e); // Prevent map click which would close the tooltip immediately
-    });
+    // Activate tooltip on both click and touch for mobile usability
+    .on('click', activateTooltip)
+    .on('touchstart', activateTooltip);
 
     circleMarkers[m.id || m.trackID] = cm;
   };

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -845,6 +845,8 @@ var currentTrackID = null;
 
 // New controller to cancel previous request
 var markerStreamSource = null;
+// Track currently opened tooltip so we can close it when needed
+var activeTooltipMarker = null;
 
 
 /**
@@ -958,6 +960,14 @@ document.addEventListener('DOMContentLoaded', function () {
     '<a href="https://atomfast.net" target="_blank">Atomcloud</a>, ' +
     '<a href="https://radiaverse.com" target="_blank">Radiacode</a>'
   );
+
+  // Close any fixed tooltip when clicking on empty map space
+  map.on('click', function(e) {
+    if (e.originalEvent && e.originalEvent.target.closest('.custom-tooltip')) {
+      return; // keep tooltip open if click was inside it
+    }
+    closeActiveTooltip();
+  });
 
   // Track view initialization
   var initialMarkers = JSON.parse('{{ .Markers | toJSON }}');
@@ -1343,6 +1353,15 @@ function createDateRangeSlider(){
     return buildMarkerContent(marker);
   }
 
+  // Ensure only one tooltip remains open and restore hover behavior on close
+  function closeActiveTooltip() {
+    if (activeTooltipMarker) {
+      activeTooltipMarker.on('mouseout', activeTooltipMarker.closeTooltip);
+      activeTooltipMarker.closeTooltip();
+      activeTooltipMarker = null;
+    }
+  }
+
 
 /* Request markers for current bounds/zoom, render them,
  * and keep the date sliders in sync with the viewport.
@@ -1394,10 +1413,15 @@ function updateMarkers(){
     .addTo(map)
     .bindTooltip(getTooltipContent(m),
         { direction:'top', className:'custom-tooltip', offset:[0,-8], interactive:true })
-    // Open tooltip on click so mobile users see the same UI without double tapping.
+    // Fix tooltip on click and ensure only one stays open across the map
     .on('click', function (e) {
+      if (activeTooltipMarker && activeTooltipMarker !== this) {
+        closeActiveTooltip();
+      }
+      activeTooltipMarker = this;
       this.openTooltip();
-      L.DomEvent.stop(e); // Stop propagation to preserve inner link clicks.
+      this.off('mouseout', this.closeTooltip);
+      L.DomEvent.stop(e); // Prevent map click which would close the tooltip immediately
     });
 
     circleMarkers[m.id || m.trackID] = cm;

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -961,8 +961,12 @@ document.addEventListener('DOMContentLoaded', function () {
     '<a href="https://radiaverse.com" target="_blank">Radiacode</a>'
   );
 
-  // Close any fixed tooltip when clicking on empty map space
-  map.on('click', function() {
+  // Close fixed tooltip only when clicking outside its content
+  map.on('click', function(e) {
+    // If the click originates inside an active tooltip, keep it open
+    if (e.originalEvent && e.originalEvent.target.closest('.custom-tooltip')) {
+      return;
+    }
     closeActiveTooltip();
   });
 
@@ -1367,8 +1371,9 @@ function createDateRangeSlider(){
     activeTooltipMarker = this;
     this.openTooltip();
     this.off('mouseout', this.closeTooltip);
-    L.DomEvent.disableClickPropagation(this.getTooltip().getElement());
-    L.DomEvent.stop(e); // prevent map from also handling this event
+    // Allow tooltip links to bubble to document handlers while
+    // preventing the map from treating this as an outside click
+    L.DomEvent.stop(e);
   }
 
 
@@ -1422,10 +1427,9 @@ function updateMarkers(){
     .addTo(map)
     .bindTooltip(getTooltipContent(m),
         { direction:'top', className:'custom-tooltip', offset:[0,-8], interactive:true })
-    // Activate tooltip on each touch event so a single tap fixes it
+    // Fix tooltip on mobile tap or desktop click
     .on('click', activateTooltip)
-    .on('touchstart', activateTooltip)
-    .on('touchend', activateTooltip);
+    .on('touchstart', activateTooltip);
 
     circleMarkers[m.id || m.trackID] = cm;
   };

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -961,11 +961,22 @@ document.addEventListener('DOMContentLoaded', function () {
     '<a href="https://radiaverse.com" target="_blank">Radiacode</a>'
   );
 
-  // Close fixed tooltip only when clicking outside its content
+  // Close fixed tooltip when interaction is outside markers or tooltips
   map.on('click', function(e) {
-    // If the click originates inside an active tooltip, keep it open
-    if (e.originalEvent && e.originalEvent.target.closest('.custom-tooltip')) {
-      return;
+    if (e.originalEvent &&
+        (e.originalEvent.target.closest('.custom-tooltip') ||
+         e.originalEvent.target.closest('.leaflet-interactive'))){
+      return; // keep open if click was on marker or its tooltip
+    }
+    closeActiveTooltip();
+  });
+
+  // Hide tooltip once the cursor leaves markers and tooltips
+  map.on('mousemove', function(e) {
+    if (e.originalEvent &&
+        (e.originalEvent.target.closest('.custom-tooltip') ||
+         e.originalEvent.target.closest('.leaflet-interactive'))){
+      return; // pointer still over marker or tooltip
     }
     closeActiveTooltip();
   });
@@ -1363,7 +1374,7 @@ function createDateRangeSlider(){
     }
   }
 
-  // Fix tooltip on tap/click and keep links usable
+  // Activate tooltip on hover or click and keep links usable
   function activateTooltip(e) {
     if (activeTooltipMarker && activeTooltipMarker !== this) {
       closeActiveTooltip();
@@ -1427,9 +1438,9 @@ function updateMarkers(){
     .addTo(map)
     .bindTooltip(getTooltipContent(m),
         { direction:'top', className:'custom-tooltip', offset:[0,-8], interactive:true })
-    // Fix tooltip on mobile tap or desktop click
-    .on('click', activateTooltip)
-    .on('touchstart', activateTooltip);
+    // Activate tooltip on hover or click so links are usable
+    .on('mouseover', activateTooltip)
+    .on('click', activateTooltip);
 
     circleMarkers[m.id || m.trackID] = cm;
   };

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -1422,9 +1422,10 @@ function updateMarkers(){
     .addTo(map)
     .bindTooltip(getTooltipContent(m),
         { direction:'top', className:'custom-tooltip', offset:[0,-8], interactive:true })
-    // Activate tooltip on both click and touch for mobile usability
+    // Activate tooltip on each touch event so a single tap fixes it
     .on('click', activateTooltip)
-    .on('touchstart', activateTooltip);
+    .on('touchstart', activateTooltip)
+    .on('touchend', activateTooltip);
 
     circleMarkers[m.id || m.trackID] = cm;
   };

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -1316,9 +1316,9 @@ function createDateRangeSlider(){
 
 // Function definitions
 
-// ---------- Marker popups and tooltips ----------
-// Build HTML once so popups and tooltips share identical content.
-  function buildMarkerContent(marker) {
+  // ---------- Marker tooltip builder ----------
+  // Build HTML once so all markers share identical tooltip content.
+    function buildMarkerContent(marker) {
     // Return markup with hooks; events handled globally via delegation.
     return `
       <div class="custom-tooltip">
@@ -1338,15 +1338,10 @@ function createDateRangeSlider(){
       </div>`;
 }
 
-// Popup reuses shared builder to stay in sync with tooltips.
-function getPopupContent(marker) {
-  return buildMarkerContent(marker);
-}
-
-// Tooltip uses the same builder for hover previews.
-function getTooltipContent(marker) {
-  return buildMarkerContent(marker);
-}
+  // Tooltip uses the shared builder for hover/tap previews.
+  function getTooltipContent(marker) {
+    return buildMarkerContent(marker);
+  }
 
 
 /* Request markers for current bounds/zoom, render them,
@@ -1399,7 +1394,11 @@ function updateMarkers(){
     .addTo(map)
     .bindTooltip(getTooltipContent(m),
         { direction:'top', className:'custom-tooltip', offset:[0,-8], interactive:true })
-    .bindPopup(getPopupContent(m));
+    // Open tooltip on click so mobile users see the same UI without double tapping.
+    .on('click', function (e) {
+      this.openTooltip();
+      L.DomEvent.stop(e); // Stop propagation to preserve inner link clicks.
+    });
 
     circleMarkers[m.id || m.trackID] = cm;
   };


### PR DESCRIPTION
## Summary
- Remove popup binding from markers to avoid double-tap on mobile
- Open tooltip on click and stop event propagation for working links

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68c51225ff9c83329dd95682c2a4424b