### PR TITLE
Purge stale archive temp files and slow refresh cadence

### DIFF
--- a/chicha-isotope-map.go
+++ b/chicha-isotope-map.go
@@ -3314,10 +3314,10 @@ func main() {
 		safecastrealtime.Start(ctxRT, db, *dbType, log.Printf)
 	}
 
-	// Build a daily tar.gz with all known JSON .cim files only when operators
-	// explicitly opt in via -json-archive-path. This avoids surprise disk IO
-	// on deployments that do not need the bundle while keeping the design
-	// configurable through channels when enabled.
+	// Build a weekly tar.gz with all known JSON .cim files only when operators
+	// explicitly opt in via -json-archive-path. Stretching the cadence keeps
+	// IO predictable while still letting deployments opt in when they need a
+	// fresh bundle.
 	var (
 		archiveGen     *jsonarchive.Generator
 		archiveCancel  context.CancelFunc
@@ -3332,7 +3332,7 @@ func main() {
 			archivePath = abs
 		}
 		log.Printf("json archive destination resolved: %s", archivePath)
-		archiveGen = jsonarchive.Start(ctxArchive, db, *dbType, archivePath, 24*time.Hour, log.Printf)
+		archiveGen = jsonarchive.Start(ctxArchive, db, *dbType, archivePath, 7*24*time.Hour, log.Printf)
 	} else {
 		log.Printf("json archive disabled: set -json-archive-path to enable tarball generation")
 	}


### PR DESCRIPTION
## Summary
- clean up stale json-*.tar.gz temporary archives before starting the background generator so restarts do not serve partially written files
- stretch the json archive generator refresh interval to once per week to honor the requested cadence

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d142ab6c7c8332bf48d2ae089cf939