### PR TITLE
Enable optional JSON archive generation

### DIFF
--- a/pkg/jsonarchive/generator.go
+++ b/pkg/jsonarchive/generator.go
@@ -67,6 +67,9 @@ func Start(
 	// so HTTP handlers keep responding without waiting for the fresh build to
 	// finish. This keeps startup "Clear is better than clever" by serving the
 	// existing snapshot while the background worker prepares the next revision.
+	// Capture any existing archive so Fetch callers can immediately serve it
+	// while the background build runs. This keeps the system responsive even
+	// before the first refresh completes.
 	var initialResult result
 	haveInitial := false
 	if info, err := os.Stat(destPath); err == nil && info.Mode().IsRegular() {
@@ -124,9 +127,8 @@ func Start(
 		ticker := time.NewTicker(refreshInterval)
 		defer ticker.Stop()
 
-
-		current := result{}
-		haveResult := false
+		current := initialResult
+		haveResult := haveInitial
 
 		for {
 			select {


### PR DESCRIPTION
## Summary
- only start the JSON archive generator when -json-archive-path is set and log when disabled
- expose the daily tarball endpoint and documentation only when the generator is active
- reuse an existing archive snapshot immediately after startup while the background rebuild runs

## Testing
- go test ./... *(fails: command hung waiting for module download in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d08b0ae5608332bc8b2537cbddedc3