### PR TITLE
Fix Safecast realtime calibration for LND tubes

### DIFF
--- a/pkg/safecast-realtime/conversion_test.go
+++ b/pkg/safecast-realtime/conversion_test.go
@@ -21,6 +21,7 @@ func TestFromRealtime(t *testing.T) {
 		{name: "ascii microsievert", value: 1.5, unit: "uSv/h", want: 1.5, ok: true},
 		{name: "lnd 7317 cpm", value: 668, unit: "lnd_7317", want: 668 / 334.0, ok: true},
 		{name: "lnd 7318 cps", value: 334.0 / 60.0, unit: "lnd-7318-cps", want: 1, ok: true},
+		{name: "lnd 7318 cps underscore", value: 334.0 / 60.0, unit: "lnd_7318c_cps", want: 1, ok: true},
 		{name: "lnd 7318 cpm with suffix", value: 3340, unit: "lnd-7318-cpm", want: 3340 / 334.0, ok: true},
 		{name: "lnd 712 cpm", value: 216, unit: "lnd_712", want: 216 / 108.0, ok: true},
 		{name: "lnd 7128 ec", value: 216, unit: "lnd_7128_ec", want: 216 / 108.0, ok: true},

--- a/pkg/safecast-realtime/conversion_test.go
+++ b/pkg/safecast-realtime/conversion_test.go
@@ -20,10 +20,11 @@ func TestFromRealtime(t *testing.T) {
 		{name: "already microsievert", value: 0.42, unit: "µSv/h", want: 0.42, ok: true},
 		{name: "ascii microsievert", value: 1.5, unit: "uSv/h", want: 1.5, ok: true},
 		{name: "lnd 7317 cpm", value: 668, unit: "lnd_7317", want: 668 / 334.0, ok: true},
+		{name: "lnd 7318 cps", value: 334.0 / 60.0, unit: "lnd-7318-cps", want: 1, ok: true},
 		{name: "lnd 7318 cpm with suffix", value: 3340, unit: "lnd-7318-cpm", want: 3340 / 334.0, ok: true},
 		{name: "lnd 712 cpm", value: 216, unit: "lnd_712", want: 216 / 108.0, ok: true},
 		{name: "lnd 7128 ec", value: 216, unit: "lnd_7128_ec", want: 216 / 108.0, ok: true},
-		{name: "legacy micro roentgen", value: 53, unit: "lnd_7318u", want: 0.53, ok: true},
+		{name: "lnd 7318 fallback", value: 53, unit: "lnd_7318u", want: 53 / 334.0, ok: true},
 		{name: "unknown detector", value: 123, unit: "lnd_78017", want: 0, ok: false},
 		{name: "non positive", value: 0, unit: "lnd_7317", want: 0, ok: false},
 	}

--- a/pkg/safecast-realtime/fetcher_test.go
+++ b/pkg/safecast-realtime/fetcher_test.go
@@ -73,6 +73,7 @@ func TestDevicePayloadUnmarshalTube(t *testing.T) {
 
 	js := `{
                 "device_urn": "device:123",
+                "device_class": "product:com.blues.radnote",
                 "device_title": "bGeigie #123",
                 "service_transport": "walk:lnd-7318c:open",
                 "loc_lat": 35.0,
@@ -93,6 +94,9 @@ func TestDevicePayloadUnmarshalTube(t *testing.T) {
 	}
 	if d.Name != "bGeigie #123" {
 		t.Fatalf("Name=%q want bGeigie #123", d.Name)
+	}
+	if d.Class != "product:com.blues.radnote" {
+		t.Fatalf("Class=%q want product:com.blues.radnote", d.Class)
 	}
 
 	jsAlt := `{"service_transport":"car","device_name":"bGeigie","value_time":"2024-06-01T00:01:02Z","lnd_712_cpm":216}`
@@ -136,6 +140,12 @@ func TestDevicePayloadMeasurementSelection(t *testing.T) {
 			wantValue: 73,
 			wantUnit:  "lnd_7318u",
 		},
+		{
+			name:      "radnote cps reinterpretation",
+			json:      `{"device_urn":"device:3","device_class":"product:com.blues.radnote","lnd_7318c":1077}`,
+			wantValue: 1077,
+			wantUnit:  "lnd_7318c_cps",
+		},
 	}
 
 	for _, tc := range cases {
@@ -166,6 +176,7 @@ func TestDevicePayloadMetrics(t *testing.T) {
                 "loc_lon": 139.0,
                 "temperature_c": 21.5,
                 "humidity": "48",
+                "env_press": 1015.5,
                 "when_captured": "2024-05-01T12:00:00Z"
         }`
 
@@ -181,5 +192,8 @@ func TestDevicePayloadMetrics(t *testing.T) {
 	}
 	if v, ok := d.Metrics["humidity_percent"]; !ok || v != 48 {
 		t.Fatalf("humidity_percent=%v ok=%v", v, ok)
+	}
+	if v, ok := d.Metrics["pressure_hpa"]; !ok || v != 1015.5 {
+		t.Fatalf("pressure_hpa=%v ok=%v", v, ok)
 	}
 }


### PR DESCRIPTION
## Summary
- normalise realtime payload parsing so CPS readings win over CPM and raw detector fields remain usable
- update detector conversions to handle both CPS and CPM inputs for LND 7318/712 tubes and cover them with tests
- extend realtime fetcher tests to lock in the new measurement selection priorities

## Testing
- Unable to run `go test ./...` because the command requires downloading external modules and hangs without network access.


------
https://chatgpt.com/codex/tasks/task_e_68ca6effd65c8332b8f451b4ed09ba9a