### PR TITLE
Refactor dataset loading and isolate database drivers

### DIFF
--- a/database_drivers.go
+++ b/database_drivers.go
@@ -1,0 +1,14 @@
+//go:build !test
+
+// This file wires in heavyweight SQL drivers only for production builds.
+// go test/go vet exclude it via the build tag so command-line tooling stays
+// responsive while keeping runtime behaviour unchanged for binaries.
+package main
+
+import "chicha-isotope-map/pkg/database/drivers"
+
+func init() {
+	// Touch the drivers package so its init functions register SQL
+	// backends before the application opens database connections.
+	drivers.Ready()
+}

--- a/pkg/database/drivers/drivers.go
+++ b/pkg/database/drivers/drivers.go
@@ -1,0 +1,9 @@
+// Package drivers groups database/sql driver registrations so heavy
+// dependencies stay out of lightweight go test/go vet runs unless a
+// binary explicitly imports this package.
+package drivers
+
+// Ready is a no-op helper used by main packages to make the import
+// explicit.  Calling Ready from init maintains clarity about why the
+// package is pulled in while still avoiding mutexes or other side effects.
+func Ready() {}

--- a/pkg/database/drivers/duckdb.go
+++ b/pkg/database/drivers/duckdb.go
@@ -12,8 +12,10 @@
 //   # Windows (PowerShell)
 //   $env:CGO_ENABLED="1"; go build -tags duckdb -o chicha-isotope-map.exe
 
-package database
+package drivers
 
 import (
+	// DuckDB stays behind an explicit build tag because it requires CGO.
+	// Binaries that need DuckDB can import this package with the duckdb tag.
 	_ "github.com/marcboeker/go-duckdb"
 )

--- a/pkg/database/drivers/genji.go
+++ b/pkg/database/drivers/genji.go
@@ -1,7 +1,9 @@
 //go:build dragonfly || ios || freebsd || darwin || (linux && ppc64) || (linux && ppc64le) || (linux && s390x) || (linux && amd64) || (linux && mips64) || (linux && mips64le) || (linux && arm64) || android || (windows && amd64) || (windows && arm64)
 
-package database
+package drivers
 
 import (
+	// Register the Genji driver when a binary explicitly opts into the
+	// drivers package.  Tests can skip importing this package to stay fast.
 	_ "github.com/genjidb/genji/driver"
 )

--- a/pkg/database/drivers/postgresql_pgx.go
+++ b/pkg/database/drivers/postgresql_pgx.go
@@ -1,7 +1,9 @@
 //go:build (dragonfly && amd64) || (openbsd && amd64) || (openbsd && arm64) || (openbsd && mips64) || (netbsd && amd64) || (netbsd && arm64) || freebsd || darwin || (linux && ppc64) || (linux && ppc64le) || (linux && s390x) || (linux && amd64) || (linux && mips64) || (linux && mips64le) || (linux && arm64) || (linux && 386) || (linux && riscv64) || android || (aix && ppc64) || (illumos && amd64) || (solaris && amd64) || (plan9 && amd64)
 
-package database
+package drivers
 
 import (
+	// Register PostgreSQL via pgx when binaries import this package.
+	// Tests can exclude it by skipping the drivers package entirely.
 	_ "github.com/jackc/pgx/v5/stdlib"
 )

--- a/pkg/database/drivers/sqlite.go
+++ b/pkg/database/drivers/sqlite.go
@@ -1,7 +1,10 @@
 //go:build (netbsd && amd64) || ios || freebsd || darwin || (linux && riscv64) || (linux && ppc64le) || (linux && s390x) || (linux && amd64) || (linux && arm64) || (linux && 386) || android || (openbsd && amd64) || (openbsd && arm64)
 
-package database
+package drivers
 
 import (
+	// Export the modernc SQLite driver so production binaries can opt in by
+	// importing this lightweight package instead of pulling the dependency
+	// into every test build.
 	_ "modernc.org/sqlite"
 )

--- a/pkg/safecast-realtime/conversion.go
+++ b/pkg/safecast-realtime/conversion.go
@@ -17,17 +17,17 @@ const (
 	// Safecast labels these fields as "lnd_7317" even though the hardware
 	// variants are 7318U and 7318C.  Field manuals quote 334 CPM per µSv/h.
 	factorLND7317 = 334.0
-        // factorLND7317CPS converts counts per second into µSv/h for 7318 tubes.
-        // Dividing the CPM factor by 60 honours the same calibration while
-        // accepting realtime CPS feeds without duplicating constants elsewhere.
-        factorLND7317CPS = factorLND7317
+	// factorLND7317CPS converts counts per second into µSv/h for 7318 tubes.
+	// Dividing the CPM factor by 60 honours the same calibration while
+	// accepting realtime CPS feeds without duplicating constants elsewhere.
+	factorLND7317CPS = factorLND7317 / 60.0
 	// factorLND712 covers the classic LND 712 and the shielded 7128 EC.
 	// Both share the same 108 CPM per µSv/h calibration in Safecast docs.
 	factorLND712 = 108.0
-        // factorLND712CPS mirrors the CPM constant for CPS payloads on LND 712.
-        // Safecast documents 108 CPM per µSv/h; for per-second counts we divide
-        // by 60 so both units share the same physical calibration.
-        factorLND712CPS = factorLND712
+	// factorLND712CPS mirrors the CPM constant for CPS payloads on LND 712.
+	// Safecast documents 108 CPM per µSv/h; for per-second counts we divide
+	// by 60 so both units share the same physical calibration.
+	factorLND712CPS = factorLND712 / 60.0
 )
 
 // ─── Public conversion helpers ──────────────────────────────────────────────
@@ -63,7 +63,6 @@ func FromRealtime(value float64, unit string) (float64, bool) {
 	if clean == "" {
 		return 0, false
 	}
-
 
 	if containsAny(clean, []string{"lnd7317", "lnd7318"}) {
 		if strings.Contains(clean, "cps") {

--- a/scripts/bGeigeieZen-upload-diag/database_drivers.go
+++ b/scripts/bGeigeieZen-upload-diag/database_drivers.go
@@ -1,0 +1,13 @@
+//go:build !test
+
+// Wiring SQL drivers via a dedicated file keeps go test/go vet nimble while
+// command binaries still register the backends they rely on.
+package main
+
+import "chicha-isotope-map/pkg/database/drivers"
+
+func init() {
+	// Ensure driver registrations run before the diagnostics tool touches
+	// database/sql.  Using a function call keeps the import intentional.
+	drivers.Ready()
+}


### PR DESCRIPTION
## Summary
- load the country resolver dataset lazily via a channel-backed coordinator to unblock tooling
- adjust realtime conversion constants and resolver accessors to use the cached dataset snapshot
- isolate heavy SQL driver registrations in pkg/database/drivers and gate them from go test builds

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68cd8899bb188332845eb4a655cc68fd