### PR TITLE
Add realtime Safecast polling

### DIFF
--- a/chicha-isotope-map.go
+++ b/chicha-isotope-map.go
@@ -2241,7 +2241,8 @@ func streamMarkersHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Printf("realtime query: %v", err)
 	}
-	log.Printf("realtime markers: %d", len(rtMarks)) // help diagnose missing live points
+	// Log bounds alongside count to help diagnose empty map tiles.
+	log.Printf("realtime markers: %d lat[%f,%f] lon[%f,%f]", len(rtMarks), minLat, maxLat, minLon, maxLon)
 
 	// merge realtime slice with streaming channel using a goroutine.
 	merged := make(chan database.Marker)

--- a/chicha-isotope-map.go
+++ b/chicha-isotope-map.go
@@ -46,6 +46,7 @@ import (
 	"chicha-isotope-map/pkg/database"
 	"chicha-isotope-map/pkg/logger"
 	"chicha-isotope-map/pkg/qrlogoext"
+	"chicha-isotope-map/pkg/realtime"
 )
 
 //go:embed public_html/*
@@ -68,6 +69,7 @@ var defaultLat = flag.Float64("default-lat", 44.08832, "Default map latitude")
 var defaultLon = flag.Float64("default-lon", 42.97577, "Default map longitude")
 var defaultZoom = flag.Int("default-zoom", 11, "Default map zoom")
 var defaultLayer = flag.String("default-layer", "OpenStreetMap", `Default base layer: "OpenStreetMap" or "Google Satellite"`)
+var realtimeEnabled = flag.Bool("realtime", true, "Enable polling of Safecast realtime devices")
 
 var CompileVersion = "dev"
 
@@ -86,110 +88,110 @@ type SpeedRange struct{ Min, Max float64 }
 // processBGeigieZenFile parses bGeigie Zen/Nano $BNRDD logs.
 // Supports ISO8601 timestamps at field[2] and DMM coordinates with N/S/E/W.
 func processBGeigieZenFile(
-    file multipart.File,
-    trackID string,
-    db *database.Database,
-    dbType string,
+	file multipart.File,
+	trackID string,
+	db *database.Database,
+	dbType string,
 ) (database.Bounds, string, error) {
-    logT(trackID, "BGEIGIE", "▶ start (stream)")
+	logT(trackID, "BGEIGIE", "▶ start (stream)")
 
-    sc := bufio.NewScanner(file)
-    sc.Buffer(make([]byte, 0, 64*1024), 2*1024*1024)
+	sc := bufio.NewScanner(file)
+	sc.Buffer(make([]byte, 0, 64*1024), 2*1024*1024)
 
-    const cpmPerMicroSv = 334.0
-    markers := make([]database.Marker, 0, 4096)
+	const cpmPerMicroSv = 334.0
+	markers := make([]database.Marker, 0, 4096)
 
-    parsed := 0
-    skipped := 0
-    for sc.Scan() {
-        line := strings.TrimSpace(sc.Text())
-        if line == "" || !strings.HasPrefix(line, "$BNRDD") {
-            skipped++
-            continue
-        }
-        if i := strings.IndexByte(line, '*'); i != -1 {
-            line = line[:i]
-        }
-        p := strings.Split(line, ",")
-        if len(p) < 6 { // need at least up to CPMvalid
-            skipped++
-            continue
-        }
+	parsed := 0
+	skipped := 0
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || !strings.HasPrefix(line, "$BNRDD") {
+			skipped++
+			continue
+		}
+		if i := strings.IndexByte(line, '*'); i != -1 {
+			line = line[:i]
+		}
+		p := strings.Split(line, ",")
+		if len(p) < 6 { // need at least up to CPMvalid
+			skipped++
+			continue
+		}
 
-        var (
-            ts  int64
-            cps float64
-            cpm float64
-            lat float64
-            lon float64
-        )
+		var (
+			ts  int64
+			cps float64
+			cpm float64
+			lat float64
+			lon float64
+		)
 
-        // Zen variant: 0:$BNRDD 1:ver 2:ISO8601 3:CPS 4:CPM 5:CPMvalid 6:fix 7:LATdmm 8:N/S 9:LONdmm 10:E/W ...
-        if len(p) >= 11 && strings.Contains(p[2], "T") {
-            if t, err := time.Parse(time.RFC3339, strings.TrimSpace(p[2])); err == nil {
-                ts = t.Unix()
-            }
-            cps = parseFloat(p[3])
-            cpm = parseFloat(p[4])
-            lat = parseDMM(p[7], p[8], 2)
-            lon = parseDMM(p[9], p[10], 3)
-        } else if len(p) >= 8 { // legacy fallback: decimals (+ optional suffix)
-            // We only accept if date/time parse succeeds via known helper; otherwise skip silently.
-            // If parseBGeigieDateTime isn't present, ts remains 0 and entry is skipped.
-            ts = 0
-            // try compact forms if helper exists in build
-            // cps/cpm & coords
-            cps = parseFloat(p[3])
-            cpm = parseFloat(p[4])
-            lat = parseBGeigieCoord(p[6])
-            lon = parseBGeigieCoord(p[7])
-        }
+		// Zen variant: 0:$BNRDD 1:ver 2:ISO8601 3:CPS 4:CPM 5:CPMvalid 6:fix 7:LATdmm 8:N/S 9:LONdmm 10:E/W ...
+		if len(p) >= 11 && strings.Contains(p[2], "T") {
+			if t, err := time.Parse(time.RFC3339, strings.TrimSpace(p[2])); err == nil {
+				ts = t.Unix()
+			}
+			cps = parseFloat(p[3])
+			cpm = parseFloat(p[4])
+			lat = parseDMM(p[7], p[8], 2)
+			lon = parseDMM(p[9], p[10], 3)
+		} else if len(p) >= 8 { // legacy fallback: decimals (+ optional suffix)
+			// We only accept if date/time parse succeeds via known helper; otherwise skip silently.
+			// If parseBGeigieDateTime isn't present, ts remains 0 and entry is skipped.
+			ts = 0
+			// try compact forms if helper exists in build
+			// cps/cpm & coords
+			cps = parseFloat(p[3])
+			cpm = parseFloat(p[4])
+			lat = parseBGeigieCoord(p[6])
+			lon = parseBGeigieCoord(p[7])
+		}
 
-        if ts == 0 || (lat == 0 && lon == 0) {
-            skipped++
-            continue
-        }
+		if ts == 0 || (lat == 0 && lon == 0) {
+			skipped++
+			continue
+		}
 
-        dose := 0.0
-        if cpm > 0 {
-            dose = cpm / cpmPerMicroSv
-        } else if cps > 0 {
-            dose = (cps * 60.0) / cpmPerMicroSv
-        } else {
-            skipped++
-            continue
-        }
+		dose := 0.0
+		if cpm > 0 {
+			dose = cpm / cpmPerMicroSv
+		} else if cps > 0 {
+			dose = (cps * 60.0) / cpmPerMicroSv
+		} else {
+			skipped++
+			continue
+		}
 
-        countRate := cps
-        if countRate == 0 && cpm > 0 {
-            countRate = cpm / 60.0
-        }
+		countRate := cps
+		if countRate == 0 && cpm > 0 {
+			countRate = cpm / 60.0
+		}
 
-        markers = append(markers, database.Marker{
-            DoseRate:  dose,
-            Date:      ts,
-            Lon:       lon,
-            Lat:       lat,
-            CountRate: countRate,
-            Zoom:      0,
-            Speed:     0,
-            TrackID:   trackID,
-        })
-        parsed++
-    }
-    if err := sc.Err(); err != nil {
-        return database.Bounds{}, trackID, err
-    }
-    if len(markers) == 0 {
-        return database.Bounds{}, trackID, fmt.Errorf("no valid $BNRDD points found (parsed=%d skipped=%d)", parsed, skipped)
-    }
+		markers = append(markers, database.Marker{
+			DoseRate:  dose,
+			Date:      ts,
+			Lon:       lon,
+			Lat:       lat,
+			CountRate: countRate,
+			Zoom:      0,
+			Speed:     0,
+			TrackID:   trackID,
+		})
+		parsed++
+	}
+	if err := sc.Err(); err != nil {
+		return database.Bounds{}, trackID, err
+	}
+	if len(markers) == 0 {
+		return database.Bounds{}, trackID, fmt.Errorf("no valid $BNRDD points found (parsed=%d skipped=%d)", parsed, skipped)
+	}
 
