### PR TITLE
Replace live icon with Safecast heart

### DIFF
--- a/public_html/map.html
+++ b/public_html/map.html
@@ -544,6 +544,25 @@ body, html {
           color: #000;
         }
 
+        /* Keep the icons in the speed filter aligned regardless of emoji vs. SVG source. */
+        .speed-filter-icon {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          width: 1.5em;
+          height: 1.5em;
+          margin-left: 6px;
+          font-size: 1.2em;
+          line-height: 1;
+        }
+
+        /* Ensure the SVG heart scales with the surrounding emoji-based icons. */
+        .speed-filter-icon img {
+          display: block;
+          width: 100%;
+          height: 100%;
+        }
+
     </style>
 
     <!-- Translation script -->
@@ -934,7 +953,7 @@ function shouldDisplayBySpeed(speed) {
   if (isTrackView) return true;        // filter disabled in track view
 
   const st = loadSpeedFilterState();   // global mode
-  if (speed < 0) {                     // 📡 realtime markers use negative speed
+  if (speed < 0) {                     // Safecast heart markers use negative speed to signal realtime data
     if (!window.safecastRealtimeEnabled) {
       // Safety net: when realtime is disabled we never show synthetic negative speeds.
       return false;
@@ -1006,8 +1025,8 @@ var markerStreamSource = null;
 /**
  * Load previously saved speed-filter state from sessionStorage.
  * If nothing is stored yet, return defaults that reflect backend capabilities.
- *   Realtime on:  📡 on, ✈️ off, 🚗 on, 🚶 on  (as requested).
- *   Realtime off: ✈️ off, 🚗 on, 🚶 on  (📡 absent).
+ *   Realtime on:  Safecast heart on, ✈️ off, 🚗 on, 🚶 on  (as requested).
+ *   Realtime off: ✈️ off, 🚗 on, 🚶 on  (heart absent).
  */
 function loadSpeedFilterState() {
   // We derive defaults from the realtime flag so the UI matches backend capabilities.
@@ -1172,7 +1191,7 @@ document.addEventListener('DOMContentLoaded', function () {
   /**
    * Build a Leaflet control with three check-boxes that filter markers
    * by recorded speed. Labels now show speed in km/h instead of m/s.
-   * Default state (when realtime exists): 📡 on, ✈️ off, 🚗 on, 🚶 on.
+   * Default state (when realtime exists): Safecast heart on, ✈️ off, 🚗 on, 🚶 on.
    */
   function createSpeedFilterControls() {
 
@@ -1188,16 +1207,18 @@ document.addEventListener('DOMContentLoaded', function () {
         div.style.padding = '6px 10px';
 
         // helper that returns one <label> line
-        const row = (id, emoji, checked) => `
+        const row = (id, iconMarkup, checked) => `
             <label style="white-space:nowrap;display:block;cursor:pointer;">
             <input id="${id}" type="checkbox" ${checked ? 'checked' : ''}/>
-          ${emoji}
+            <span class="speed-filter-icon">${iconMarkup}</span>
             </label>`;
 
         // Build rows dynamically so the realtime checkbox only appears when supported server-side.
         const pieces = [];
         if (window.safecastRealtimeEnabled) {
-          pieces.push(row('sfLive', '📡', state.live));
+          // Use the Safecast heart artwork so the live toggle reflects the new branding.
+          const liveIconMarkup = '<img src="safecast-heart.svg" alt="Realtime measurements"/>';
+          pieces.push(row('sfLive', liveIconMarkup, state.live));
           pieces.push('<div class="leaflet-control-layers-separator"></div>');
         }
         pieces.push(

--- a/public_html/safecast-heart.svg
+++ b/public_html/safecast-heart.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="120" height="110" viewBox="0 0 120 110" xmlns="http://www.w3.org/2000/svg">
+  <!-- We store the icon as vector graphics so it scales crisply on high-DPI displays. -->
+  <path d="M60 106L15 61C4 50 0 34 11 22C22 11 40 11 51 22L60 31L69 22C80 11 98 11 109 22C120 34 116 50 105 61Z" fill="#000000"/>
+  <!-- The white path approximates the Safecast glyph to keep brand recognition inside the heart. -->
+  <path d="M78 27C69 20 56 20 47 26L43 29H61C70 29 77 32 83 37L86 40L55 48C44 51 37 58 33 66L32 69L50 63C59 60 66 63 73 68L78 72L52 80C43 82 36 87 32 94L31 96L37 95C50 93 62 87 71 78L89 61L72 50L89 39Z" fill="#FFFFFF"/>
+  <!-- The blue circle mirrors the accent dot from the provided logo. -->
+  <circle cx="44" cy="84" r="7" fill="#4FA3C8"/>
+</svg>


### PR DESCRIPTION
## Summary
- add the Safecast heart SVG asset to public_html so the realtime icon is available offline
- swap the live control to use the heart artwork and align the speed filter icon styling
- refresh inline comments to reference the new branding for realtime markers

## Testing
- go test ./... *(fails: command timed out and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68c950c796dc833294391df367c091c0