### PR TITLE
Filter Safecast realtime devices to supported tubes

### DIFF
--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -682,6 +682,9 @@ ORDER BY device_id,fetched_at DESC;`
 	}
 	defer rows.Close()
 
+	now := time.Now().Unix()
+	const daySeconds = int64((24 * time.Hour) / time.Second)
+
 	seen := make(map[string]bool)
 	var out []Marker
 	for rows.Next() {
@@ -700,6 +703,9 @@ ORDER BY device_id,fetched_at DESC;`
 		}
 		if val <= 0 {
 			continue // ignore non-positive readings
+		}
+		if now-measured > daySeconds {
+			continue // drop devices that have been silent for more than a day
 		}
 		if seen[id] {
 			continue // keep the newest reading only once per device

--- a/pkg/safecast-realtime/fetcher_test.go
+++ b/pkg/safecast-realtime/fetcher_test.go
@@ -1,0 +1,99 @@
+package safecastrealtime
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestIsRadiationReading exercises the filtering logic so realtime fetches keep
+// only detectors we understand.  This guards the pipeline against Safecast Air
+// payloads and unsupported tubes that otherwise pollute the map with zeros.
+func TestIsRadiationReading(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		d    devicePayload
+		want bool
+	}{
+		{
+			name: "car 7318 cpm",
+			d:    devicePayload{Type: "car", Tube: "lnd-7318c", Unit: "lnd_7318c_cpm"},
+			want: true,
+		},
+		{
+			name: "air sensor type",
+			d:    devicePayload{Type: "AirSensor", Tube: "", Unit: "µSv/h"},
+			want: false,
+		},
+		{
+			name: "air descriptor in tube",
+			d:    devicePayload{Type: "walk", Tube: "Safecast Air", Unit: "µSv/h"},
+			want: false,
+		},
+		{
+			name: "unknown tube",
+			d:    devicePayload{Type: "car", Tube: "lnd-78017", Unit: "lnd_78017_cpm"},
+			want: false,
+		},
+		{
+			name: "direct microsievert",
+			d:    devicePayload{Type: "walk", Tube: "", Unit: "µSv/h"},
+			want: true,
+		},
+		{
+			name: "allowed tube via unit",
+			d:    devicePayload{Type: "bike", Tube: "", Unit: "lnd_7128_ec"},
+			want: true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isRadiationReading(tc.d); got != tc.want {
+				t.Fatalf("isRadiationReading(%+v)=%v want %v", tc.d, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDevicePayloadUnmarshalTube confirms we extract both the transport and
+// tube hints from the flexible JSON feed.  Keeping the parsing logic stable
+// prevents regressions when the service advertises multiple metadata forms.
+func TestDevicePayloadUnmarshalTube(t *testing.T) {
+	t.Parallel()
+
+	js := `{
+                "device_urn": "device:123",
+                "service_transport": "walk:lnd-7318c:open",
+                "loc_lat": 35.0,
+                "loc_lon": 139.0,
+                "lnd_7318c_cpm": 42,
+                "when_captured": "2024-05-01T12:34:56Z"
+        }`
+
+	var d devicePayload
+	if err := json.Unmarshal([]byte(js), &d); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if d.Type != "walk" {
+		t.Fatalf("Type=%q want walk", d.Type)
+	}
+	if d.Tube != "lnd-7318c" {
+		t.Fatalf("Tube=%q want lnd-7318c", d.Tube)
+	}
+
+	jsAlt := `{"service_transport":"car","tube_type":"LND 712","lnd_712_cpm":216}`
+	var dAlt devicePayload
+	if err := json.Unmarshal([]byte(jsAlt), &dAlt); err != nil {
+		t.Fatalf("unmarshal alt: %v", err)
+	}
+	if dAlt.Type != "car" {
+		t.Fatalf("Type=%q want car", dAlt.Type)
+	}
+	if dAlt.Tube != "LND 712" {
+		t.Fatalf("Tube=%q want LND 712", dAlt.Tube)
+	}
+}

--- a/pkg/safecast-realtime/fetcher_test.go
+++ b/pkg/safecast-realtime/fetcher_test.go
@@ -3,48 +3,50 @@ package safecastrealtime
 import (
 	"encoding/json"
 	"testing"
+	"time"
 )
 
-// TestIsRadiationReading exercises the filtering logic so realtime fetches keep
-// only detectors we understand.  This guards the pipeline against Safecast Air
-// payloads and unsupported tubes that otherwise pollute the map with zeros.
-func TestIsRadiationReading(t *testing.T) {
+// TestConvertIfRadiation exercises the filtering logic so realtime fetches keep
+// only detectors that emit radiation readings.  This guards the pipeline
+// against Safecast Air payloads that otherwise pollute the map with zeros.
+func TestConvertIfRadiation(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
 		name string
 		d    devicePayload
-		want bool
+		want float64
+		ok   bool
 	}{
 		{
 			name: "car 7318 cpm",
-			d:    devicePayload{Type: "car", Tube: "lnd-7318c", Unit: "lnd_7318c_cpm"},
-			want: true,
+			d:    devicePayload{ID: "geigiecast:1", Type: "car", Tube: "lnd-7318c", Unit: "lnd_7318c_cpm", Value: 334},
+			want: 1,
+			ok:   true,
 		},
 		{
 			name: "air sensor type",
-			d:    devicePayload{Type: "AirSensor", Tube: "", Unit: "µSv/h"},
-			want: false,
+			d:    devicePayload{ID: "airsensor:2", Type: "AirSensor", Unit: "µSv/h", Value: 0.5},
+			want: 0,
+			ok:   false,
 		},
 		{
-			name: "air descriptor in tube",
-			d:    devicePayload{Type: "walk", Tube: "Safecast Air", Unit: "µSv/h"},
-			want: false,
-		},
-		{
-			name: "unknown tube",
-			d:    devicePayload{Type: "car", Tube: "lnd-78017", Unit: "lnd_78017_cpm"},
-			want: false,
+			name: "air descriptor in name",
+			d:    devicePayload{ID: "geigiecast:3", Type: "walk", Name: "Safecast Air Monitor", Unit: "µSv/h", Value: 0.5},
+			want: 0,
+			ok:   false,
 		},
 		{
 			name: "direct microsievert",
-			d:    devicePayload{Type: "walk", Tube: "", Unit: "µSv/h"},
-			want: true,
+			d:    devicePayload{ID: "geigiecast:4", Type: "walk", Unit: "µSv/h", Value: 0.42},
+			want: 0.42,
+			ok:   true,
 		},
 		{
-			name: "allowed tube via unit",
-			d:    devicePayload{Type: "bike", Tube: "", Unit: "lnd_7128_ec"},
-			want: true,
+			name: "unsupported tube",
+			d:    devicePayload{ID: "geigiecast:5", Type: "car", Tube: "lnd-78017", Unit: "lnd_78017_cpm", Value: 10},
+			want: 0,
+			ok:   false,
 		},
 	}
 
@@ -52,8 +54,12 @@ func TestIsRadiationReading(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			if got := isRadiationReading(tc.d); got != tc.want {
-				t.Fatalf("isRadiationReading(%+v)=%v want %v", tc.d, got, tc.want)
+			got, ok := convertIfRadiation(tc.d)
+			if ok != tc.ok {
+				t.Fatalf("convertIfRadiation(%+v) ok=%v want %v", tc.d, ok, tc.ok)
+			}
+			if ok && (got < tc.want-0.0001 || got > tc.want+0.0001) {
+				t.Fatalf("convertIfRadiation(%+v)=%v want %v", tc.d, got, tc.want)
 			}
 		})
 	}
@@ -67,6 +73,7 @@ func TestDevicePayloadUnmarshalTube(t *testing.T) {
 
 	js := `{
                 "device_urn": "device:123",
+                "device_title": "bGeigie #123",
                 "service_transport": "walk:lnd-7318c:open",
                 "loc_lat": 35.0,
                 "loc_lon": 139.0,
@@ -84,8 +91,11 @@ func TestDevicePayloadUnmarshalTube(t *testing.T) {
 	if d.Tube != "lnd-7318c" {
 		t.Fatalf("Tube=%q want lnd-7318c", d.Tube)
 	}
+	if d.Name != "bGeigie #123" {
+		t.Fatalf("Name=%q want bGeigie #123", d.Name)
+	}
 
-	jsAlt := `{"service_transport":"car","tube_type":"LND 712","lnd_712_cpm":216}`
+	jsAlt := `{"service_transport":"car","device_name":"bGeigie","value_time":"2024-06-01T00:01:02Z","lnd_712_cpm":216}`
 	var dAlt devicePayload
 	if err := json.Unmarshal([]byte(jsAlt), &dAlt); err != nil {
 		t.Fatalf("unmarshal alt: %v", err)
@@ -93,7 +103,11 @@ func TestDevicePayloadUnmarshalTube(t *testing.T) {
 	if dAlt.Type != "car" {
 		t.Fatalf("Type=%q want car", dAlt.Type)
 	}
-	if dAlt.Tube != "LND 712" {
-		t.Fatalf("Tube=%q want LND 712", dAlt.Tube)
+	if dAlt.Name != "bGeigie" {
+		t.Fatalf("Name=%q want bGeigie", dAlt.Name)
+	}
+	wantTime, _ := time.Parse(time.RFC3339, "2024-06-01T00:01:02Z")
+	if dAlt.Time != wantTime.Unix() {
+		t.Fatalf("Time=%d want %d", dAlt.Time, wantTime.Unix())
 	}
 }

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -826,6 +826,103 @@ function getRadius(doseRate, zoomLevel) {
   return Math.max(r, 2);                       // prevent tiny circles
 }
 
+// Thresholds for realtime freshness expressed in seconds so both the
+// rendering loop and periodic refresh share the same rules.
+const LIVE_ACTIVE_WINDOW = 5 * 60;         // 5 minutes keeps "working" sensors bright
+const LIVE_RECENT_WINDOW = 24 * 60 * 60;   // 24 hours before removal
+
+// parseColor extracts RGB components from either hex (#rrggbb) or rgb(r,g,b)
+// strings.  Keeping this helper local avoids pulling external libraries while
+// letting us reuse the logic for alpha blending and contrast checks.
+function parseColor(color) {
+  if (!color) return null;
+  if (color.startsWith('#')) {
+    const hex = color.slice(1);
+    if (hex.length === 6) {
+      return {
+        r: parseInt(hex.slice(0, 2), 16),
+        g: parseInt(hex.slice(2, 4), 16),
+        b: parseInt(hex.slice(4, 6), 16),
+      };
+    }
+    if (hex.length === 3) {
+      return {
+        r: parseInt(hex[0] + hex[0], 16),
+        g: parseInt(hex[1] + hex[1], 16),
+        b: parseInt(hex[2] + hex[2], 16),
+      };
+    }
+  }
+  if (color.startsWith('rgb')) {
+    const parts = color.match(/\d+/g);
+    if (parts && parts.length >= 3) {
+      return {
+        r: parseInt(parts[0], 10),
+        g: parseInt(parts[1], 10),
+        b: parseInt(parts[2], 10),
+      };
+    }
+  }
+  return null;
+}
+
+// colorWithAlpha returns an rgba() string using the provided alpha.  We reuse
+// parseColor so realtime markers can reuse the same gradient palette while
+// dimming stale sensors without affecting the text opacity.
+function colorWithAlpha(color, alpha) {
+  const rgb = parseColor(color);
+  if (!rgb) return color;
+  const a = Math.min(Math.max(alpha, 0), 1);
+  return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${a})`;
+}
+
+// isDarkColor estimates perceived brightness to choose a contrasting text
+// color.  A simple luminance formula keeps the implementation lightweight.
+function isDarkColor(color) {
+  const rgb = parseColor(color);
+  if (!rgb) return false;
+  const luminance = 0.299 * rgb.r + 0.587 * rgb.g + 0.114 * rgb.b;
+  return luminance < 140;
+}
+
+// formatMicroRoentgen converts µSv/h into µR/h text while avoiding excessive
+// decimals.  Smaller values keep two decimals; larger ones are rounded to the
+// nearest whole number for quick scanning on the map.
+function formatMicroRoentgen(doseRate) {
+  const micro = doseRate * 100;
+  if (micro >= 100) return micro.toFixed(0);
+  if (micro >= 10) return micro.toFixed(1);
+  if (micro >= 1) return micro.toFixed(2);
+  return micro.toFixed(3);
+}
+
+// buildRealtimeIcon returns the HTML markup and sizing data for a realtime
+// marker.  It handles the three freshness buckets: active (white ring, opaque),
+// recent (grey ring, half opacity), and stale (>24h, hidden).
+function buildRealtimeIcon(marker, zoomLevel, nowSec) {
+  const lastSeen = marker.date || 0;
+  if (!lastSeen) return null;
+
+  const ageSec = nowSec - lastSeen;
+  if (ageSec > LIVE_RECENT_WINDOW) {
+    return null; // drop sensors that have been silent longer than a day
+  }
+
+  const active = ageSec <= LIVE_ACTIVE_WINDOW;
+  const baseColor = getGradientColor(marker.doseRate);
+  const fill = active ? baseColor : colorWithAlpha(baseColor, 0.5);
+  const border = active ? '#ffffff' : '#888888';
+  const textColor = isDarkColor(active ? baseColor : fill) ? '#ffffff' : '#000000';
+
+  const radius = getRadius(marker.doseRate, zoomLevel) * 3;
+  const size = radius * 2;
+  const value = formatMicroRoentgen(marker.doseRate);
+
+  const html = `<div class="live-marker" style="background:${fill};border:2px solid ${border};color:${textColor};width:${size}px;height:${size}px;line-height:${size}px;">${value}</div>`;
+
+  return { html, size, radius };
+}
+
 
 /**
  * Decide whether the marker with given speed (m/s)
@@ -1068,6 +1165,9 @@ document.addEventListener('DOMContentLoaded', function () {
 
   // Initialize UI elements
   initializeUIElements();
+
+  // Periodically refresh realtime styling so markers fade without map motion.
+  setInterval(adjustMarkerRadius, 60 * 1000);
 
   /**
    * Build a Leaflet control with three check-boxes that filter markers
@@ -1480,16 +1580,11 @@ function updateMarkers(){
 
     let marker;
     if (isLive) { // realtime marker with value inside the circle
-      const ageSec = Date.now()/1000 - m.date;
-      const fresh = ageSec < 20*60; // stale after 20 minutes
-      const baseColor = getGradientColor(m.doseRate);
-      const border = fresh ? '#fff' : '#888';
-      const opacity = fresh ? 1 : 0.3;
-      const r = getRadius(m.doseRate, zoom) * 3; // larger circle for realtime visibility
-      const size = r * 2;
-      const html = `<div class="live-marker" style="background:${baseColor};border:1px solid ${border};opacity:${opacity};width:${size}px;height:${size}px;line-height:${size}px;">${m.doseRate.toFixed(2)}</div>`;
+      const nowSec = Date.now() / 1000;
+      const icon = buildRealtimeIcon(m, zoom, nowSec);
+      if (!icon) return; // device is older than 24 hours
       marker = L.marker([m.lat, m.lon], {
-        icon: L.divIcon({className:'', html: html, iconSize:[size, size], iconAnchor:[r, r]})
+        icon: L.divIcon({className:'', html: icon.html, iconSize:[icon.size, icon.size], iconAnchor:[icon.radius, icon.radius]})
       })
       .addTo(map)
       .bindTooltip(getTooltipContent(m), { direction:'top', className:'custom-tooltip', offset:[0,-8], interactive:true })
@@ -1551,19 +1646,18 @@ function debounceUpdateMarkers() {
 
 function adjustMarkerRadius() {
   var zoomLevel = map.getZoom();
+  const nowSec = Date.now() / 1000;
   for (let key in circleMarkers) {
     let marker = circleMarkers[key];
     if (marker.isRealtime) {
-      // Rebuild div icon to scale realtime markers with zoom
-      const r = getRadius(marker.doseRate, zoomLevel) * 1.5;
-      const size = r * 2;
-      const ageSec = Date.now()/1000 - marker.date;
-      const fresh = ageSec < 20*60; // 20 minutes freshness window
-      const baseColor = getGradientColor(marker.doseRate);
-      const border = fresh ? '#fff' : '#888';
-      const opacity = fresh ? 1 : 0.3;
-      const html = `<div class="live-marker" style="background:${baseColor};border:1px solid ${border};opacity:${opacity};width:${size}px;height:${size}px;line-height:${size}px;">${marker.doseRate.toFixed(2)}</div>`;
-      marker.setIcon(L.divIcon({className:'', html: html, iconSize:[size, size], iconAnchor:[r, r]}));
+      // Recompute icon style so stale sensors fade without user interaction.
+      const icon = buildRealtimeIcon(marker, zoomLevel, nowSec);
+      if (!icon) {
+        map.removeLayer(marker);
+        delete circleMarkers[key];
+        continue;
+      }
+      marker.setIcon(L.divIcon({className:'', html: icon.html, iconSize:[icon.size, icon.size], iconAnchor:[icon.radius, icon.radius]}));
     } else if (typeof marker.setRadius === 'function') {
       // Circle markers scale by adjusting radius directly
       let newRadius = getRadius(marker.doseRate, zoomLevel);


### PR DESCRIPTION
## Summary
- capture Safecast service_transport tube hints so the realtime poller knows the detector type
- filter realtime payloads to skip Safecast Air units and tubes we cannot calibrate
- reuse the converted dose rate for summaries and add tests that lock the new filtering rules and JSON parsing in place

## Testing
- go test ./pkg/safecast-realtime (fails: requires external module downloads in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68c936b5e3448332ae5cb18f7171b0e5