### PR TITLE
Add realtime Safecast polling

### DIFF
--- a/pkg/database/models.go
+++ b/pkg/database/models.go
@@ -27,3 +27,16 @@ type Bounds struct {
 	MinLat, MinLon float64
 	MaxLat, MaxLon float64
 }
+
+// RealtimeMeasurement keeps the latest network readings.
+// We store raw numbers so the history can be rendered later.
+type RealtimeMeasurement struct {
+	ID         int64   `json:"id"`         // Primary key for database storage
+	DeviceID   string  `json:"deviceID"`   // Remote device identifier
+	Value      float64 `json:"value"`      // Reported radiation value
+	Unit       string  `json:"unit"`       // Measurement unit from the device
+	Lat        float64 `json:"lat"`        // Device latitude
+	Lon        float64 `json:"lon"`        // Device longitude
+	MeasuredAt int64   `json:"measuredAt"` // Timestamp supplied by the device
+	FetchedAt  int64   `json:"fetchedAt"`  // When we pulled it, aids freshness checks
+}

--- a/pkg/realtime/fetcher.go
+++ b/pkg/realtime/fetcher.go
@@ -1,0 +1,109 @@
+package realtime
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"time"
+
+	"chicha-isotope-map/pkg/database"
+)
+
+// devicePayload maps only fields we care about from the Safecast JSON.
+// Keeping it small avoids coupling to the full upstream schema.
+type devicePayload struct {
+	ID    string  `json:"id"`
+	Value float64 `json:"value"`
+	Unit  string  `json:"unit"`
+	Lat   float64 `json:"lat"`
+	Lon   float64 `json:"lon"`
+	Time  int64   `json:"time"`
+}
+
+// fetch pulls device data once and returns normalized measurements.
+func fetch(ctx context.Context, url string) ([]database.RealtimeMeasurement, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var raw []devicePayload
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, err
+	}
+	now := time.Now().Unix()
+	out := make([]database.RealtimeMeasurement, 0, len(raw))
+	for _, d := range raw {
+		out = append(out, database.RealtimeMeasurement{
+			DeviceID:   d.ID,
+			Value:      d.Value,
+			Unit:       d.Unit,
+			Lat:        d.Lat,
+			Lon:        d.Lon,
+			MeasuredAt: d.Time,
+			FetchedAt:  now,
+		})
+	}
+	return out, nil
+}
+
+// Start launches background workers that keep the live table updated.
+// We poll every 15 minutes as requested by Safecast to avoid flooding.
+// Two goroutines communicate over a channel; no mutex is needed.
+func Start(ctx context.Context, db *database.Database, dbType string) {
+	const url = "https://tt.safecast.org/devices"
+	const pollInterval = 15 * time.Minute
+
+	measurements := make(chan database.RealtimeMeasurement)
+
+	// DB writer goroutine.
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case m := <-measurements:
+				if err := db.InsertRealtimeMeasurement(m, dbType); err != nil {
+					log.Printf("realtime store: %v", err)
+				}
+			}
+		}
+	}()
+
+	// Fetcher goroutine.
+	go func() {
+		ticker := time.NewTicker(pollInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				close(measurements)
+				return
+			case <-ticker.C:
+				data, err := fetch(ctx, url)
+				if err != nil {
+					log.Printf("realtime fetch: %v", err)
+					continue
+				}
+				for _, m := range data {
+					select {
+					case <-ctx.Done():
+						close(measurements)
+						return
+					case measurements <- m:
+					}
+				}
+			}
+		}
+	}()
+}


### PR DESCRIPTION
## Summary
- create realtime_measurements table and insert helper
- poll Safecast devices in background every 15 minutes
- wire realtime fetcher into main server

## Testing
- `go test ./...` *(fails: command hung, likely due to network restrictions)*
- `go vet ./...` *(fails: command hung, likely due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68c7bbdbc2c08332be4c9a814cea3407