### PR TITLE
Rename realtime helpers and gate Safecast feed

### DIFF
--- a/pkg/safecast-realtime/conversion.go
+++ b/pkg/safecast-realtime/conversion.go
@@ -1,0 +1,119 @@
+package safecastrealtime
+
+import (
+	"strings"
+	"unicode"
+)
+
+// muReplacer collapses the two common micro symbols into ASCII 'u'.
+// Doing the work once keeps normalizeUnit cheap because strings.NewReplacer
+// builds an internal table that we can reuse safely across calls.
+var muReplacer = strings.NewReplacer("µ", "u", "μ", "u")
+
+// ─── Constants with calibration factors ─────────────────────────────────────
+
+const (
+	// factorLND7317 handles Safecast realtime CPM feeds for LND 7318 tubes.
+	// Safecast labels these fields as "lnd_7317" even though the hardware
+	// variants are 7318U and 7318C.  Field manuals quote 334 CPM per µSv/h.
+	factorLND7317 = 334.0
+	// factorLND712 covers the classic LND 712 and the shielded 7128 EC.
+	// Both share the same 108 CPM per µSv/h calibration in Safecast docs.
+	factorLND712 = 108.0
+)
+
+// ─── Public conversion helpers ──────────────────────────────────────────────
+
+// FromRealtime converts a raw Safecast realtime reading into µSv/h.
+// The bool return value reports whether the conversion succeeded.  We keep the
+// logic here so both storage and presentation layers stay consistent and follow
+// the Go Proverb "Don't communicate by sharing memory, share memory by
+// communicating" – callers only exchange simple numbers instead of duplicating
+// rules.
+func FromRealtime(value float64, unit string) (float64, bool) {
+	if value <= 0 {
+		return 0, false
+	}
+
+	normalized := normalizeUnit(unit)
+	if normalized == "" {
+		return 0, false
+	}
+
+	// Direct µSv/h values can be forwarded as-is.  We also accept plain
+	// "usv/h" strings because some payloads replace the micro sign with
+	// ASCII 'u'.
+	if strings.Contains(normalized, "usv") {
+		return value, true
+	}
+
+	// Safecast sometimes provides micro roentgen-per-hour values labelled
+	// with a trailing "u".  Those numbers are scaled by 100, so 53 means
+	// 0.53 µSv/h.  Keeping the handling here fixes legacy rows that were
+	// stored before realtime parsing normalised the unit name.
+	if strings.HasSuffix(normalized, "u") && strings.Contains(normalized, "lnd") {
+		return value / 100.0, true
+	}
+
+	// Counts-per-minute fields require detector specific calibration.  We
+	// normalise the string further by keeping only letters and digits so we
+	// can match both "lnd_7317" and "lnd-7317-cpm" without another lookup
+	// table.
+	clean := keepAlphaNumeric(normalized)
+	if clean == "" {
+		return 0, false
+	}
+
+	if containsAny(clean, []string{"lnd7317", "lnd7318"}) {
+		return value / factorLND7317, true
+	}
+	if containsAny(clean, []string{"lnd7128", "lnd712"}) {
+		return value / factorLND712, true
+	}
+
+	// Unknown detectors remain unconverted so the caller can decide whether
+	// to display raw CPM or hide the value.  LND 78017 falls into this
+	// branch until we receive an official calibration factor.
+	return 0, false
+}
+
+// ─── Internal helpers ───────────────────────────────────────────────────────
+
+// normalizeUnit prepares a string for downstream checks by trimming spaces,
+// lowercasing, and replacing different micro symbols with ASCII 'u'.  Keeping
+// the replacement table small ensures the function stays easy to audit.
+func normalizeUnit(unit string) string {
+	trimmed := strings.TrimSpace(unit)
+	if trimmed == "" {
+		return ""
+	}
+	lowered := strings.ToLower(muReplacer.Replace(trimmed))
+	return lowered
+}
+
+// keepAlphaNumeric removes every rune that is not a letter or digit.  This
+// makes substring checks robust to underscores, dashes, and other separators
+// in upstream unit names.  The helper keeps the code explicit and close to the
+// data we consume, embracing "A little copying is better than a little
+// dependency".
+func keepAlphaNumeric(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// containsAny reports whether the haystack contains one of the provided
+// needles.  We keep this helper private because callers should rely on
+// FromRealtime's semantics instead of performing their own matches.
+func containsAny(haystack string, needles []string) bool {
+	for _, n := range needles {
+		if strings.Contains(haystack, n) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/safecast-realtime/conversion_test.go
+++ b/pkg/safecast-realtime/conversion_test.go
@@ -1,0 +1,47 @@
+package safecastrealtime
+
+import (
+	"math"
+	"testing"
+)
+
+// TestFromRealtime exercises the supported realtime conversions so a future
+// refactor will not accidentally remove detector specific calibration factors.
+func TestFromRealtime(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value float64
+		unit  string
+		want  float64
+		ok    bool
+	}{
+		{name: "already microsievert", value: 0.42, unit: "µSv/h", want: 0.42, ok: true},
+		{name: "ascii microsievert", value: 1.5, unit: "uSv/h", want: 1.5, ok: true},
+		{name: "lnd 7317 cpm", value: 668, unit: "lnd_7317", want: 668 / 334.0, ok: true},
+		{name: "lnd 7318 cpm with suffix", value: 3340, unit: "lnd-7318-cpm", want: 3340 / 334.0, ok: true},
+		{name: "lnd 712 cpm", value: 216, unit: "lnd_712", want: 216 / 108.0, ok: true},
+		{name: "lnd 7128 ec", value: 216, unit: "lnd_7128_ec", want: 216 / 108.0, ok: true},
+		{name: "legacy micro roentgen", value: 53, unit: "lnd_7318u", want: 0.53, ok: true},
+		{name: "unknown detector", value: 123, unit: "lnd_78017", want: 0, ok: false},
+		{name: "non positive", value: 0, unit: "lnd_7317", want: 0, ok: false},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := FromRealtime(tc.value, tc.unit)
+			if ok != tc.ok {
+				t.Fatalf("FromRealtime(%f,%q) ok=%t want %t", tc.value, tc.unit, ok, tc.ok)
+			}
+			if !ok {
+				return
+			}
+			if math.Abs(got-tc.want) > 1e-9 {
+				t.Fatalf("FromRealtime(%f,%q)=%f want %f", tc.value, tc.unit, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- rename the realtime helpers into the new pkg/safecast-realtime package so conversion and polling live together
- add the opt-in --safecast-realtime flag that injects the converter, fetches markers conditionally, and starts the poller
- teach the database layer to accept an injected realtime converter so µSv/h values remain calibrated without import cycles

## Testing
- go test ./pkg/...


------
https://chatgpt.com/codex/tasks/task_e_68c868914d208332b63c78d018d19f9d