-    bbox, trackID, err := processAndStoreMarkers(markers, trackID, db, dbType)
-    if err != nil {
-        return bbox, trackID, err
-    }
-    logT(trackID, "BGEIGIE", "✔ done (parsed=%d)", parsed)
-    return bbox, trackID, nil
+	bbox, trackID, err := processAndStoreMarkers(markers, trackID, db, dbType)
+	if err != nil {
+		return bbox, trackID, err
+	}
+	logT(trackID, "BGEIGIE", "✔ done (parsed=%d)", parsed)
+	return bbox, trackID, nil
 }
 
 var speedCatalog = map[string]SpeedRange{
@@ -1466,7 +1468,9 @@ func processAtomSwiftCSVFile(
 	logT(trackID, "CSV", "parsed %d markers", len(markers))
 
 	bbox, trackID, err := processAndStoreMarkers(markers, trackID, db, dbType)
-	if err != nil { return bbox, trackID, err }
+	if err != nil {
+		return bbox, trackID, err
+	}
 	logT(trackID, "BGEIGIE", "✔ done")
 	return bbox, trackID, nil
 }
@@ -1686,7 +1690,9 @@ func processAtomFastFile(
 // parseBGeigieCoord parses coordinates that may have hemisphere suffix.
 func parseBGeigieCoord(s string) float64 {
 	s = strings.TrimSpace(s)
-	if s == "" { return 0 }
+	if s == "" {
+		return 0
+	}
 	r := s[len(s)-1]
 	if (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') {
 		base := s[:len(s)-1]
@@ -1706,19 +1712,28 @@ func parseBGeigieCoord(s string) float64 {
 func parseDMM(val, hemi string, degDigits int) float64 {
 	val = strings.TrimSpace(val)
 	hemi = strings.TrimSpace(hemi)
-	if val == "" { return 0 }
+	if val == "" {
+		return 0
+	}
 	f, err := strconv.ParseFloat(val, 64)
-	if err != nil { return 0 }
+	if err != nil {
+		return 0
+	}
 	deg := int(f / 100.0)
 	minutes := f - float64(deg*100)
 	d := float64(deg) + minutes/60.0
 	switch strings.ToUpper(hemi) {
-	case "S", "W": d = -d
+	case "S", "W":
+		d = -d
 	}
 	if degDigits == 2 {
-		if d < -90 || d > 90 { return 0 }
+		if d < -90 || d > 90 {
+			return 0
+		}
 	} else {
-		if d < -180 || d > 180 { return 0 }
+		if d < -180 || d > 180 {
+			return 0
+		}
 	}
 	return d
 }
@@ -2158,6 +2173,12 @@ func getMarkersHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if rt, err := db.GetLatestRealtimeByBounds(minLat, minLon, maxLat, maxLon, *dbType); err == nil {
+		markers = append(markers, rt...)
+	} else {
+		log.Printf("realtime query: %v", err)
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(markers)
 }
@@ -2206,15 +2227,51 @@ func streamMarkersHandler(w http.ResponseWriter, r *http.Request) {
 	// Choose streaming source: either entire map or a single track.
 	ctx := r.Context()
 	var (
-		src   <-chan database.Marker
-		errCh <-chan error
+		baseSrc <-chan database.Marker
+		errCh   <-chan error
 	)
 	if trackID != "" {
-		src, errCh = db.StreamMarkersByTrackIDZoomAndBounds(ctx, trackID, zoom, minLat, minLon, maxLat, maxLon, *dbType)
+		baseSrc, errCh = db.StreamMarkersByTrackIDZoomAndBounds(ctx, trackID, zoom, minLat, minLon, maxLat, maxLon, *dbType)
 	} else {
-		src, errCh = db.StreamMarkersByZoomAndBounds(ctx, zoom, minLat, minLon, maxLat, maxLon, *dbType)
+		baseSrc, errCh = db.StreamMarkersByZoomAndBounds(ctx, zoom, minLat, minLon, maxLat, maxLon, *dbType)
 	}
-	agg := aggregateMarkers(ctx, src, zoom)
+
+	// Fetch current realtime points once so the map reflects network devices.
+	rtMarks, err := db.GetLatestRealtimeByBounds(minLat, minLon, maxLat, maxLon, *dbType)
+	if err != nil {
+		log.Printf("realtime query: %v", err)
+	}
+	log.Printf("realtime markers: %d", len(rtMarks)) // help diagnose missing live points
+
+	// merge realtime slice with streaming channel using a goroutine.
+	merged := make(chan database.Marker)
+	go func() {
+		defer close(merged)
+		for _, m := range rtMarks {
+			select {
+			case merged <- m:
+			case <-ctx.Done():
+				return
+			}
+		}
+		for {
+			select {
+			case m, ok := <-baseSrc:
+				if !ok {
+					return
+				}
+				select {
+				case merged <- m:
+				case <-ctx.Done():
+					return
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	agg := aggregateMarkers(ctx, merged, zoom)
 
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
@@ -2301,6 +2358,13 @@ func main() {
 	}
 	if err = db.InitSchema(dbCfg); err != nil {
 		log.Fatalf("DB schema: %v", err)
+	}
+
+	if *realtimeEnabled {
+		// Launch realtime Safecast polling.
+		ctxRT, cancelRT := context.WithCancel(context.Background())
+		defer cancelRT()
+		realtime.Start(ctxRT, db, *dbType, log.Printf)
 	}
 
 	// 4. Маршруты и статика

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"math"
 	"sort"
 	"strings"
 	"time"
@@ -336,6 +337,19 @@ CREATE TABLE IF NOT EXISTS markers (
   speed      DOUBLE PRECISION,
   trackID    TEXT,
   CONSTRAINT markers_unique UNIQUE (doseRate,date,lon,lat,countRate,zoom,speed,trackID)
+);
+
+CREATE TABLE IF NOT EXISTS realtime_measurements (
+  id          BIGSERIAL PRIMARY KEY,
+  device_id   TEXT,
+  transport   TEXT,
+  value       DOUBLE PRECISION,
+  unit        TEXT,
+  lat         DOUBLE PRECISION,
+  lon         DOUBLE PRECISION,
+  measured_at BIGINT,
+  fetched_at  BIGINT,
+  CONSTRAINT realtime_unique UNIQUE (device_id,measured_at)
 );`
 
 	case "sqlite", "genji":
@@ -353,7 +367,21 @@ CREATE TABLE IF NOT EXISTS markers (
   trackID    TEXT
 );
 CREATE UNIQUE INDEX IF NOT EXISTS idx_markers_unique
-  ON markers (doseRate,date,lon,lat,countRate,zoom,speed,trackID);`
+  ON markers (doseRate,date,lon,lat,countRate,zoom,speed,trackID);
+
+CREATE TABLE IF NOT EXISTS realtime_measurements (
+  id          INTEGER PRIMARY KEY,
+  device_id   TEXT,
+  transport   TEXT,
+  value       REAL,
+  unit        TEXT,
+  lat         REAL,
+  lon         REAL,
+  measured_at BIGINT,
+  fetched_at  BIGINT
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_realtime_unique
+  ON realtime_measurements (device_id,measured_at);`
 
 	case "duckdb":
 		// DuckDB — no SERIAL/AUTOINCREMENT; use a sequence + DEFAULT nextval(...).
@@ -373,6 +401,20 @@ CREATE TABLE IF NOT EXISTS markers (
   speed      DOUBLE,
   trackID    TEXT,
   CONSTRAINT markers_unique UNIQUE (doseRate,date,lon,lat,countRate,zoom,speed,trackID)
+);
+
+CREATE SEQUENCE IF NOT EXISTS realtime_measurements_id_seq START 1;
+CREATE TABLE IF NOT EXISTS realtime_measurements (
+  id          BIGINT PRIMARY KEY DEFAULT nextval('realtime_measurements_id_seq'),
+  device_id   TEXT,
+  transport   TEXT,
+  value       DOUBLE,
+  unit        TEXT,
+  lat         DOUBLE,
+  lon         DOUBLE,
+  measured_at BIGINT,
+  fetched_at  BIGINT,
+  CONSTRAINT realtime_unique UNIQUE (device_id,measured_at)
 );`
 
 	default:
@@ -382,7 +424,54 @@ CREATE TABLE IF NOT EXISTS markers (
 	if _, err := db.DB.Exec(schema); err != nil {
 		return fmt.Errorf("init schema: %w", err)
 	}
+
+	// Ensure optional columns exist even for older databases.
+	if err := db.ensureRealtimeTransportColumn(cfg.DBType); err != nil {
+		return fmt.Errorf("add transport column: %w", err)
+	}
+
 	return nil
+}
+
+// ensureRealtimeTransportColumn adds the transport column to realtime_measurements when missing.
+// We keep SQL portable by using vendor-specific IF NOT EXISTS only where supported.
+// Older SQLite/Genji databases are inspected via PRAGMA before issuing ALTER TABLE.
+func (db *Database) ensureRealtimeTransportColumn(dbType string) error {
+	switch strings.ToLower(dbType) {
+	case "pgx", "duckdb":
+		// These engines support IF NOT EXISTS and will ignore duplicates.
+		_, err := db.DB.Exec(`ALTER TABLE realtime_measurements ADD COLUMN IF NOT EXISTS transport TEXT`)
+		return err
+
+	default:
+		// SQLite and friends: introspect the table first to avoid an error.
+		rows, err := db.DB.Query(`PRAGMA table_info(realtime_measurements);`)
+		if err != nil {
+			return fmt.Errorf("describe realtime_measurements: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var (
+				cid     int
+				name    string
+				ctype   string
+				notnull int
+				dflt    sql.NullString
+				pk      int
+			)
+			if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+				return fmt.Errorf("scan pragma: %w", err)
+			}
+			if name == "transport" {
+				return nil // column already present
+			}
+		}
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("iterate pragma: %w", err)
+		}
+		_, err = db.DB.Exec(`ALTER TABLE realtime_measurements ADD COLUMN transport TEXT`)
+		return err
+	}
 }
 
 // InsertMarkersBulk inserts markers in batches using multi-row VALUES.
@@ -516,6 +605,223 @@ ON CONFLICT DO NOTHING`,
 			m.CountRate, m.Zoom, m.Speed, m.TrackID)
 		return err
 	}
+}
+
+// InsertRealtimeMeasurement stores live device data and skips duplicates.
+// A little copying is better than a little dependency, so we build SQL by hand.
+func (db *Database) InsertRealtimeMeasurement(m RealtimeMeasurement, dbType string) error {
+	switch strings.ToLower(dbType) {
+	case "pgx", "duckdb":
+		_, err := db.DB.Exec(`
+INSERT INTO realtime_measurements
+      (device_id,transport,value,unit,lat,lon,measured_at,fetched_at)
+VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+ON CONFLICT ON CONSTRAINT realtime_unique DO NOTHING`,
+			m.DeviceID, m.Transport, m.Value, m.Unit, m.Lat, m.Lon, m.MeasuredAt, m.FetchedAt)
+		return err
+
+	default:
+		if m.ID == 0 {
+			m.ID = <-db.idGenerator
+		}
+		_, err := db.DB.Exec(`
+INSERT INTO realtime_measurements
+      (id,device_id,transport,value,unit,lat,lon,measured_at,fetched_at)
+VALUES (?,?,?,?,?,?,?,?,?)
+ON CONFLICT(device_id,measured_at) DO NOTHING`,
+			m.ID, m.DeviceID, m.Transport, m.Value, m.Unit, m.Lat, m.Lon, m.MeasuredAt, m.FetchedAt)
+		return err
+	}
+}
+
+// GetLatestRealtimeByBounds returns the newest reading per device within bounds.
+// We keep SQL portable and filter duplicates in Go, following "Clear is better than clever".
+func (db *Database) GetLatestRealtimeByBounds(minLat, minLon, maxLat, maxLon float64, dbType string) ([]Marker, error) {
+	var query string
+	switch strings.ToLower(dbType) {
+	case "pgx", "duckdb":
+		query = `
+SELECT device_id,value,unit,lat,lon,measured_at
+FROM realtime_measurements
+WHERE lat BETWEEN $1 AND $2 AND lon BETWEEN $3 AND $4
+ORDER BY device_id,fetched_at DESC;`
+	default:
+		query = `
+SELECT device_id,value,unit,lat,lon,measured_at
+FROM realtime_measurements
+WHERE lat BETWEEN ? AND ? AND lon BETWEEN ? AND ?
+ORDER BY device_id,fetched_at DESC;`
+	}
+
+	rows, err := db.DB.Query(query, minLat, maxLat, minLon, maxLon)
+	if err != nil {
+		return nil, fmt.Errorf("query realtime: %w", err)
+	}
+	defer rows.Close()
+
+	seen := make(map[string]bool)
+	var out []Marker
+	for rows.Next() {
+		var (
+			id       string
+			val      float64
+			unit     string
+			lat, lon float64
+			measured int64
+		)
+		if err := rows.Scan(&id, &val, &unit, &lat, &lon, &measured); err != nil {
+			return nil, fmt.Errorf("scan realtime: %w", err)
+		}
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		out = append(out, Marker{
+			DoseRate:  val,
+			Date:      measured,
+			Lon:       lon,
+			Lat:       lat,
+			CountRate: 0,
+			Zoom:      0,
+			Speed:     -1, // negative speed marks realtime in UI
+			TrackID:   id,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate realtime: %w", err)
+	}
+	return out, nil
+}
+
+// PromoteStaleRealtime moves device histories from the realtime table into the
+// regular markers table when a device has been offline for more than a day and
+// changed its position.  This keeps long tracks for mobile devices while
+// leaving stationary sensors in place.  The cutoff value is a Unix timestamp
+// (seconds) – any device whose newest fetched_at is older is eligible.
+func (db *Database) PromoteStaleRealtime(cutoff int64, dbType string) error {
+	// gather candidate device IDs over a channel to avoid blocking callers
+	ids := make(chan string)
+	errc := make(chan error, 1)
+
+	go func() {
+		defer close(ids)
+		var q string
+		switch strings.ToLower(dbType) {
+		case "pgx", "duckdb":
+			q = `SELECT device_id FROM realtime_measurements GROUP BY device_id HAVING max(fetched_at) <= $1`
+		default:
+			q = `SELECT device_id FROM realtime_measurements GROUP BY device_id HAVING max(fetched_at) <= ?`
+		}
+		rows, err := db.DB.Query(q, cutoff)
+		if err != nil {
+			errc <- fmt.Errorf("stale list: %w", err)
+			return
+		}
+		for rows.Next() {
+			var id string
+			if err := rows.Scan(&id); err != nil {
+				errc <- fmt.Errorf("scan stale: %w", err)
+				rows.Close()
+				return
+			}
+			ids <- id
+		}
+		errc <- rows.Err()
+	}()
+
+	// process each device sequentially; no mutex is needed
+	for id := range ids {
+		ms, err := db.fetchRealtimeByDevice(id, dbType)
+		if err != nil {
+			return err
+		}
+		if !moved(ms) {
+			continue // stationary sensors stay in realtime table
+		}
+
+		tx, err := db.DB.Begin()
+		if err != nil {
+			return err
+		}
+		for _, m := range ms {
+			marker := Marker{
+				DoseRate:  m.Value,
+				Date:      m.MeasuredAt,
+				Lon:       m.Lon,
+				Lat:       m.Lat,
+				CountRate: 0,
+				Zoom:      0,
+				Speed:     0,
+				TrackID:   id,
+			}
+			if err := db.SaveMarkerAtomic(tx, marker, dbType); err != nil {
+				tx.Rollback()
+				return err
+			}
+		}
+		if err := db.deleteRealtimeDevice(tx, id, dbType); err != nil {
+			tx.Rollback()
+			return err
+		}
+		if err := tx.Commit(); err != nil {
+			return err
+		}
+	}
+	return <-errc
+}
+
+// fetchRealtimeByDevice returns all realtime rows for a given device.
+func (db *Database) fetchRealtimeByDevice(id, dbType string) ([]RealtimeMeasurement, error) {
+	var q string
+	switch strings.ToLower(dbType) {
+	case "pgx", "duckdb":
+		q = `SELECT device_id,transport,value,unit,lat,lon,measured_at,fetched_at FROM realtime_measurements WHERE device_id=$1`
+	default:
+		q = `SELECT device_id,transport,value,unit,lat,lon,measured_at,fetched_at FROM realtime_measurements WHERE device_id=?`
+	}
+	rows, err := db.DB.Query(q, id)
+	if err != nil {
+		return nil, fmt.Errorf("fetch realtime: %w", err)
+	}
+	defer rows.Close()
+	var out []RealtimeMeasurement
+	for rows.Next() {
+		var m RealtimeMeasurement
+		if err := rows.Scan(&m.DeviceID, &m.Transport, &m.Value, &m.Unit, &m.Lat, &m.Lon, &m.MeasuredAt, &m.FetchedAt); err != nil {
+			return nil, fmt.Errorf("scan realtime row: %w", err)
+		}
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}
+
+// deleteRealtimeDevice removes all realtime rows for the given device.
+func (db *Database) deleteRealtimeDevice(exec sqlExecutor, id, dbType string) error {
+	var q string
+	switch strings.ToLower(dbType) {
+	case "pgx", "duckdb":
+		q = `DELETE FROM realtime_measurements WHERE device_id=$1`
+	default:
+		q = `DELETE FROM realtime_measurements WHERE device_id=?`
+	}
+	_, err := exec.Exec(q, id)
+	return err
+}
+
+// moved reports whether a set of realtime measurements changed location.
+// A tiny epsilon avoids floating‑point noise.
+func moved(ms []RealtimeMeasurement) bool {
+	if len(ms) == 0 {
+		return false
+	}
+	const eps = 0.0001
+	baseLat, baseLon := ms[0].Lat, ms[0].Lon
+	for _, m := range ms[1:] {
+		if math.Abs(m.Lat-baseLat) > eps || math.Abs(m.Lon-baseLon) > eps {
+			return true
+		}
+	}
+	return false
 }
 
 // sqlExecutor is satisfied by both *sql.Tx and *sql.DB.

--- a/pkg/database/models.go
+++ b/pkg/database/models.go
@@ -27,3 +27,17 @@ type Bounds struct {
 	MinLat, MinLon float64
 	MaxLat, MaxLon float64
 }
+
+// RealtimeMeasurement keeps the latest network readings.
+// We store raw numbers so the history can be rendered later.
+type RealtimeMeasurement struct {
+	ID         int64   `json:"id"`         // Primary key for database storage
+	DeviceID   string  `json:"deviceID"`   // Remote device identifier
+	Transport  string  `json:"transport"`  // How the device moves (car, walk), kept for future use
+	Value      float64 `json:"value"`      // Reported radiation value
+	Unit       string  `json:"unit"`       // Measurement unit from the device
+	Lat        float64 `json:"lat"`        // Device latitude
+	Lon        float64 `json:"lon"`        // Device longitude
+	MeasuredAt int64   `json:"measuredAt"` // Timestamp supplied by the device
+	FetchedAt  int64   `json:"fetchedAt"`  // When we pulled it, aids freshness checks
+}

--- a/pkg/realtime/fetcher.go
+++ b/pkg/realtime/fetcher.go
@@ -1,0 +1,224 @@
+package realtime
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"chicha-isotope-map/pkg/database"
+)
+
+// devicePayload maps only fields we care about from the Safecast JSON.
+// Keeping it small avoids coupling to the full upstream schema.
+type devicePayload struct {
+	ID      string  `json:"id"`
+	Type    string  `json:"type"` // may describe transport (car, walk)
+	Value   float64 `json:"value"`
+	Unit    string  `json:"unit"`
+	Lat     float64 `json:"lat"`
+	Lon     float64 `json:"lon"`
+	Time    int64   `json:"time"`
+	Country string  `json:"country"` // optional; fall back to bbox lookup
+}
+
+// fetch pulls device data once.
+// Returning raw payload keeps this function simple and lets callers derive
+// both measurements and summaries without another pass.
+func fetch(ctx context.Context, url string) ([]devicePayload, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var raw []devicePayload
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, err
+	}
+	return raw, nil
+}
+
+// bbox defines a coarse country boundary.
+// We keep only a few major regions to avoid heavyweight geo libraries.
+type bbox struct {
+	code           string
+	minLat, maxLat float64
+	minLon, maxLon float64
+}
+
+var countryBoxes = []bbox{
+	{"JP", 30, 46, 129, 146},  // Japan
+	{"US", 24, 49, -125, -66}, // Continental USA
+	{"RU", 41, 82, 19, 180},   // Rough Russia mainland
+	{"EU", 36, 71, -25, 40},   // Generic Europe box
+}
+
+// countryFor returns a rough country code for given coordinates.
+// Unknown points fall back to "??".
+func countryFor(lat, lon float64) string {
+	for _, b := range countryBoxes {
+		if lat >= b.minLat && lat <= b.maxLat && lon >= b.minLon && lon <= b.maxLon {
+			return b.code
+		}
+	}
+	return "??"
+}
+
+// Start launches background workers that keep the live table updated.
+// We poll every 15 minutes as requested by Safecast to avoid flooding.
+// Two goroutines communicate over a channel; no mutex is needed.
+// logf defines where progress messages are written.
+func Start(ctx context.Context, db *database.Database, dbType string, logf func(string, ...any)) {
+	const url = "https://tt.safecast.org/devices"
+	const pollInterval = 15 * time.Minute
+
+	if logf == nil {
+		logf = log.Printf
+	}
+
+	// Announce poller start once so operators know interval and source.
+	logf("realtime poller start: url=%s interval=%s", url, pollInterval)
+
+	measurements := make(chan database.RealtimeMeasurement)
+	reports := make(chan int)
+
+	// DB writer goroutine.
+	// It counts successes and errors per batch and logs once per report.
+	go func() {
+		var stored, errs int
+		var lastErr error
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case m := <-measurements:
+				if err := db.InsertRealtimeMeasurement(m, dbType); err != nil {
+					errs++
+					lastErr = err
+				} else {
+					stored++
+				}
+			case n := <-reports:
+				if errs > 0 {
+					logf("realtime poll: devices %d stored %d errors %d last=%v next=%s", n, stored, errs, lastErr, pollInterval)
+				} else {
+					logf("realtime poll: devices %d stored %d next=%s", n, stored, pollInterval)
+				}
+				stored, errs, lastErr = 0, 0, nil
+			}
+		}
+	}()
+
+	// Fetcher goroutine runs once immediately and then every pollInterval.
+	// Running the first fetch before waiting on the ticker gives operators
+	// instant feedback after startup, embodying "Make interfaces easy to
+	// use correctly".
+	go func() {
+		ticker := time.NewTicker(pollInterval)
+		defer ticker.Stop()
+
+		// prevIDs remembers devices from prior fetch to compute add/remove counts.
+		prevIDs := make(map[string]struct{})
+
+		for {
+			data, err := fetch(ctx, url)
+			if err != nil {
+				logf("realtime fetch error: %v", err)
+			} else {
+				// Log how many devices were returned to understand coverage.
+				logf("realtime fetch: devices %d", len(data))
+
+				// Summaries are computed while forwarding measurements to DB.
+				stats := make(map[string]struct {
+					sum   float64
+					count int
+				})
+				curr := make(map[string]struct{})
+				now := time.Now().Unix()
+
+				for _, d := range data {
+					curr[d.ID] = struct{}{}
+					c := d.Country
+					if c == "" {
+						c = countryFor(d.Lat, d.Lon)
+					}
+					s := stats[c]
+					s.sum += d.Value
+					s.count++
+					stats[c] = s
+
+					m := database.RealtimeMeasurement{
+						DeviceID:   d.ID,
+						Transport:  d.Type,
+						Value:      d.Value,
+						Unit:       d.Unit,
+						Lat:        d.Lat,
+						Lon:        d.Lon,
+						MeasuredAt: d.Time,
+						FetchedAt:  now,
+					}
+					select {
+					case <-ctx.Done():
+						close(measurements)
+						return
+					case measurements <- m:
+					}
+				}
+				reports <- len(data)
+
+				// Calculate device churn since last poll.
+				added, removed := 0, 0
+				for id := range curr {
+					if _, ok := prevIDs[id]; !ok {
+						added++
+					}
+				}
+				for id := range prevIDs {
+					if _, ok := curr[id]; !ok {
+						removed++
+					}
+				}
+				prevIDs = curr
+
+				// Build country summary lines.
+				parts := make([]string, 0, len(stats))
+				for country, s := range stats {
+					avg := s.sum / float64(s.count)
+					parts = append(parts, fmt.Sprintf("%s:%d avg=%.2f", country, s.count, avg))
+				}
+				sort.Strings(parts)
+
+				// Prepare example map link using the first device.
+				example := ""
+				if len(data) > 0 {
+					e := data[0]
+					example = fmt.Sprintf("https://www.openstreetmap.org/?mlat=%f&mlon=%f&zoom=12", e.Lat, e.Lon)
+				}
+
+				logf("realtime summary: %s added=%d removed=%d example=%s", strings.Join(parts, " "), added, removed, example)
+
+				// Promote stale device histories to normal tracks once a day.
+				go db.PromoteStaleRealtime(time.Now().Add(-24*time.Hour).Unix(), dbType)
+			}
+			select {
+			case <-ctx.Done():
+				close(measurements)
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+}

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -532,6 +532,18 @@ body, html {
         /* Removed old collapsible legend styles (legend-control, legend-header, legend-title, legend-toggle, legend-body, legend-row, legend-swatch, legend-label)
            to avoid duplicate legends. Only the compact legend + modal remain. */
 
+        /* Live marker icon: a circle with centered value text */
+        .live-marker {
+          border-radius: 50%;
+          width: 24px;
+          height: 24px;
+          line-height: 24px;
+          text-align: center;
+          font-size: 10px;
+          font-weight: bold;
+          color: #000;
+        }
+
     </style>
 
     <!-- Translation script -->
@@ -821,6 +833,7 @@ function shouldDisplayBySpeed(speed) {
   if (isTrackView) return true;        // filter disabled in track view
 
   const st = loadSpeedFilterState();   // global mode
+  if (speed < 0) return st.live;       // 📡 realtime markers use negative speed
   if (speed >= 70 && speed <= 500) return st.plane;  // ✈️
   if (speed >= 7  && speed <  70)  return st.car;    // 🚗
   /* speed < 7 m/s  → pedestrian */
@@ -886,13 +899,15 @@ var markerStreamSource = null;
 /**
  * Load previously saved speed-filter state from sessionStorage.
  * If nothing is stored yet, return default state
- *   ✈️ off, 🚗 on, 🚶 on  (as requested).
+ *   📡 on, ✈️ off, 🚗 on, 🚶 on  (as requested).
  */
 function loadSpeedFilterState() {
-  const def = { plane: false, car: true, ped: true };
+  // Defaults: live on, plane off, car on, pedestrian on.
+  const def = { live: true, plane: false, car: true, ped: true };
   try {
     const raw = sessionStorage.getItem('speedFilterState');
-    return raw ? JSON.parse(raw) : def;
+    const st = raw ? JSON.parse(raw) : {};
+    return Object.assign({}, def, st);
   } catch (e) {
     return def;
   }
@@ -1034,7 +1049,7 @@ document.addEventListener('DOMContentLoaded', function () {
   /**
    * Build a Leaflet control with three check-boxes that filter markers
    * by recorded speed. Labels now show speed in km/h instead of m/s.
-   * Default state: ✈️ off, 🚗 on, 🚶 on.
+   * Default state: 📡 on, ✈️ off, 🚗 on, 🚶 on.
    */
   function createSpeedFilterControls() {
 
@@ -1056,9 +1071,11 @@ document.addEventListener('DOMContentLoaded', function () {
           ${emoji}
             </label>`;
 
-        // order: ✈️, 🚗, 🚶  (top → bottom)
+        // order: 📡, ✈️, 🚗, 🚶  (top → bottom)
         div.innerHTML =
-          row('sfPlane', '✈️',  state.plane) +
+          row('sfLive',  '📡', state.live)  +
+          '<div class="leaflet-control-layers-separator"></div>' +
+          row('sfPlane', '✈️', state.plane) +
           row('sfCar',   '🚗', state.car)   +
           row('sfPed',   '🚶', state.ped);
 
@@ -1068,6 +1085,7 @@ document.addEventListener('DOMContentLoaded', function () {
         // attach change-handlers
         div.querySelectorAll('input[type=checkbox]').forEach(cb => {
           cb.addEventListener('change', () => {
+            state.live  = div.querySelector('#sfLive').checked;
             state.plane = div.querySelector('#sfPlane').checked;
             state.car   = div.querySelector('#sfCar').checked;
             state.ped   = div.querySelector('#sfPed').checked;
@@ -1422,20 +1440,43 @@ function updateMarkers(){
     maxTs = Math.max(maxTs, m.date);
     if (savedRange && (m.date < savedRange[0] || m.date > savedRange[1])) return;
     if (!shouldDisplayBySpeed(m.speed)) return;
-    const cm = L.circleMarker([m.lat, m.lon], {
-      radius      : getRadius(m.doseRate, zoom),
-      fillColor   : getGradientColor(m.doseRate),
-      color       : getGradientColor(m.doseRate),
-      weight      : 1,
-      opacity     : getFillOpacity(m.speed) + 0.1,
-      fillOpacity : getFillOpacity(m.speed)
-    })
-    .addTo(map)
-    .bindTooltip(getTooltipContent(m),
-        { direction:'top', className:'custom-tooltip', offset:[0,-8], interactive:true })
-    .bindPopup(getPopupContent(m));
 
-    circleMarkers[m.id || m.trackID] = cm;
+    let marker;
+    const isLive = m.speed < 0; // negative speed denotes realtime marker
+    if (isLive) { // realtime marker with value inside the circle
+      const ageSec = Date.now()/1000 - m.date;
+      const fresh = ageSec < 20*60; // stale after 20 minutes
+      const baseColor = getGradientColor(m.doseRate);
+      const border = fresh ? '#fff' : '#888';
+      const opacity = fresh ? 1 : 0.3;
+      const r = getRadius(m.doseRate, zoom) * 1.5;
+      const size = r * 2;
+      const html = `<div class="live-marker" style="background:${baseColor};border:1px solid ${border};opacity:${opacity};width:${size}px;height:${size}px;line-height:${size}px;">${m.doseRate.toFixed(2)}</div>`;
+      marker = L.marker([m.lat, m.lon], {
+        icon: L.divIcon({className:'', html: html, iconSize:[size, size], iconAnchor:[r, r]})
+      })
+      .addTo(map)
+      .bindTooltip(getTooltipContent(m), { direction:'top', className:'custom-tooltip', offset:[0,-8], interactive:true })
+      .bindPopup(getPopupContent(m));
+    } else {
+      marker = L.circleMarker([m.lat, m.lon], {
+        radius      : getRadius(m.doseRate, zoom),
+        fillColor   : getGradientColor(m.doseRate),
+        color       : getGradientColor(m.doseRate),
+        weight      : 1,
+        opacity     : getFillOpacity(m.speed) + 0.1,
+        fillOpacity : getFillOpacity(m.speed)
+      })
+      .addTo(map)
+      .bindTooltip(getTooltipContent(m), { direction:'top', className:'custom-tooltip', offset:[0,-8], interactive:true })
+      .bindPopup(getPopupContent(m));
+    }
+
+    // Store dose rate and timestamp on marker for later size updates
+    marker.doseRate  = m.doseRate;
+    marker.date      = m.date;
+    marker.isRealtime = isLive;
+    circleMarkers[m.id || m.trackID] = marker;
   };
 
   es.addEventListener('done', () => {
@@ -1476,8 +1517,22 @@ function adjustMarkerRadius() {
   var zoomLevel = map.getZoom();
   for (let key in circleMarkers) {
     let marker = circleMarkers[key];
-    let newRadius = getRadius(marker.doseRate, zoomLevel);
-    marker.setRadius(newRadius);
+    if (marker.isRealtime) {
+      // Rebuild div icon to scale realtime markers with zoom
+      const r = getRadius(marker.doseRate, zoomLevel) * 1.5;
+      const size = r * 2;
+      const ageSec = Date.now()/1000 - marker.date;
+      const fresh = ageSec < 20*60; // 20 minutes freshness window
+      const baseColor = getGradientColor(marker.doseRate);
+      const border = fresh ? '#fff' : '#888';
+      const opacity = fresh ? 1 : 0.3;
+      const html = `<div class="live-marker" style="background:${baseColor};border:1px solid ${border};opacity:${opacity};width:${size}px;height:${size}px;line-height:${size}px;">${marker.doseRate.toFixed(2)}</div>`;
+      marker.setIcon(L.divIcon({className:'', html: html, iconSize:[size, size], iconAnchor:[r, r]}));
+    } else if (typeof marker.setRadius === 'function') {
+      // Circle markers scale by adjusting radius directly
+      let newRadius = getRadius(marker.doseRate, zoomLevel);
+      marker.setRadius(newRadius);
+    }
   }
 }
 

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -1372,6 +1372,10 @@ function createDateRangeSlider(){
 // Build HTML once so popups and tooltips share identical content.
   function buildMarkerContent(marker) {
     // Return markup with hooks; events handled globally via delegation.
+    const speedText = marker.speed < 0
+      ? '—' // negative speed marks realtime points; no motion available
+      : `${(marker.speed * 3.6).toFixed(1)} km/h`;
+
     return `
       <div class="custom-tooltip">
         <div><strong>${translate('radiation_dose')}:</strong><br>
@@ -1380,7 +1384,7 @@ function createDateRangeSlider(){
             ${translate(doseCategory(marker.doseRate))}
           </a>)
         </div>
-        <div><strong>${translate('speed')}:</strong> ${(marker.speed * 3.6).toFixed(1)} km/h</div>
+        <div><strong>${translate('speed')}:</strong> ${speedText}</div>
         <div style="margin-top:4px">
           <!-- clicking the link switches to track mode -->
           <a href="#" class="track-link" data-track="${marker.trackID}" style="font-weight:bold;">

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -1435,21 +1435,21 @@ function updateMarkers(){
 
   es.onmessage = e => {
     let m; try { m = JSON.parse(e.data); } catch { return; }
-    if (m.trackID) tracks.add(m.trackID);
+    const isLive = m.speed < 0; // negative speed denotes realtime marker
+    if (!isLive && m.trackID) tracks.add(m.trackID);
     minTs = Math.min(minTs, m.date);
     maxTs = Math.max(maxTs, m.date);
     if (savedRange && (m.date < savedRange[0] || m.date > savedRange[1])) return;
     if (!shouldDisplayBySpeed(m.speed)) return;
 
     let marker;
-    const isLive = m.speed < 0; // negative speed denotes realtime marker
     if (isLive) { // realtime marker with value inside the circle
       const ageSec = Date.now()/1000 - m.date;
       const fresh = ageSec < 20*60; // stale after 20 minutes
       const baseColor = getGradientColor(m.doseRate);
       const border = fresh ? '#fff' : '#888';
       const opacity = fresh ? 1 : 0.3;
-      const r = getRadius(m.doseRate, zoom) * 1.5;
+      const r = getRadius(m.doseRate, zoom) * 3; // larger circle for realtime visibility
       const size = r * 2;
       const html = `<div class="live-marker" style="background:${baseColor};border:1px solid ${border};opacity:${opacity};width:${size}px;height:${size}px;line-height:${size}px;">${m.doseRate.toFixed(2)}</div>`;
       marker = L.marker([m.lat, m.lon], {


### PR DESCRIPTION
## Summary
- create realtime_measurements table and insert helper
- poll Safecast devices in background every 15 minutes
- wire realtime fetcher into main server
- allow disabling realtime polling via `-realtime` flag
- add map checkbox to show or hide live points
- track device transport type and summarize poll results in logs
- log poller start, fetch counts, per-country averages, device churn, and example map link
- fetch realtime devices immediately at startup
- stream and render latest realtime markers with value and stale/fresh styling
- separate live checkbox with a divider
- add migration to ensure `transport` column exists for existing databases
- move offline mobile devices from realtime storage into permanent tracks
- resize realtime markers safely by storing their metadata and rebuilding icons on zoom
- log realtime marker count for each bounding-box request

## Testing
- `GOPROXY=off go vet ./...` *(hangs: no output, terminated)*
- `GOPROXY=off timeout 100 go test ./...` *(hangs: no output, terminated)*
- `GOPROXY=off timeout 100 go build ./...` *(hangs: no output, terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68c7bbdbc2c08332be4c9a814cea3407