### PR TITLE
Optimize track indexing for archive builds

### DIFF
--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -654,7 +654,12 @@ func (h *Handler) finalizeSummaries(
 	var base int64
 	var err error
 
-	if trimmed := strings.TrimSpace(startAfter); trimmed != "" {
+	if summaries[0].Index > 0 {
+		// New database streaming already delivers the index, so we only need to
+		// adjust it into a zero-based base once. This keeps handlers cheap while
+		// still supporting legacy databases that lack the precomputed value.
+		base = summaries[0].Index - 1
+	} else if trimmed := strings.TrimSpace(startAfter); trimmed != "" {
 		base, err = h.DB.CountTrackIDsUpTo(ctx, trimmed, h.DBType)
 		if err != nil {
 			return 0, err

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -318,6 +318,9 @@ func desiredIndexesPortable(dbType string) []struct{ name, sql string } {
 			// 2) Selective singles
 			{"idx_markers_trackid",
 				`CREATE INDEX IF NOT EXISTS idx_markers_trackid ON markers (trackID)`},
+			// Date-first variant accelerates archive/year pagination that filters primarily by time.
+			{"idx_markers_date_trackid",
+				`CREATE INDEX IF NOT EXISTS idx_markers_date_trackid ON markers (date, trackID)`},
 			// Dedicated date helpers keep slider filtering responsive even with WAL on.
 			{"idx_markers_trackid_date",
 				`CREATE INDEX IF NOT EXISTS idx_markers_trackid_date ON markers (trackID, date)`},
@@ -350,6 +353,9 @@ func desiredIndexesPortable(dbType string) []struct{ name, sql string } {
 				`CREATE INDEX IF NOT EXISTS idx_markers_identity_probe ON markers (lat, lon, date, doseRate)`},
 			{"idx_markers_trackid",
 				`CREATE INDEX IF NOT EXISTS idx_markers_trackid ON markers (trackID)`},
+			// Date-first variant accelerates archive/year pagination that filters primarily by time.
+			{"idx_markers_date_trackid",
+				`CREATE INDEX IF NOT EXISTS idx_markers_date_trackid ON markers (date, trackID)`},
 			// Dedicated date helpers keep slider filtering responsive even with WAL on.
 			{"idx_markers_trackid_date",
 				`CREATE INDEX IF NOT EXISTS idx_markers_trackid_date ON markers (trackID, date)`},
@@ -383,6 +389,9 @@ func desiredIndexesPortable(dbType string) []struct{ name, sql string } {
 				`CREATE INDEX IF NOT EXISTS idx_markers_identity_probe ON markers (lat, lon, date, doseRate)`},
 			{"idx_markers_trackid",
 				`CREATE INDEX IF NOT EXISTS idx_markers_trackid ON markers (trackID)`},
+			// Date-first variant accelerates archive/year pagination that filters primarily by time.
+			{"idx_markers_date_trackid",
+				`CREATE INDEX IF NOT EXISTS idx_markers_date_trackid ON markers (date, trackID)`},
 			// Dedicated date helpers keep slider filtering responsive even with WAL on.
 			{"idx_markers_trackid_date",
 				`CREATE INDEX IF NOT EXISTS idx_markers_trackid_date ON markers (trackID, date)`},
@@ -416,6 +425,9 @@ func desiredIndexesPortable(dbType string) []struct{ name, sql string } {
 				`CREATE INDEX IF NOT EXISTS idx_markers_identity_probe ON markers (lat, lon, date, doseRate)`},
 			{"idx_markers_trackid",
 				`CREATE INDEX IF NOT EXISTS idx_markers_trackid ON markers (trackID)`},
+			// Date-first variant accelerates archive/year pagination that filters primarily by time.
+			{"idx_markers_date_trackid",
+				`CREATE INDEX IF NOT EXISTS idx_markers_date_trackid ON markers (date, trackID)`},
 			// Dedicated date helpers keep slider filtering responsive even with WAL on.
 			{"idx_markers_trackid_date",
 				`CREATE INDEX IF NOT EXISTS idx_markers_trackid_date ON markers (trackID, date)`},


### PR DESCRIPTION
## Summary
- add date-leading marker indexes for every supported engine so archive/time range queries hit covering btrees
- compute track indices once per page while streaming summaries to avoid per-track COUNT(DISTINCT) scans
- reuse streamed indices when building archives and API payloads to prevent redundant lookups

## Testing
- ⚠️ `go test ./...` *(hangs on this environment; interrupted after waiting to avoid blocking the run)*

------
https://chatgpt.com/codex/tasks/task_e_68d08f341b308332a3784f4b8524ffdf