### PR TITLE
Clarify data licensing in all translations

### DIFF
--- a/public_html/translations.json
+++ b/public_html/translations.json
@@ -58,6 +58,8 @@
     "legend_full_ar": "هذا المقياس يوضح مدى أمان المكان للحياة والماء والطعام.\nتذكّر: قد تكون القياسات ناقصة؛ استخدمها كدليل فقط.\n\nأخضر (0–11 µR/h)\nخلفية طبيعية.\n• ماء الآبار غالبًا آمن.\n• يمكن الزراعة دون فحص.\n\nأصفر (11–30 µR/h)\nخلفية مرتفعة.\n• افحص الماء والتربة.\n• اختبر أي طعام قبل تناوله.\n\nأحمر (30–100 µR/h)\nتلوث خطير.\n• لا تشرب الماء.\n• الزراعة أو الأكل هنا خطر؛ الفحوص المخبرية ضرورية.\n\nأسود (>100 µR/h)\nمنطقة حرجة.\n• الماء والطعام غير صالحين.\n• الإقامة الطويلة ممنوعة؛ الزيارة القصيرة مع حماية فقط.\n",
     "legend_safe": "آمن",
     "legend_title": "مفتاح",
+    "license_full": "ينمو هذا المشروع تحت رخصة <a href=\"/LICENSE\" target=\"_blank\">GNU GPLv3</a>. يوجد النص الكامل في جذر المستودع وعلى موقع GNU. يمكنك دراسة الكود ومشاركته وتعديله ما دامت هذه الحريات ترافق عملك. تُنشر بيانات الأبحاث بموجب ترخيص Creative Commons 1.0 لضمان بقاء القياسات في الملك العام.",
+    "license_title": "الترخيص",
     "live_chart_all": "All readings",
     "live_chart_averaged": "Averaged over [[window]]",
     "live_chart_close": "Close",
@@ -107,6 +109,8 @@
     "radiation_dose": "معدل الجرعة",
     "select_files": "يرجى اختيار ملف واحد على الأقل",
     "short_link_tooltip": "انقر لنسخ رابط قصير للمشاركة",
+    "sources_full": "نحن نشكر كل من يشارك القياسات.\n\nعمليات الرفع المجهولة ترسم مسارات هادئة على الخريطة.\n<a href=\"https://safecast.org\" target=\"_blank\">Safecast</a> ترعى أرشيفًا عالميًا للقراءات.\n<a href=\"https://atomfast.net\" target=\"_blank\">Atomfast</a> يبقي Atomcloud متقدًا.\n<a href=\"https://radiaverse.com\" target=\"_blank\">Radioverse</a> يجمع رؤى Radiacode.\n\nكل مساهمة توسّع الصورة المشتركة؛ ندعوك بحرارة لإضافة مساهمتك.",
+    "sources_title": "مصادر البيانات",
     "speed": "السرعة",
     "speed_filter_tooltip_accuracy": "القياسات الأبطأ تبقى أقرب إلى الأرض، لذا بيانات المشاة هي الأدق.",
     "speed_filter_tooltip_car": "سيارة: من 7 إلى 70 كم/س للقيادة والمسوح المتنقلة.",
@@ -122,7 +126,8 @@
     "upload_button_tooltip": "أضف مسار القياسات الخاص بك إلى الخريطة. الصيغ المدعومة: .kml، .kmz، .gpx، .csv، .rctrk، .json، .log. يمكنك رفع عدة ملفات، وبعد الرفع ستفتح صفحة المسار.",
     "upload_error": "خطأ",
     "waiting_for_server": "بانتظار الخادم...",
-    "your_location": "موقعك"
+    "your_location": "موقعك",
+    "legend_full_en": "This scale shows how likely a spot is safe for folk, water, and food.\nMind: the readings might not be complete, and some rays could be higher or hiding. Treat these numbers as guidance only.\n\nGreen (0–11 µR/h)\nBackground near natural.\n• Water from wells is generally safe.\n• You can grow plants without checks.\n\nYellow (11–30 µR/h)\nRaised background; take care.\n• Check water and soil.\n• Test any veg, mushrooms, or other produce before you eat.\n\nRed (30–100 µR/h)\nSerious contamination.\n• Don't drink the water.\n• Growing or eating produce from here is risky; lab tests are a must.\n\nBlack (>100 µR/h)\nCritical zone.\n• Water and food cannot be used.\n• Staying long-term is out; only short visits with protection.\n"
   },
   "cs": {
     "api_example_archive_desc": "Stáhne archiv tgz se všemi zveřejněnými soubory .cim, pokud je JSON archiv zapnutý.",
@@ -177,7 +182,14 @@
     "legal_contact": "Máte-li zpětnou vazbu, napište na:",
     "legal_full": "Preambule. Společně tvoříme otevřenou mapu, na níž lidé z celého světa sdílejí dozimetrická měření pro dobro všech – pro vědu, životní prostředí, vzdělávání i bezpečnost. Když zveřejníte svá data, pomáháte mnoha lidem. Prosíme, pečujte o toto společné dílo.\n\n1) Odpovědnost. Za správnost a obsah zasílaných informací nesete odpovědnost vy sami. Data se zveřejňují a používají „tak, jak jsou“. Služba nepotvrzuje ani negarantuje jejich správnost, úplnost či vhodnost pro jakýkoli účel a neodpovídá za následky jejich využití.\n\n2) Otevřenost a licence. Sdílením měření, dat, přibližné polohy, modelu zařízení nebo dalších údajů berete na vědomí, že budou dostupné všem a lze je svobodně používat podle licence CC0 1.0 (Public Domain). Kód zůstává pod licencí GPL. Autorství vám zůstává; odměna se neposkytuje; další šíření třetími stranami nemáme pod kontrolou.\n\n3) „Jak jsou“ a bez ověření. Příspěvky se zveřejňují bez předchozí kontroly. Nemůžeme zaručit kalibraci přístrojů ani bezchybnost údajů. Informace slouží k výzkumným účelům a nepředstavují odborné doporučení.\n\n4) Soukromí a moderace. Kvůli bezpečnosti a důvěře můžeme časy a souřadnice zobecňovat a technická metadata odstraňovat či anonymizovat. Materiály, které jsou podle našeho rozumného uvážení spam, padělek, porušují zákon nebo narušují službu, můžeme skrýt či smazat. Poctivých měření si vážíme a usilujeme o jejich zachování.\n\n5) Cookies. Web používá pouze krátkodobé technické session cookie; po skončení návštěvy zmizí. Žádné další stopy neukládáme.\n\nPřátelé, tato mapa je výsledkem společného úsilí a otevřených srdcí. Vnímejte ji jako náčrt krajiny, nikoli jako přesný plán. Pokud vám naše práce dává smysl, přidejte se – společně ji vylepšíme.",
     "legal_title": "Právní informace",
+    "legend_attention": "Pozor",
     "legend_button_tooltip": "Otevřít legendu úrovní radiace.",
+    "legend_danger": "Nebezpečí",
+    "legend_full_cs": "Tato stupnice ukazuje, jak je místo bezpečné pro lidi, vodu a potraviny.\nPamatujte: měření může být neúplné; používejte ji jen jako vodítko.\n\nZelená (0–11 µR/h)\nTéměř přirozené pozadí.\n• Voda ze studní je obvykle bezpečná.\n• Rostliny lze pěstovat bez testů.\n\nŽlutá (11–30 µR/h)\nZvýšené pozadí.\n• Zkontrolujte vodu a půdu.\n• Otestujte jakékoli potraviny před konzumací.\n\nČervená (30–100 µR/h)\nVážná kontaminace.\n• Nepijte vodu.\n• Pěstování nebo konzumace je riskantní; laboratorní testy jsou nutné.\n\nČerná (>100 µR/h)\nKritická zóna.\n• Voda ani jídlo nejsou použitelné.\n• Zůstávejte jen krátce a s ochranou.",
+    "legend_safe": "Bezpečné",
+    "legend_title": "Legenda",
+    "license_full": "Tento projekt funguje pod licencí <a href=\"/LICENSE\" target=\"_blank\">GNU GPLv3</a>. Celý text najdete v kořeni repozitáře a na webu GNU. Kód můžete studovat, sdílet i upravovat, pokud si tyto svobody ponechají i vaše úpravy. Výzkumná data zveřejňujeme pod licencí Creative Commons 1.0, takže měření zůstávají ve veřejném prostoru.",
+    "license_title": "Licence",
     "live_chart_all": "All readings",
     "live_chart_averaged": "Averaged over [[window]]",
     "live_chart_close": "Close",
@@ -227,6 +239,8 @@
     "radiation_dose": "Dávkový příkon",
     "select_files": "Vyberte prosím alespoň jeden soubor",
     "short_link_tooltip": "Kliknutím zkopírujete krátký sdílený odkaz",
+    "sources_full": "Všem, kdo sdílejí měření, děkujeme.\n\nAnonymní nahrávky kreslí na mapě tiché stopy.\n<a href=\"https://safecast.org\" target=\"_blank\">Safecast</a> pečuje o celosvětový archiv měření.\n<a href=\"https://atomfast.net\" target=\"_blank\">Atomfast</a> udržuje službu Atomcloud v chodu.\n<a href=\"https://radiaverse.com\" target=\"_blank\">Radioverse</a> shromažďuje poznatky z Radiacode.\n\nKaždý příspěvek rozšiřuje společný obraz; budeme rádi, když přidáte ten svůj.",
+    "sources_title": "Zdroje dat",
     "speed": "Rychlost",
     "speed_filter_tooltip_accuracy": "Pomalejší měření zůstávají nejblíže zemi, proto jsou pěší data nejpřesnější.",
     "speed_filter_tooltip_car": "Auto: 7–70 km/h pro jízdy a mobilní průzkumy.",
@@ -242,7 +256,8 @@
     "upload_button_tooltip": "Přidejte svou měřicí trasu do mapy. Podporované formáty: .kml, .kmz, .gpx, .csv, .rctrk, .json, .log. Můžete nahrát více souborů a po nahrání se otevře stránka trasy.",
     "upload_error": "Chyba",
     "waiting_for_server": "Čekání na server...",
-    "your_location": "Vaše poloha"
+    "your_location": "Vaše poloha",
+    "legend_full_en": "This scale shows how likely a spot is safe for folk, water, and food.\nMind: the readings might not be complete, and some rays could be higher or hiding. Treat these numbers as guidance only.\n\nGreen (0–11 µR/h)\nBackground near natural.\n• Water from wells is generally safe.\n• You can grow plants without checks.\n\nYellow (11–30 µR/h)\nRaised background; take care.\n• Check water and soil.\n• Test any veg, mushrooms, or other produce before you eat.\n\nRed (30–100 µR/h)\nSerious contamination.\n• Don't drink the water.\n• Growing or eating produce from here is risky; lab tests are a must.\n\nBlack (>100 µR/h)\nCritical zone.\n• Water and food cannot be used.\n• Staying long-term is out; only short visits with protection.\n"
   },
   "da": {
     "api_example_archive_desc": "Downloader en tgz-pakke med alle offentliggjorte .cim-filer når JSON-arkivet er aktiveret.",
@@ -303,6 +318,8 @@
     "legend_full_da": "Denne skala viser, hvor sikker et sted er for liv, vand og mad.\nHusk: målinger kan være ufuldstændige; brug den kun som vejledning.\n\nGrøn (0–11 µR/h)\nNæsten naturlig baggrund.\n• Brøndvand er som regel sikkert.\n• Planter kan dyrkes uden test.\n\nGul (11–30 µR/h)\nForhøjet baggrund.\n• Tjek vand og jord.\n• Undersøg mad før du spiser.\n\nRød (30–100 µR/h)\nAlvorlig forurening.\n• Drik ikke vandet.\n• Dyrkning eller spisning her er risikabelt; laboratorietest kræves.\n\nSort (>100 µR/h)\nKritisk område.\n• Vand og mad kan ikke bruges.\n• Kun korte ophold med beskyttelse.\n",
     "legend_safe": "Sikker",
     "legend_title": "Forklaring",
+    "license_full": "Dette projekt drives under <a href=\"/LICENSE\" target=\"_blank\">GNU GPLv3</a>. Den fulde tekst ligger i roden af repositoriet og på GNU's hjemmeside. Du må studere, dele og ændre koden, så længe disse friheder følger dit arbejde. Forskningsdata udgives under Creative Commons 1.0, så målingerne forbliver i det offentlige domæne.",
+    "license_title": "Licens",
     "live_chart_all": "All readings",
     "live_chart_averaged": "Averaged over [[window]]",
     "live_chart_close": "Close",
@@ -352,6 +369,8 @@
     "radiation_dose": "Dosisrate",
     "select_files": "Vælg mindst én fil",
     "short_link_tooltip": "Klik for at kopiere et kort delingslink",
+    "sources_full": "Vi takker alle, der deler målinger.\n\nAnonyme uploads tegner stille spor på kortet.\n<a href=\"https://safecast.org\" target=\"_blank\">Safecast</a> plejer et globalt arkiv af aflæsninger.\n<a href=\"https://atomfast.net\" target=\"_blank\">Atomfast</a> holder Atomcloud i gang.\n<a href=\"https://radiaverse.com\" target=\"_blank\">Radioverse</a> samler indsigter fra Radiacode.\n\nHvert bidrag udvider det fælles billede; du er hjerteligt velkommen til at tilføje dit eget.",
+    "sources_title": "Datakilder",
     "speed": "Hastighed",
     "speed_filter_tooltip_accuracy": "Langsommere målinger ligger tættest på jorden, så fodgængerdata er mest præcise.",
     "speed_filter_tooltip_car": "Bil: 7–70 km/t til kørsler og mobile målinger.",
@@ -367,7 +386,8 @@
     "upload_button_tooltip": "Tilføj din målerute til kortet. Understøttede formater: .kml, .kmz, .gpx, .csv, .rctrk, .json, .log. Du kan uploade flere filer, og efter upload åbnes sporesiden.",
     "upload_error": "Fejl",
     "waiting_for_server": "Venter på serveren...",
-    "your_location": "Din placering"
+    "your_location": "Din placering",
+    "legend_full_en": "This scale shows how likely a spot is safe for folk, water, and food.\nMind: the readings might not be complete, and some rays could be higher or hiding. Treat these numbers as guidance only.\n\nGreen (0–11 µR/h)\nBackground near natural.\n• Water from wells is generally safe.\n• You can grow plants without checks.\n\nYellow (11–30 µR/h)\nRaised background; take care.\n• Check water and soil.\n• Test any veg, mushrooms, or other produce before you eat.\n\nRed (30–100 µR/h)\nSerious contamination.\n• Don't drink the water.\n• Growing or eating produce from here is risky; lab tests are a must.\n\nBlack (>100 µR/h)\nCritical zone.\n• Water and food cannot be used.\n• Staying long-term is out; only short visits with protection.\n"
   },
   "de": {
     "api_example_archive_desc": "Lädt ein tgz-Paket mit allen veröffentlichten .cim-Dateien, sofern das JSON-Archiv aktiv ist.",
@@ -428,6 +448,8 @@
     "legend_full_de": "Diese Skala zeigt, wie sicher ein Ort für Menschen, Wasser und Nahrung ist.\nDenk daran: Messungen können unvollständig sein; nutze sie nur als Richtwert.\n\nGrün (0–11 µR/h)\nNatürliche Hintergrundstrahlung.\n• Brunnenwasser meist sicher.\n• Pflanzen können ohne Tests wachsen.\n\nGelb (11–30 µR/h)\nErhöhte Werte.\n• Wasser und Boden prüfen.\n• Jede Ernte vor dem Essen testen.\n\nRot (30–100 µR/h)\nStarke Belastung.\n• Wasser nicht trinken.\n• Anbau oder Verzehr hier gefährlich; Laborprüfungen nötig.\n\nSchwarz (>100 µR/h)\nKritische Zone.\n• Wasser und Nahrung unbrauchbar.\n• Längerer Aufenthalt verboten; nur kurz mit Schutz.\n",
     "legend_safe": "Sicher",
     "legend_title": "Legende",
+    "license_full": "Dieses Projekt steht unter der <a href=\"/LICENSE\" target=\"_blank\">GNU GPLv3</a>. Der vollständige Text liegt im Wurzelverzeichnis des Repos und auf der GNU-Seite. Du darfst den Code studieren, weitergeben und verändern, solange diese Freiheiten mit deiner Arbeit weitergegeben werden. Die Forschungsdaten erscheinen unter der Lizenz Creative Commons 1.0, damit die Messwerte gemeinfrei bleiben.",
+    "license_title": "Lizenz",
     "live_chart_all": "All readings",
     "live_chart_averaged": "Averaged over [[window]]",
     "live_chart_close": "Close",
@@ -477,6 +499,8 @@
     "radiation_dose": "Dosisleistung",
     "select_files": "Bitte wählen Sie mindestens eine Datei aus",
     "short_link_tooltip": "Klicken, um einen kurzen Freigabelink zu kopieren",
+    "sources_full": "Wir danken allen, die Messungen teilen.\n\nAnonyme Uploads zeichnen leise Wege auf die Karte.\n<a href=\"https://safecast.org\" target=\"_blank\">Safecast</a> pflegt ein weltweites Archiv von Messwerten.\n<a href=\"https://atomfast.net\" target=\"_blank\">Atomfast</a> hält die Atomcloud am Laufen.\n<a href=\"https://radiaverse.com\" target=\"_blank\">Radioverse</a> sammelt Erkenntnisse aus Radiacode.\n\nJeder Beitrag erweitert das gemeinsame Bild; wir laden dich herzlich ein, selbst mitzuwirken.",
+    "sources_title": "Datenquellen",
     "speed": "Geschwindigkeit",
     "speed_filter_tooltip_accuracy": "Langsamere Messungen bleiben näher am Boden, daher sind Fußgängerdaten am genauesten.",
     "speed_filter_tooltip_car": "Auto: 7–70 km/h für Fahrten und mobile Messungen.",
@@ -492,7 +516,8 @@
     "upload_button_tooltip": "Fügen Sie Ihre Messstrecke zur Karte hinzu. Unterstützte Formate: .kml, .kmz, .gpx, .csv, .rctrk, .json, .log. Sie können mehrere Dateien hochladen, danach öffnet sich die Track-Seite.",
     "upload_error": "Fehler",
     "waiting_for_server": "Warten auf den Server...",
-    "your_location": "Ihr Standort"
+    "your_location": "Ihr Standort",
+    "legend_full_en": "This scale shows how likely a spot is safe for folk, water, and food.\nMind: the readings might not be complete, and some rays could be higher or hiding. Treat these numbers as guidance only.\n\nGreen (0–11 µR/h)\nBackground near natural.\n• Water from wells is generally safe.\n• You can grow plants without checks.\n\nYellow (11–30 µR/h)\nRaised background; take care.\n• Check water and soil.\n• Test any veg, mushrooms, or other produce before you eat.\n\nRed (30–100 µR/h)\nSerious contamination.\n• Don't drink the water.\n• Growing or eating produce from here is risky; lab tests are a must.\n\nBlack (>100 µR/h)\nCritical zone.\n• Water and food cannot be used.\n• Staying long-term is out; only short visits with protection.\n"
   },
   "el": {
     "api_example_archive_desc": "Κατεβάζει ένα αρχείο tgz με όλα τα δημοσιευμένα αρχεία .cim όταν είναι ενεργό το JSON αρχείο.",
@@ -553,6 +578,8 @@
     "legend_full_el": "Αυτή η κλίμακα δείχνει πόσο ασφαλής είναι μια περιοχή για ζωή, νερό και τροφή.\nΘυμήσου: οι μετρήσεις μπορεί να μην είναι πλήρεις· χρησιμοποίησέ τες μόνο ως οδηγό.\n\nΠράσινο (0–11 µR/h)\nΣχεδόν φυσικό υπόβαθρο.\n• Το νερό πηγών είναι γενικά ασφαλές.\n• Μπορείς να καλλιεργείς χωρίς έλεγχο.\n\nΚίτρινο (11–30 µR/h)\nΑυξημένο υπόβαθρο.\n• Έλεγξε νερό και έδαφος.\n• Εξέτασε κάθε τρόφιμο πριν το φας.\n\nΚόκκινο (30–100 µR/h)\nΣοβαρή ρύπανση.\n• Μην πίνεις το νερό.\n• Η καλλιέργεια ή κατανάλωση εδώ είναι επικίνδυνη· απαιτούνται εργαστηριακοί έλεγχοι.\n\nΜαύρο (>100 µR/h)\nΚρίσιμη ζώνη.\n• Νερό και τροφή ακατάλληλα.\n• Μόνο σύντομη παραμονή με προστασία.\n",
     "legend_safe": "Ασφαλές",
     "legend_title": "Υπόμνημα",
+    "license_full": "Το έργο αυτό εξελίσσεται υπό την άδεια <a href=\"/LICENSE\" target=\"_blank\">GNU GPLv3</a>. Το πλήρες κείμενο βρίσκεται στη ρίζα του αποθετηρίου και στον ιστότοπο του GNU. Μπορείτε να μελετήσετε, να μοιραστείτε και να τροποποιήσετε τον κώδικα, αρκεί αυτές οι ελευθερίες να συνοδεύουν και τη δική σας δουλειά. Τα ερευνητικά δεδομένα δημοσιεύονται υπό την άδεια Creative Commons 1.0 ώστε οι μετρήσεις να παραμένουν στο δημόσιο τομέα.",
+    "license_title": "Άδεια",
     "live_chart_all": "All readings",
     "live_chart_averaged": "Averaged over [[window]]",
     "live_chart_close": "Close",
@@ -602,6 +629,8 @@
     "radiation_dose": "Ρυθμός δόσης",
     "select_files": "Παρακαλώ επιλέξτε τουλάχιστον ένα αρχείο",
     "short_link_tooltip": "Κάντε κλικ για αντιγραφή σύντομου συνδέσμου κοινής χρήσης",
+    "sources_full": "Ευχαριστούμε όλους όσοι μοιράζονται μετρήσεις.\n\nΑνώνυμες αποστολές χαράσσουν ήσυχες διαδρομές στον χάρτη.\n<a href=\"https://safecast.org\" target=\"_blank\">Safecast</a> καλλιεργεί ένα παγκόσμιο αρχείο καταγραφών.\n<a href=\"https://atomfast.net\" target=\"_blank\">Atomfast</a> κρατά το Atomcloud σε λειτουργία.\n<a href=\"https://radiaverse.com\" target=\"_blank\">Radioverse</a> συγκεντρώνει γνώσεις από τα Radiacode.\n\nΚάθε συνεισφορά μεγαλώνει τη συλλογική εικόνα· σας προσκαλούμε θερμά να προσθέσετε και τη δική σας.",
+    "sources_title": "Πηγές δεδομένων",
     "speed": "Ταχύτητα",
     "speed_filter_tooltip_accuracy": "Οι πιο αργές μετρήσεις παραμένουν πιο κοντά στο έδαφος, οπότε τα δεδομένα πεζών είναι τα πιο ακριβή.",
     "speed_filter_tooltip_car": "Αυτοκίνητο: 7–70 χλμ./ώρα για διαδρομές και κινητές μετρήσεις.",
@@ -617,7 +646,8 @@
     "upload_button_tooltip": "Προσθέστε τη διαδρομή μετρήσεών σας στον χάρτη. Υποστηριζόμενες μορφές: .kml, .kmz, .gpx, .csv, .rctrk, .json, .log. Μπορείτε να μεταφορτώσετε πολλά αρχεία· μετά τη μεταφόρτωση θα ανοίξει η σελίδα της διαδρομής.",
     "upload_error": "Σφάλμα",
     "waiting_for_server": "Αναμονή για τον διακομιστή...",
-    "your_location": "Η τοποθεσία σας"
+    "your_location": "Η τοποθεσία σας",
+    "legend_full_en": "This scale shows how likely a spot is safe for folk, water, and food.\nMind: the readings might not be complete, and some rays could be higher or hiding. Treat these numbers as guidance only.\n\nGreen (0–11 µR/h)\nBackground near natural.\n• Water from wells is generally safe.\n• You can grow plants without checks.\n\nYellow (11–30 µR/h)\nRaised background; take care.\n• Check water and soil.\n• Test any veg, mushrooms, or other produce before you eat.\n\nRed (30–100 µR/h)\nSerious contamination.\n• Don't drink the water.\n• Growing or eating produce from here is risky; lab tests are a must.\n\nBlack (>100 µR/h)\nCritical zone.\n• Water and food cannot be used.\n• Staying long-term is out; only short visits with protection.\n"
   },
   "en": {
     "api_example_archive_desc": "Downloads a tgz bundle with every published .cim file when the server enables the JSON archive.",
@@ -678,7 +708,7 @@
     "legend_full_en": "This scale shows how likely a spot is safe for folk, water, and food.\nMind: the readings might not be complete, and some rays could be higher or hiding. Treat these numbers as guidance only.\n\nGreen (0–11 µR/h)\nBackground near natural.\n• Water from wells is generally safe.\n• You can grow plants without checks.\n\nYellow (11–30 µR/h)\nRaised background; take care.\n• Check water and soil.\n• Test any veg, mushrooms, or other produce before you eat.\n\nRed (30–100 µR/h)\nSerious contamination.\n• Don't drink the water.\n• Growing or eating produce from here is risky; lab tests are a must.\n\nBlack (>100 µR/h)\nCritical zone.\n• Water and food cannot be used.\n• Staying long-term is out; only short visits with protection.\n",
     "legend_safe": "Safe",
     "legend_title": "Legend",
-    "license_full": "This project grows under the <a href=\"/LICENSE\" target=\"_blank\">GNU GPLv3</a>. The full text rests in the repository's root and on the GNU site. You may study, share, and alter the code, provided these freedoms travel with your work.",
+    "license_full": "This project grows under the <a href=\"/LICENSE\" target=\"_blank\">GNU GPLv3</a>. The full text rests in the repository's root and on the GNU site. You may study, share, and alter the code, provided these freedoms travel with your work. Research datasets are released under Creative Commons 1.0 (CC0) so the measurements remain in the public domain.",
     "license_title": "License",
     "live_chart_all": "All readings",
     "live_chart_averaged": "Averaged over [[window]]",
@@ -807,6 +837,8 @@
     "legend_full_es": "Esta escala indica cuán seguro es un lugar para vivir, beber y comer.\nRecuerda: las mediciones pueden estar incompletas; úsala solo como guía.\n\nVerde (0–11 µR/h)\nFondo natural.\n• Agua de pozo segura.\n• Se puede cultivar sin pruebas.\n\nAmarillo (11–30 µR/h)\nFondo elevado.\n• Revisa agua y suelo.\n• Analiza cualquier alimento antes de comer.\n\nRojo (30–100 µR/h)\nContaminación grave.\n• No bebas el agua.\n• Cultivar o comer de aquí es arriesgado; requiere pruebas de laboratorio.\n\nNegro (>100 µR/h)\nZona crítica.\n• Agua y comida inutilizables.\n• Sólo estancias breves con protección.\n",
     "legend_safe": "Seguro",
     "legend_title": "Leyenda",
+    "license_full": "Este proyecto se desarrolla bajo la <a href=\"/LICENSE\" target=\"_blank\">GNU GPLv3</a>. El texto completo está en la raíz del repositorio y en el sitio de GNU. Puedes estudiar, compartir y modificar el código, siempre que estas libertades acompañen tu trabajo. Los datos de investigación se publican con la licencia Creative Commons 1.0 para que las mediciones sigan en el dominio público.",
+    "license_title": "Licencia",
     "live_chart_all": "All readings",
     "live_chart_averaged": "Averaged over [[window]]",
     "live_chart_close": "Close",
@@ -856,6 +888,8 @@
     "radiation_dose": "Tasa de dosis",
     "select_files": "Por favor, seleccione al menos un archivo",
     "short_link_tooltip": "Haz clic para copiar un enlace corto para compartir",
+    "sources_full": "Agradecemos a todas las personas que comparten mediciones.\n\nLos envíos anónimos dibujan sendas silenciosas en el mapa.\n<a href=\"https://safecast.org\" target=\"_blank\">Safecast</a> mantiene un archivo global de lecturas.\n<a href=\"https://atomfast.net\" target=\"_blank\">Atomfast</a> mantiene vivo Atomcloud.\n<a href=\"https://radiaverse.com\" target=\"_blank\">Radioverse</a> reúne el conocimiento de Radiacode.\n\nCada aporte amplía la imagen común; te invitamos con cariño a sumar el tuyo.",
+    "sources_title": "Fuentes de datos",
     "speed": "Velocidad",
     "speed_filter_tooltip_accuracy": "Las mediciones más lentas se mantienen más cerca del suelo, por eso los datos de peatón son los más precisos.",
     "speed_filter_tooltip_car": "Auto: 7–70 km/h para recorridos y mediciones móviles.",
@@ -871,7 +905,8 @@
     "upload_button_tooltip": "Agregue su recorrido de mediciones al mapa. Formatos compatibles: .kml, .kmz, .gpx, .csv, .rctrk, .json, .log. Puede subir varios archivos y, después de la carga, se abrirá la página del recorrido.",
     "upload_error": "Error",
     "waiting_for_server": "Esperando al servidor...",
-    "your_location": "Tu ubicación"
+    "your_location": "Tu ubicación",
+    "legend_full_en": "This scale shows how likely a spot is safe for folk, water, and food.\nMind: the readings might not be complete, and some rays could be higher or hiding. Treat these numbers as guidance only.\n\nGreen (0–11 µR/h)\nBackground near natural.\n• Water from wells is generally safe.\n• You can grow plants without checks.\n\nYellow (11–30 µR/h)\nRaised background; take care.\n• Check water and soil.\n• Test any veg, mushrooms, or other produce before you eat.\n\nRed (30–100 µR/h)\nSerious contamination.\n• Don't drink the water.\n• Growing or eating produce from here is risky; lab tests are a must.\n\nBlack (>100 µR/h)\nCritical zone.\n• Water and food cannot be used.\n• Staying long-term is out; only short visits with protection.\n"
   },
   "fa": {
     "api_example_archive_desc": "وقتی آرشیو JSON فعال باشد یک بسته tgz شامل تمام فایل‌های .cim منتشرشده را دانلود می‌کند.",
@@ -932,6 +967,8 @@
     "legend_full_fa": "این مقیاس نشان می‌دهد یک محل برای زندگی، آب و غذا چقدر امن است.\nبه یاد داشته باشید: اندازه‌گیری‌ها ممکن است ناقص باشد؛ فقط به عنوان راهنما استفاده کنید.\n\nسبز (0–11 µR/h)\nزمینه نزدیک به طبیعی.\n• آب چاه معمولاً امن است.\n• می‌توان بدون آزمایش گیاه کاشت.\n\nزرد (11–30 µR/h)\nزمینه بالا رفته.\n• آب و خاک را بررسی کنید.\n• هر غذایی را پیش از خوردن آزمایش کنید.\n\nقرمز (30–100 µR/h)\nآلودگی شدید.\n• آب را ننوشید.\n• کاشت یا خوردن اینجا خطرناک است؛ آزمایشگاه لازم است.\n\nسیاه (>100 µR/h)\nمنطقه بحرانی.\n• آب و غذا قابل استفاده نیست.\n• فقط توقف کوتاه با حفاظت.\n",
     "legend_safe": "ایمن",
     "legend_title": "راهنما",
+    "license_full": "این پروژه تحت مجوز <a href=\"/LICENSE\" target=\"_blank\">GNU GPLv3</a> رشد می‌کند. متن کامل در ریشه مخزن و در وب‌سایت GNU در دسترس است. می‌توانید کد را مطالعه، به اشتراک بگذارید و تغییر دهید؛ به شرطی که این آزادی‌ها همراه کار شما بماند. داده‌های پژوهشی با مجوز Creative Commons 1.0 منتشر می‌شوند تا اندازه‌گیری‌ها در حوزه عمومی باقی بمانند.",
+    "license_title": "مجوز",
     "live_chart_all": "All readings",
     "live_chart_averaged": "Averaged over [[window]]",
     "live_chart_close": "Close",
@@ -981,6 +1018,8 @@
     "radiation_dose": "نرخ دوز",
     "select_files": "لطفاً دست‌کم یک فایل انتخاب کنید",
     "short_link_tooltip": "برای کپی کردن لینک کوتاه اشتراک کلیک کنید",
+    "sources_full": "از همه کسانی که اندازه‌گیری‌ها را به اشتراک می‌گذارند سپاسگزاریم.\n\nبارگذاری‌های ناشناس ردپاهای آرامی روی نقشه ترسیم می‌کنند.\n<a href=\"https://safecast.org\" target=\"_blank\">Safecast</a> آرشیوی جهانی از قرائت‌ها را نگه می‌دارد.\n<a href=\"https://atomfast.net\" target=\"_blank\">Atomfast</a> ابر Atomcloud را روشن نگه می‌دارد.\n<a href=\"https://radiaverse.com\" target=\"_blank\">Radioverse</a> بینش‌های Radiacode را گرد می‌آورد.\n\nهر مشارکت تصویر مشترک را گسترده‌تر می‌کند؛ با آغوش باز از شما دعوت می‌کنیم سهم خود را بیفزایید.",
+    "sources_title": "منابع داده",
     "speed": "سرعت",
     "speed_filter_tooltip_accuracy": "اندازه‌گیری‌های آهسته‌تر نزدیک‌تر به سطح زمین می‌مانند، بنابراین داده‌های پیاده دقیق‌ترین هستند.",
     "speed_filter_tooltip_car": "خودرو: ۷ تا ۷۰ کیلومتر بر ساعت برای رانندگی و پایش سیار.",
@@ -996,7 +1035,8 @@
     "upload_button_tooltip": "مسیر اندازه‌گیری خود را به نقشه اضافه کنید. قالب‌های پشتیبانی‌شده: ‎.kml, .kmz, .gpx, .csv, .rctrk, .json, .log‎. می‌توانید چندین فایل بارگذاری کنید و پس از بارگذاری، صفحهٔ مسیر باز می‌شود.",
     "upload_error": "خطا",
     "waiting_for_server": "در انتظار سرور...",
-    "your_location": "موقعیت شما"
+    "your_location": "موقعیت شما",
+    "legend_full_en": "This scale shows how likely a spot is safe for folk, water, and food.\nMind: the readings might not be complete, and some rays could be higher or hiding. Treat these numbers as guidance only.\n\nGreen (0–11 µR/h)\nBackground near natural.\n• Water from wells is generally safe.\n• You can grow plants without checks.\n\nYellow (11–30 µR/h)\nRaised background; take care.\n• Check water and soil.\n• Test any veg, mushrooms, or other produce before you eat.\n\nRed (30–100 µR/h)\nSerious contamination.\n• Don't drink the water.\n• Growing or eating produce from here is risky; lab tests are a must.\n\nBlack (>100 µR/h)\nCritical zone.\n• Water and food cannot be used.\n• Staying long-term is out; only short visits with protection.\n"
   },
   "fi": {
     "api_example_archive_desc": "Lataa tgz-paketin, jossa on kaikki julkaistut .cim-tiedostot, kun JSON-arkisto on käytössä.",
@@ -1057,6 +1097,8 @@
     "legend_full_fi": "Tämä asteikko kertoo, kuinka turvallinen paikka on elämälle, vedelle ja ruoalle.\nMuista: mittaukset voivat olla puutteellisia; käytä vain ohjeena.\n\nVihreä (0–11 µR/h)\nLähes luonnollinen tausta.\n• Kaivovesi yleensä turvallista.\n• Voit kasvattaa kasveja ilman testejä.\n\nKeltainen (11–30 µR/h)\nKohonnut tausta.\n• Tarkista vesi ja maa.\n• Tutki ruoka ennen syömistä.\n\nPunainen (30–100 µR/h)\nVakava saastuminen.\n• Älä juo vettä.\n• Täällä viljely tai syöminen on riskialtista; laboratoriotestit pakollisia.\n\nMusta (>100 µR/h)\nKriittinen alue.\n• Vesi ja ruoka käyttökelvottomia.\n• Pitkä oleskelu mahdoton; vain lyhyet käynnit suojassa.\n",
     "legend_safe": "Turvallinen",
     "legend_title": "Selite",
+    "license_full": "Tämä projekti elää <a href=\"/LICENSE\" target=\"_blank\">GNU GPLv3</a> -lisenssin alla. Koko teksti löytyy projektin juuresta ja GNU:n sivuilta. Voit tutkia, jakaa ja muokata koodia, kunhan viet nämä vapaudet mukanasi omiin töihisi. Tutkimusaineistot julkaistaan Creative Commons 1.0 -lisenssillä, jotta mittaukset pysyvät julkisessa omistuksessa.",
+    "license_title": "Lisenssi",
     "live_chart_all": "All readings",
     "live_chart_averaged": "Averaged over [[window]]",
     "live_chart_close": "Close",
@@ -1106,6 +1148,8 @@
     "radiation_dose": "Annosnopeus",
     "select_files": "Valitse vähintään yksi tiedosto",
     "short_link_tooltip": "Napsauta kopioidaksesi lyhyen jakolinkin",
+    "sources_full": "Kiitämme kaikkia mittauksia jakavia.\n\nAnonyymit lataukset piirtävät hiljaisia reittejä kartalle.\n<a href=\"https://safecast.org\" target=\"_blank\">Safecast</a> ylläpitää maailmanlaajuista mittausarkistoa.\n<a href=\"https://atomfast.net\" target=\"_blank\">Atomfast</a> pitää Atomcloudin käynnissä.\n<a href=\"https://radiaverse.com\" target=\"_blank\">Radioverse</a> kokoaa Radiacode-havaintoja.\n\nJokainen panos laajentaa yhteistä kuvaa; olet lämpimästi tervetullut lisäämään omasi.",
+    "sources_title": "Datalähteet",
     "speed": "Nopeus",
     "speed_filter_tooltip_accuracy": "Hitaammat mittaukset pysyvät lähimpänä maanpintaa, joten jalankulkijatiedot ovat tarkimpia.",
     "speed_filter_tooltip_car": "Auto: 7–70 km/h ajomittauksiin ja liikkuviin keräyksiin.",
@@ -1121,7 +1165,8 @@
     "upload_button_tooltip": "Lisää mittausreittisi kartalle. Tuetut muodot: .kml, .kmz, .gpx, .csv, .rctrk, .json, .log. Voit lähettää useita tiedostoja; lähetyksen jälkeen avautuu reittisivu.",
     "upload_error": "Virhe",
     "waiting_for_server": "Odotetaan palvelinta...",
-    "your_location": "Sijaintisi"
+    "your_location": "Sijaintisi",
+    "legend_full_en": "This scale shows how likely a spot is safe for folk, water, and food.\nMind: the readings might not be complete, and some rays could be higher or hiding. Treat these numbers as guidance only.\n\nGreen (0–11 µR/h)\nBackground near natural.\n• Water from wells is generally safe.\n• You can grow plants without checks.\n\nYellow (11–30 µR/h)\nRaised background; take care.\n• Check water and soil.\n• Test any veg, mushrooms, or other produce before you eat.\n\nRed (30–100 µR/h)\nSerious contamination.\n• Don't drink the water.\n• Growing or eating produce from here is risky; lab tests are a must.\n\nBlack (>100 µR/h)\nCritical zone.\n• Water and food cannot be used.\n• Staying long-term is out; only short visits with protection.\n"
   },
   "fr": {
     "api_example_archive_desc": "Télécharge une archive tgz avec tous les fichiers .cim publiés lorsque l’archive JSON est activée.",
@@ -1182,6 +1227,8 @@
     "legend_full_fr": "Cette échelle indique à quel point un lieu est sûr pour la vie, l’eau et la nourriture.\nSouviens‑toi : les mesures peuvent être incomplètes ; n’en fais qu’un guide.\n\nVert (0–11 µR/h)\nFond naturel.\n• L’eau de puits est généralement potable.\n• On peut cultiver sans tests.\n\nJaune (11–30 µR/h)\nFond élevé.\n• Vérifie l’eau et le sol.\n• Analyse toute nourriture avant de la consommer.\n\nRouge (30–100 µR/h)\nContamination sérieuse.\n• Ne bois pas l’eau.\n• Cultiver ou manger ici est risqué ; analyses en laboratoire obligatoires.\n\nNoir (>100 µR/h)\nZone critique.\n• Eau et nourriture inutilisables.\n• Séjour prolongé impossible ; visites courtes avec protection.\n",
     "legend_safe": "Sûr",
     "legend_title": "Légende",
+    "license_full": "Ce projet s’épanouit sous la licence <a href=\"/LICENSE\" target=\"_blank\">GNU GPLv3</a>. Le texte intégral se trouve à la racine du dépôt et sur le site du GNU. Vous pouvez étudier, partager et modifier le code, pourvu que ces libertés accompagnent vos travaux. Les données de recherche sont publiées sous licence Creative Commons 1.0 afin que les mesures demeurent dans le domaine public.",
+    "license_title": "Licence",
     "live_chart_all": "All readings",
     "live_chart_averaged": "Averaged over [[window]]",
     "live_chart_close": "Close",
@@ -1231,6 +1278,8 @@
     "radiation_dose": "Débit de dose",
     "select_files": "Veuillez sélectionner au moins un fichier",
     "short_link_tooltip": "Cliquez pour copier un lien court à partager",
+    "sources_full": "Nous remercions toutes celles et ceux qui partagent leurs mesures.\n\nLes envois anonymes tracent des chemins discrets sur la carte.\n<a href=\"https://safecast.org\" target=\"_blank\">Safecast</a> entretient une archive mondiale des relevés.\n<a href=\"https://atomfast.net\" target=\"_blank\">Atomfast</a> maintient l’Atomcloud allumée.\n<a href=\"https://radiaverse.com\" target=\"_blank\">Radioverse</a> recueille les connaissances issues de Radiacode.\n\nChaque contribution élargit la vision commune ; nous vous invitons chaleureusement à apporter la vôtre.",
+    "sources_title": "Sources de données",
     "speed": "Vitesse",
     "speed_filter_tooltip_accuracy": "Les mesures plus lentes restent proches du sol ; les données à pied sont donc les plus précises.",
     "speed_filter_tooltip_car": "Voiture : 7 à 70 km/h pour les trajets et relevés mobiles.",
@@ -1246,7 +1295,8 @@
     "upload_button_tooltip": "Ajoutez votre parcours de mesures à la carte. Formats pris en charge : .kml, .kmz, .gpx, .csv, .rctrk, .json, .log. Vous pouvez téléverser plusieurs fichiers et, après le téléversement, la page du parcours s’ouvrira.",
     "upload_error": "Erreur",
     "waiting_for_server": "En attente du serveur...",
-    "your_location": "Votre position"
+    "your_location": "Votre position",
+    "legend_full_en": "This scale shows how likely a spot is safe for folk, water, and food.\nMind: the readings might not be complete, and some rays could be higher or hiding. Treat these numbers as guidance only.\n\nGreen (0–11 µR/h)\nBackground near natural.\n• Water from wells is generally safe.\n• You can grow plants without checks.\n\nYellow (11–30 µR/h)\nRaised background; take care.\n• Check water and soil.\n• Test any veg, mushrooms, or other produce before you eat.\n\nRed (30–100 µR/h)\nSerious contamination.\n• Don't drink the water.\n• Growing or eating produce from here is risky; lab tests are a must.\n\nBlack (>100 µR/h)\nCritical zone.\n• Water and food cannot be used.\n• Staying long-term is out; only short visits with protection.\n"
   },
   "he": {
     "api_example_archive_desc": "מורידה חבילת tgz עם כל קבצי .cim שפורסמו כאשר ארכיון ה-JSON מופעל.",
@@ -1307,6 +1357,8 @@
     "legend_full_he": "סולם זה מראה עד כמה מקום בטוח לחיים, למים ולמזון.\nזכור: המדידות עשויות להיות חלקיות; השתמש בזה כהכוונה בלבד.\n\nירוק (0–11 µR/h)\nרקע כמעט טבעי.\n• מי באר לרוב בטוחים.\n• ניתן לגדל צמחים בלי בדיקות.\n\nצהוב (11–30 µR/h)\nרקע מוגבר.\n• בדוק מים ואדמה.\n• בדוק כל מזון לפני אכילה.\n\nאדום (30–100 µR/h)\nזיהום חמור.\n• אל תשתה את המים.\n• גידול או אכילה כאן מסוכנים; בדיקות מעבדה חובה.\n\nשחור (>100 µR/h)\nאזור קריטי.\n• מים ומזון אינם שימושיים.\n• שהייה ממושכת אסורה; רק ביקור קצר עם הגנה.\n",
     "legend_safe": "בטוח",
     "legend_title": "מקרא",
+    "license_full": "הפרויקט הזה פועל תחת רישיון <a href=\"/LICENSE\" target=\"_blank\">GNU GPLv3</a>. הנוסח המלא נמצא בשורש המאגר ובאתר GNU. מותר לך ללמוד, לשתף ולשנות את הקוד, כל עוד החירויות האלה ממשיכות עם עבודתך. נתוני המחקר מתפרסמים ברישיון Creative Commons 1.0 כדי שהמדידות יישארו בנחלת הכלל.",
+    "license_title": "רישיון",
     "live_chart_all": "All readings",
     "live_chart_averaged": "Averaged over [[window]]",
     "live_chart_close": "Close",
@@ -1356,6 +1408,8 @@
     "radiation_dose": "קצב מנה",
     "select_files": "אנא בחר לפחות קובץ אחד",
     "short_link_tooltip": "לחצו כדי להעתיק קישור קצר לשיתוף",
+    "sources_full": "אנחנו מודים לכל מי שמשתף מדידות.\n\nהעלאות אנונימיות מציירות שבילים שקטים על המפה.\n<a href=\"https://safecast.org\" target=\"_blank\">Safecast</a> מטפחת ארכיון עולמי של קריאות.\n<a href=\"https://atomfast.net\" target=\"_blank\">Atomfast</a> שומרת על Atomcloud פועלת.\n<a href=\"https://radiaverse.com\" target=\"_blank\">Radioverse</a> אוספת תובנות מ‑Radiacode.\n\nכל תרומה מרחיבה את התמונה המשותפת; נשמח מאוד שתוסיפו את שלכם.",
+    "sources_title": "מקורות הנתונים",
     "speed": "מהירות",
     "speed_filter_tooltip_accuracy": "מדידות איטיות נשארות קרובות יותר לקרקע, ולכן נתוני הולכי הרגל מדויקים ביותר.",
     "speed_filter_tooltip_car": "רכב: 7–70 קמ״ש לנסיעות ומדידות ניידות.",
@@ -1371,7 +1425,8 @@
     "upload_button_tooltip": "הוסף את מסלול המדידות שלך למפה. פורמטים נתמכים: ‎.kml, .kmz, .gpx, .csv, .rctrk, .json, .log‎. ניתן להעלות מספר קבצים, ולאחר ההעלאה תיפתח עמודת המסלול.",
     "upload_error": "שגיאה",
     "waiting_for_server": "ממתין לשרת...",
-    "your_location": "המיקום שלך"
+    "your_location": "המיקום שלך",
+    "legend_full_en": "This scale shows how likely a spot is safe for folk, water, and food.\nMind: the readings might not be complete, and some rays could be higher or hiding. Treat these numbers as guidance only.\n\nGreen (0–11 µR/h)\nBackground near natural.\n• Water from wells is generally safe.\n• You can grow plants without checks.\n\nYellow (11–30 µR/h)\nRaised background; take care.\n• Check water and soil.\n• Test any veg, mushrooms, or other produce before you eat.\n\nRed (30–100 µR/h)\nSerious contamination.\n• Don't drink the water.\n• Growing or eating produce from here is risky; lab tests are a must.\n\nBlack (>100 µR/h)\nCritical zone.\n• Water and food cannot be used.\n• Staying long-term is out; only short visits with protection.\n"
   },
   "hi": {
     "api_example_archive_desc": "JSON संग्रह सक्षम होने पर सभी प्रकाशित .cim फ़ाइलों वाला tgz पैकेज डाउनलोड करता है।",
@@ -1432,6 +1487,8 @@
     "legend_full_hi": "यह पैमाना बताता है कि कोई जगह जीवन, पानी और भोजन के लिए कितनी सुरक्षित है।\nयाद रखें: माप अधूरे हो सकते हैं; इसे केवल मार्गदर्शक मानें।\n\nहरा (0–11 µR/h)\nलगभग प्राकृतिक पृष्ठभूमि।\n• कुएँ का पानी आम तौर पर सुरक्षित।\n• बिना जाँच के खेती संभव।\n\nपीला (11–30 µR/h)\nपृष्ठभूमि बढ़ी हुई।\n• पानी और मिट्टी जाँचें।\n• किसी भी खाद्य पदार्थ को खाने से पहले जाँचें।\n\nलाल (30–100 µR/h)\nगंभीर प्रदूषण।\n• पानी न पिएँ।\n• यहाँ उगाना या खाना जोखिम भरा; प्रयोगशाला जाँच आवश्यक।\n\nकाला (>100 µR/h)\nअत्यंत खतरनाक।\n• पानी और खाना उपयोगी नहीं।\n• लंबे समय तक रहना मना; सिर्फ थोड़ी देर सुरक्षा के साथ।\n",
     "legend_safe": "सुरक्षित",
     "legend_title": "दिशा-सूचक",
+    "license_full": "यह प्रोजेक्ट <a href=\"/LICENSE\" target=\"_blank\">GNU GPLv3</a> लाइसेंस के तहत बढ़ता है। पूरा पाठ रिपोजिटरी की मूल डायरेक्टरी और GNU की साइट पर है। आप कोड का अध्ययन, साझा और संशोधन कर सकते हैं, बशर्ते ये स्वतंत्रताएँ आपके कार्य के साथ बनी रहें। अनुसंधान डेटा Creative Commons 1.0 लाइसेंस के तहत प्रकाशित होता है ताकि माप सार्वजनिक क्षेत्र में बने रहें।",
+    "license_title": "लाइसेंस",
     "live_chart_all": "All readings",
     "live_chart_averaged": "Averaged over [[window]]",
     "live_chart_close": "Close",
@@ -1481,6 +1538,8 @@
     "radiation_dose": "खुराक दर",
     "select_files": "कृपया कम से कम एक फ़ाइल चुनें",
     "short_link_tooltip": "शेयर करने के लिए छोटा लिंक कॉपी करने हेतु क्लिक करें",
+    "sources_full": "हम उन सभी का धन्यवाद करते हैं जो माप साझा करते हैं।\n\nगुमनाम अपलोड नक्शे पर शांत पथ बनाते हैं।\n<a href=\"https://safecast.org\" target=\"_blank\">Safecast</a> रीडिंग्स का वैश्विक अभिलेख संभालता है।\n<a href=\"https://atomfast.net\" target=\"_blank\">Atomfast</a> Atomcloud को चालू रखता है।\n<a href=\"https://radiaverse.com\" target=\"_blank\">Radioverse</a> Radiacode से मिली समझ को जोड़ता है।\n\nहर योगदान साझा तस्वीर को विस्तृत करता है; हम आपको भी सादर आमंत्रित करते हैं कि अपना योगदान जोड़ें।",
+    "sources_title": "डेटा स्रोत",
     "speed": "गति",
     "speed_filter_tooltip_accuracy": "धीमी माप ज़मीन के सबसे करीब रहती हैं, इसलिए पैदल डेटा सबसे सटीक होता है।",
     "speed_filter_tooltip_car": "कार: ड्राइव और मोबाइल मापों के लिए 7–70 किमी/घंटा।",
@@ -1496,7 +1555,8 @@
     "upload_button_tooltip": "अपना माप ट्रैक मानचित्र में जोड़ें। समर्थित प्रारूप: .kml, .kmz, .gpx, .csv, .rctrk, .json, .log। आप कई फ़ाइलें अपलोड कर सकते हैं और अपलोड के बाद ट्रैक पेज खुलेगा।",
     "upload_error": "त्रुटि",
     "waiting_for_server": "सर्वर की प्रतीक्षा कर रहे हैं...",
-    "your_location": "आपका स्थान"
+    "your_location": "आपका स्थान",
+    "legend_full_en": "This scale shows how likely a spot is safe for folk, water, and food.\nMind: the readings might not be complete, and some rays could be higher or hiding. Treat these numbers as guidance only.\n\nGreen (0–11 µR/h)\nBackground near natural.\n• Water from wells is generally safe.\n• You can grow plants without checks.\n\nYellow (11–30 µR/h)\nRaised background; take care.\n• Check water and soil.\n• Test any veg, mushrooms, or other produce before you eat.\n\nRed (30–100 µR/h)\nSerious contamination.\n• Don't drink the water.\n• Growing or eating produce from here is risky; lab tests are a must.\n\nBlack (>100 µR/h)\nCritical zone.\n• Water and food cannot be used.\n• Staying long-term is out; only short visits with protection.\n"
   },
   "hu": {
     "api_example_archive_desc": "Letölt egy tgz csomagot az összes közzétett .cim fájllal, ha a JSON archívum engedélyezett.",
@@ -1557,6 +1617,8 @@
     "legend_full_hu": "Ez a skála megmutatja, mennyire biztonságos egy hely az életre, vízre és élelemre.\nNe feledd: a mérések hiányosak lehetnek; csak iránymutató.\n\nZöld (0–11 µR/h)\nSzinte természetes háttér.\n• A kútvíz többnyire biztonságos.\n• Növényeket vizsgálat nélkül lehet termeszteni.\n\nSárga (11–30 µR/h)\nEmelkedett háttér.\n• Vizsgáld meg a vizet és a talajt.\n• Teszteld az ételt evés előtt.\n\nPiros (30–100 µR/h)\nKomoly szennyezés.\n• Ne igyál a vízből.\n• Itt termelni vagy enni veszélyes; laborvizsgálat kell.\n\nFekete (>100 µR/h)\nKritikus zóna.\n• Víz és élelem használhatatlan.\n• Csak rövid tartózkodás védelemmel.\n",
     "legend_safe": "Biztonságos",
     "legend_title": "Jelmagyarázat",
+    "license_full": "Ez a projekt a <a href=\"/LICENSE\" target=\"_blank\">GNU GPLv3</a> licenc alatt működik. A teljes szöveg a repó gyökerében és a GNU oldalán található. Szabadon tanulmányozhatod, megoszthatod és módosíthatod a kódot, feltéve hogy ezek a szabadságok a te munkáddal is együtt maradnak. A kutatási adatokat a Creative Commons 1.0 licenc alatt tesszük közzé, hogy a mérések közkinccsé maradjanak.",
+    "license_title": "Licenc",
     "live_chart_all": "All readings",
     "live_chart_averaged": "Averaged over [[window]]",
     "live_chart_close": "Close",
@@ -1606,6 +1668,8 @@
     "radiation_dose": "Dózisteljesítmény",
     "select_files": "Kérjük, válassz legalább egy fájlt",
     "short_link_tooltip": "Kattints a rövid megosztási link másolásához",
+    "sources_full": "Köszönet mindenkinek, aki megosztja a mérési adatokat.\n\nAz anonim feltöltések csendes útvonalakat rajzolnak a térképre.\n<a href=\"https://safecast.org\" target=\"_blank\">Safecast</a> globális archívumot gondoz a leolvasásokból.\n<a href=\"https://atomfast.net\" target=\"_blank\">Atomfast</a> életben tartja az Atomcloudot.\n<a href=\"https://radiaverse.com\" target=\"_blank\">Radioverse</a> összegyűjti a Radiacode tapasztalatait.\n\nMinden hozzájárulás szélesíti a közös képet; szeretettel várjuk a te adataidat is.",
+    "sources_title": "Adatforrások",
     "speed": "Sebesség",
     "speed_filter_tooltip_accuracy": "A lassabb mérések maradnak legközelebb a talajhoz, ezért a gyalogos adatok a legpontosabbak.",
     "speed_filter_tooltip_car": "Autó: 7–70 km/h az utakhoz és mobil mérésekhez.",
@@ -1621,7 +1685,8 @@
     "upload_button_tooltip": "Add hozzá a mérési útvonaladat a térképhez. Támogatott formátumok: .kml, .kmz, .gpx, .csv, .rctrk, .json, .log. Több fájlt is feltölthetsz, és a feltöltés után megnyílik az útvonal oldala.",
     "upload_error": "Hiba",
     "waiting_for_server": "Várakozás a szerverre...",
-    "your_location": "A te helyzeted"
+    "your_location": "A te helyzeted",
+    "legend_full_en": "This scale shows how likely a spot is safe for folk, water, and food.\nMind: the readings might not be complete, and some rays could be higher or hiding. Treat these numbers as guidance only.\n\nGreen (0–11 µR/h)\nBackground near natural.\n• Water from wells is generally safe.\n• You can grow plants without checks.\n\nYellow (11–30 µR/h)\nRaised background; take care.\n• Check water and soil.\n• Test any veg, mushrooms, or other produce before you eat.\n\nRed (30–100 µR/h)\nSerious contamination.\n• Don't drink the water.\n• Growing or eating produce from here is risky; lab tests are a must.\n\nBlack (>100 µR/h)\nCritical zone.\n• Water and food cannot be used.\n• Staying long-term is out; only short visits with protection.\n"
   },
   "id": {
     "api_example_archive_desc": "Mengunduh paket tgz dengan semua berkas .cim yang dipublikasikan saat arsip JSON diaktifkan.",
@@ -1682,6 +1747,8 @@
     "legend_full_id": "Skala ini menunjukkan seberapa aman suatu tempat bagi hidup, air, dan makanan.\nIngat: pengukuran bisa tidak lengkap; pakai sebagai panduan saja.\n\nHijau (0–11 µR/h)\nLatar mendekati alami.\n• Air sumur umumnya aman.\n• Tanaman bisa ditanam tanpa tes.\n\nKuning (11–30 µR/h)\nLatar meningkat.\n• Periksa air dan tanah.\n• Uji makanan sebelum dimakan.\n\nMerah (30–100 µR/h)\nKontaminasi serius.\n• Jangan minum airnya.\n• Menanam atau makan di sini berbahaya; tes laboratorium wajib.\n\nHitam (>100 µR/h)\nZona kritis.\n• Air dan makanan tak dapat digunakan.\n• Hanya boleh singgah sebentar dengan perlindungan.\n",
     "legend_safe": "Aman",
     "legend_title": "Legenda",
+    "license_full": "Proyek ini berjalan di bawah <a href=\"/LICENSE\" target=\"_blank\">GNU GPLv3</a>. Teks lengkapnya ada di direktori akar repositori dan di situs GNU. Anda boleh mempelajari, membagikan, dan mengubah kode selama kebebasan ini tetap menyertai karya Anda. Data riset diterbitkan dengan lisensi Creative Commons 1.0 agar pengukuran tetap berada di ranah publik.",
+    "license_title": "Lisensi",
     "live_chart_all": "All readings",
     "live_chart_averaged": "Averaged over [[window]]",
     "live_chart_close": "Close",
@@ -1731,6 +1798,8 @@
     "radiation_dose": "Laju dosis",
     "select_files": "Pilih setidaknya satu berkas",
     "short_link_tooltip": "Klik untuk menyalin tautan pendek berbagi",
+    "sources_full": "Kami berterima kasih kepada semua orang yang berbagi pengukuran.\n\nUnggahan anonim melukis jalur sunyi di peta.\n<a href=\"https://safecast.org\" target=\"_blank\">Safecast</a> merawat arsip pembacaan global.\n<a href=\"https://atomfast.net\" target=\"_blank\">Atomfast</a> menjaga Atomcloud tetap menyala.\n<a href=\"https://radiaverse.com\" target=\"_blank\">Radioverse</a> menghimpun wawasan dari Radiacode.\n\nSetiap kontribusi memperluas gambaran bersama; kami mengundang Anda untuk menambahkan milik Anda.",
+    "sources_title": "Sumber data",
     "speed": "Kecepatan",
     "speed_filter_tooltip_accuracy": "Pengukuran yang lebih lambat tetap paling dekat dengan tanah, sehingga data pejalan kaki paling akurat.",
     "speed_filter_tooltip_car": "Mobil: 7–70 km/jam untuk perjalanan dan pengukuran bergerak.",
@@ -1746,7 +1815,8 @@
     "upload_button_tooltip": "Tambahkan lintasan pengukuran Anda ke peta. Format yang didukung: .kml, .kmz, .gpx, .csv, .rctrk, .json, .log. Anda bisa mengunggah beberapa berkas; setelah unggah, halaman lintasan akan terbuka.",
     "upload_error": "Kesalahan",
     "waiting_for_server": "Menunggu server...",
-    "your_location": "Lokasimu"
+    "your_location": "Lokasimu",
+    "legend_full_en": "This scale shows how likely a spot is safe for folk, water, and food.\nMind: the readings might not be complete, and some rays could be higher or hiding. Treat these numbers as guidance only.\n\nGreen (0–11 µR/h)\nBackground near natural.\n• Water from wells is generally safe.\n• You can grow plants without checks.\n\nYellow (11–30 µR/h)\nRaised background; take care.\n• Check water and soil.\n• Test any veg, mushrooms, or other produce before you eat.\n\nRed (30–100 µR/h)\nSerious contamination.\n• Don't drink the water.\n• Growing or eating produce from here is risky; lab tests are a must.\n\nBlack (>100 µR/h)\nCritical zone.\n• Water and food cannot be used.\n• Staying long-term is out; only short visits with protection.\n"
   },
   "it": {
     "api_example_archive_desc": "Scarica un archivio tgz con tutti i file .cim pubblicati quando l’archivio JSON è attivo.",
@@ -1807,6 +1877,8 @@
     "legend_full_it": "Questa scala indica quanto un luogo è sicuro per vita, acqua e cibo.\nRicorda: le misurazioni possono essere incomplete; usala solo come guida.\n\nVerde (0–11 µR/h)\nFondo naturale.\n• L’acqua di pozzo è generalmente sicura.\n• Si possono coltivare piante senza test.\n\nGiallo (11–30 µR/h)\nFondo elevato.\n• Controlla acqua e terreno.\n• Verifica ogni alimento prima di mangiare.\n\nRosso (30–100 µR/h)\nContaminazione seria.\n• Non bere l’acqua.\n• Coltivare o mangiare qui è rischioso; servono esami di laboratorio.\n\nNero (>100 µR/h)\nZona critica.\n• Acqua e cibo inutilizzabili.\n• Permanenza lunga vietata; solo brevi visite con protezione.\n",
     "legend_safe": "Sicuro",
     "legend_title": "Legenda",
+    "license_full": "Questo progetto cresce sotto la <a href=\"/LICENSE\" target=\"_blank\">GNU GPLv3</a>. Il testo completo si trova nella radice del repository e sul sito GNU. Puoi studiare, condividere e modificare il codice, purché queste libertà accompagnino anche il tuo lavoro. I dati della ricerca sono pubblicati con licenza Creative Commons 1.0, così le misurazioni restano nel dominio pubblico.",
+    "license_title": "Licenza",
     "live_chart_all": "All readings",
     "live_chart_averaged": "Averaged over [[window]]",
     "live_chart_close": "Close",
@@ -1856,6 +1928,8 @@
     "radiation_dose": "Tasso di dose",
     "select_files": "Seleziona almeno un file",
     "short_link_tooltip": "Clicca per copiare un link breve da condividere",
+    "sources_full": "Ringraziamo tutte le persone che condividono le misurazioni.\n\nI caricamenti anonimi tracciano percorsi silenziosi sulla mappa.\n<a href=\"https://safecast.org\" target=\"_blank\">Safecast</a> cura un archivio globale di rilevazioni.\n<a href=\"https://atomfast.net\" target=\"_blank\">Atomfast</a> mantiene vivo l’Atomcloud.\n<a href=\"https://radiaverse.com\" target=\"_blank\">Radioverse</a> raccoglie le intuizioni provenienti da Radiacode.\n\nOgni contributo amplia l’immagine comune; ti invitiamo con calore ad aggiungere il tuo.",
+    "sources_title": "Fonti dati",
     "speed": "Velocità",
     "speed_filter_tooltip_accuracy": "Le misurazioni più lente restano più vicine al suolo, quindi i dati a piedi sono i più precisi.",
     "speed_filter_tooltip_car": "Auto: 7–70 km/h per percorsi e rilevazioni mobili.",
@@ -1871,7 +1945,8 @@
     "upload_button_tooltip": "Aggiungi il tuo percorso di misurazioni alla mappa. Formati supportati: .kml, .kmz, .gpx, .csv, .rctrk, .json, .log. Puoi caricare più file e, al termine, si aprirà la pagina del percorso.",
     "upload_error": "Errore",
     "waiting_for_server": "In attesa del server...",
-    "your_location": "La tua posizione"
+    "your_location": "La tua posizione",
+    "legend_full_en": "This scale shows how likely a spot is safe for folk, water, and food.\nMind: the readings might not be complete, and some rays could be higher or hiding. Treat these numbers as guidance only.\n\nGreen (0–11 µR/h)\nBackground near natural.\n• Water from wells is generally safe.\n• You can grow plants without checks.\n\nYellow (11–30 µR/h)\nRaised background; take care.\n• Check water and soil.\n• Test any veg, mushrooms, or other produce before you eat.\n\nRed (30–100 µR/h)\nSerious contamination.\n• Don't drink the water.\n• Growing or eating produce from here is risky; lab tests are a must.\n\nBlack (>100 µR/h)\nCritical zone.\n• Water and food cannot be used.\n• Staying long-term is out; only short visits with protection.\n"
   },
   "ja": {
     "api_example_archive_desc": "JSON アーカイブが有効な場合、公開済みの .cim ファイルをすべて含む tgz バンドルをダウンロードします。",
@@ -1932,6 +2007,8 @@
     "legend_full_ja": "この尺度は、場所が生活・水・食べ物にどれほど安全かを示します。\n測定値は不完全な場合があるので、参考程度に。\n\n緑 (0–11 µR/h)\nほぼ自然背景。\n• 井戸水は概ね安全。\n• 植物は検査なしで栽培可。\n\n黄 (11–30 µR/h)\n背景上昇。\n• 水と土を確認。\n• 食べ物は食前に検査を。\n\n赤 (30–100 µR/h)\n深刻な汚染。\n• 水は飲めない。\n• ここでの栽培・摂取は危険；検査が必須。\n\n黒 (>100 µR/h)\n極めて危険。\n• 水も食料も使えない。\n• 長期滞在は禁止；短時間で防護が必要。\n",
     "legend_safe": "安全",
     "legend_title": "凡例",
+    "license_full": "このプロジェクトは<a href=\"/LICENSE\" target=\"_blank\">GNU GPLv3</a>の下で育っています。全文はリポジトリのルートとGNUのサイトにあります。この自由があなたの成果にも受け継がれる限り、コードを学び、共有し、改変できます。研究データは Creative Commons 1.0 ライセンスで公開され、測定値がパブリックドメインにとどまるようにしています。",
+    "license_title": "ライセンス",
     "live_chart_all": "All readings",
     "live_chart_averaged": "Averaged over [[window]]",
     "live_chart_close": "Close",
@@ -1981,6 +2058,8 @@
     "radiation_dose": "線量率",
     "select_files": "少なくとも 1 つのファイルを選択してください",
     "short_link_tooltip": "クリックして共有用の短いリンクをコピー",
+    "sources_full": "計測を共有してくださるすべての方に感謝します。\n\n匿名のアップロードが地図に静かな軌跡を描きます。\n<a href=\"https://safecast.org\" target=\"_blank\">Safecast</a>は世界規模の記録を育てています。\n<a href=\"https://atomfast.net\" target=\"_blank\">Atomfast</a>はAtomcloudを灯し続けています。\n<a href=\"https://radiaverse.com\" target=\"_blank\">Radioverse</a>はRadiacodeの知見を集めています。\n\n一つひとつの貢献が共有の景色を広げます。ぜひあなたの測定もお寄せください。",
+    "sources_title": "データ提供元",
     "speed": "速度",
     "speed_filter_tooltip_accuracy": "ゆっくりした測定ほど地表に近く、徒歩データが最も精度が高くなります。",
     "speed_filter_tooltip_car": "車：走行や移動測定用に7～70km/h。",
@@ -1996,7 +2075,8 @@
     "upload_button_tooltip": "測定したトラックを地図に追加します。対応形式：.kml、.kmz、.gpx、.csv、.rctrk、.json、.log。複数のファイルをアップロードでき、完了後にトラックページが開きます。",
     "upload_error": "エラー",
     "waiting_for_server": "サーバーを待機中...",
-    "your_location": "あなたの位置"
+    "your_location": "あなたの位置",
+    "legend_full_en": "This scale shows how likely a spot is safe for folk, water, and food.\nMind: the readings might not be complete, and some rays could be higher or hiding. Treat these numbers as guidance only.\n\nGreen (0–11 µR/h)\nBackground near natural.\n• Water from wells is generally safe.\n• You can grow plants without checks.\n\nYellow (11–30 µR/h)\nRaised background; take care.\n• Check water and soil.\n• Test any veg, mushrooms, or other produce before you eat.\n\nRed (30–100 µR/h)\nSerious contamination.\n• Don't drink the water.\n• Growing or eating produce from here is risky; lab tests are a must.\n\nBlack (>100 µR/h)\nCritical zone.\n• Water and food cannot be used.\n• Staying long-term is out; only short visits with protection.\n"
   },
   "ko": {
     "api_example_archive_desc": "JSON 아카이브가 활성화된 경우 게시된 모든 .cim 파일이 포함된 tgz 번들을 다운로드합니다.",
@@ -2057,6 +2137,8 @@
     "legend_full_ko": "이 척도는 장소가 사람, 물, 음식에 얼마나 안전한지 보여줍니다.\n측정값은 불완전할 수 있으니 참고용으로만 쓰세요.\n\n초록 (0–11 µR/h)\n자연에 가까운 배경.\n• 우물물은 대체로 안전.\n• 검사 없이 재배 가능.\n\n노랑 (11–30 µR/h)\n배경 상승.\n• 물과 토양을 확인.\n• 음식은 먹기 전 검사.\n\n빨강 (30–100 µR/h)\n심각한 오염.\n• 물을 마시지 마세요.\n• 여기서 재배·섭취는 위험; 실험실 검사 필요.\n\n검정 (>100 µR/h)\n치명적 구역.\n• 물과 음식 사용 불가.\n• 보호장비로 짧게만 머무르세요.\n",
     "legend_safe": "안전",
     "legend_title": "범례",
+    "license_full": "이 프로젝트는 <a href=\"/LICENSE\" target=\"_blank\">GNU GPLv3</a> 라이선스 아래에서 성장합니다. 전문은 저장소 루트와 GNU 웹사이트에서 볼 수 있습니다. 이 자유들이 당신의 작업에도 함께한다면 코드를 공부하고, 공유하고, 수정할 수 있습니다. 연구 데이터는 Creative Commons 1.0 라이선스로 공개되어 측정값이 퍼블릭 도메인에 머물도록 합니다.",
+    "license_title": "라이선스",
     "live_chart_all": "All readings",
     "live_chart_averaged": "Averaged over [[window]]",
     "live_chart_close": "Close",
@@ -2106,6 +2188,8 @@
     "radiation_dose": "선량률",
     "select_files": "파일을 하나 이상 선택하세요",
     "short_link_tooltip": "클릭하여 짧은 공유 링크를 복사하세요",
+    "sources_full": "측정을 나눠 주시는 모든 분들께 감사드립니다.\n\n익명 업로드가 지도에 조용한 궤적을 그려 줍니다.\n<a href=\"https://safecast.org\" target=\"_blank\">Safecast</a>는 전 세계 읽기 기록을 가꿉니다.\n<a href=\"https://atomfast.net\" target=\"_blank\">Atomfast</a>는 Atomcloud의 불을 지킵니다.\n<a href=\"https://radiaverse.com\" target=\"_blank\">Radioverse</a>는 Radiacode에서 얻은 통찰을 모읍니다.\n\n각 기여가 공동의 그림을 넓혀 줍니다. 여러분의 데이터도 기꺼이 기다리고 있습니다.",
+    "sources_title": "데이터 출처",
     "speed": "속도",
     "speed_filter_tooltip_accuracy": "속도가 느릴수록 지면과 가까이 유지되므로 보행 데이터가 가장 정확합니다.",
     "speed_filter_tooltip_car": "자동차: 주행 및 이동 측정을 위한 7–70km/h.",
@@ -2121,7 +2205,8 @@
     "upload_button_tooltip": "측정 트랙을 지도에 추가하세요. 지원 형식: .kml, .kmz, .gpx, .csv, .rctrk, .json, .log. 여러 파일을 업로드할 수 있으며, 업로드가 완료되면 트랙 페이지가 열립니다.",
     "upload_error": "오류",
     "waiting_for_server": "서버 대기 중...",
-    "your_location": "내 위치"
+    "your_location": "내 위치",
+    "legend_full_en": "This scale shows how likely a spot is safe for folk, water, and food.\nMind: the readings might not be complete, and some rays could be higher or hiding. Treat these numbers as guidance only.\n\nGreen (0–11 µR/h)\nBackground near natural.\n• Water from wells is generally safe.\n• You can grow plants without checks.\n\nYellow (11–30 µR/h)\nRaised background; take care.\n• Check water and soil.\n• Test any veg, mushrooms, or other produce before you eat.\n\nRed (30–100 µR/h)\nSerious contamination.\n• Don't drink the water.\n• Growing or eating produce from here is risky; lab tests are a must.\n\nBlack (>100 µR/h)\nCritical zone.\n• Water and food cannot be used.\n• Staying long-term is out; only short visits with protection.\n"
   },
   "ms": {
     "api_example_archive_desc": "Memuat turun pakej tgz dengan semua fail .cim yang diterbitkan apabila arkib JSON diaktifkan.",
@@ -2182,6 +2267,8 @@
     "legend_full_ms": "Skala ini menunjukkan tahap keselamatan tempat untuk kehidupan, air dan makanan.\nIngat: bacaan mungkin tidak lengkap; guna sebagai panduan sahaja.\n\nHijau (0–11 µR/h)\nLatar hampir semula jadi.\n• Air perigi biasanya selamat.\n• Boleh menanam tanpa ujian.\n\nKuning (11–30 µR/h)\nLatar meningkat.\n• Periksa air dan tanah.\n• Uji makanan sebelum makan.\n\nMerah (30–100 µR/h)\nPencemaran serius.\n• Jangan minum air.\n• Menanam atau makan di sini berbahaya; perlu ujian makmal.\n\nHitam (>100 µR/h)\nZon kritikal.\n• Air dan makanan tidak boleh digunakan.\n• Hanya lawatan singkat dengan perlindungan.\n",
     "legend_safe": "Selamat",
     "legend_title": "Legenda",
+    "license_full": "Projek ini berkembang di bawah <a href=\"/LICENSE\" target=\"_blank\">GNU GPLv3</a>. Teks penuh berada di direktori akar repositori dan di laman GNU. Anda boleh mengkaji, berkongsi dan mengubah kod selagi kebebasan ini kekal bersama hasil kerja anda. Data penyelidikan diterbitkan di bawah lesen Creative Commons 1.0 agar bacaan kekal dalam domain awam.",
+    "license_title": "Lesen",
     "live_chart_all": "All readings",
     "live_chart_averaged": "Averaged over [[window]]",
     "live_chart_close": "Close",
@@ -2231,6 +2318,8 @@
     "radiation_dose": "Kadar dos",
     "select_files": "Sila pilih sekurang-kurangnya satu fail",
     "short_link_tooltip": "Klik untuk menyalin pautan ringkas perkongsian",
+    "sources_full": "Kami berterima kasih kepada semua yang berkongsi bacaan.\n\nMuat naik tanpa nama melakar jejak sunyi di atas peta.\n<a href=\"https://safecast.org\" target=\"_blank\">Safecast</a> memelihara arkib global bacaan.\n<a href=\"https://atomfast.net\" target=\"_blank\">Atomfast</a> memastikan Atomcloud terus bernyala.\n<a href=\"https://radiaverse.com\" target=\"_blank\">Radioverse</a> menghimpun pandangan daripada Radiacode.\n\nSetiap sumbangan meluaskan gambaran bersama; kami mengalu-alukan anda untuk menambah milik anda.",
+    "sources_title": "Sumber data",
     "speed": "Kelajuan",
     "speed_filter_tooltip_accuracy": "Pengukuran yang lebih perlahan kekal paling hampir dengan tanah, jadi data pejalan kaki paling tepat.",
     "speed_filter_tooltip_car": "Kereta: 7–70 km/j untuk pemanduan dan tinjauan bergerak.",
@@ -2246,7 +2335,8 @@
     "upload_button_tooltip": "Tambahkan jejak pengukuran anda pada peta. Format yang disokong: .kml, .kmz, .gpx, .csv, .rctrk, .json, .log. Anda boleh memuat naik berbilang fail; selepas muat naik, halaman jejak akan dibuka.",
     "upload_error": "Ralat",
     "waiting_for_server": "Menunggu pelayan...",
-    "your_location": "Lokasi anda"
+    "your_location": "Lokasi anda",
+    "legend_full_en": "This scale shows how likely a spot is safe for folk, water, and food.\nMind: the readings might not be complete, and some rays could be higher or hiding. Treat these numbers as guidance only.\n\nGreen (0–11 µR/h)\nBackground near natural.\n• Water from wells is generally safe.\n• You can grow plants without checks.\n\nYellow (11–30 µR/h)\nRaised background; take care.\n• Check water and soil.\n• Test any veg, mushrooms, or other produce before you eat.\n\nRed (30–100 µR/h)\nSerious contamination.\n• Don't drink the water.\n• Growing or eating produce from here is risky; lab tests are a must.\n\nBlack (>100 µR/h)\nCritical zone.\n• Water and food cannot be used.\n• Staying long-term is out; only short visits with protection.\n"
   },
   "nl": {
     "api_example_archive_desc": "Downloadt een tgz-pakket met alle gepubliceerde .cim-bestanden wanneer het JSON-archief is ingeschakeld.",
@@ -2307,6 +2397,8 @@
     "legend_full_nl": "Deze schaal laat zien hoe veilig een plek is voor leven, water en eten.\nOnthoud: metingen kunnen onvolledig zijn; gebruik het alleen als richtlijn.\n\nGroen (0–11 µR/h)\nBijna natuurlijke achtergrond.\n• Pompwater is meestal veilig.\n• Je kunt zonder tests planten kweken.\n\nGeel (11–30 µR/h)\nVerhoogde achtergrond.\n• Controleer water en bodem.\n• Test voedsel voordat je het eet.\n\nRood (30–100 µR/h)\nErnstige besmetting.\n• Drink het water niet.\n• Telen of eten van hier is riskant; labtests nodig.\n\nZwart (>100 µR/h)\nKritieke zone.\n• Water en voedsel onbruikbaar.\n• Alleen kort verblijf met bescherming.\n",
     "legend_safe": "Veilig",
     "legend_title": "Legenda",
+    "license_full": "Dit project valt onder de <a href=\"/LICENSE\" target=\"_blank\">GNU GPLv3</a>. De volledige tekst staat in de hoofdmap van de repository en op de GNU-site. Je mag de code bestuderen, delen en aanpassen, zolang deze vrijheden met jouw werk meereizen. De onderzoeksgegevens worden uitgegeven onder de Creative Commons 1.0-licentie, zodat de metingen publiek domein blijven.",
+    "license_title": "Licentie",
     "live_chart_all": "All readings",
     "live_chart_averaged": "Averaged over [[window]]",
     "live_chart_close": "Close",
@@ -2356,6 +2448,8 @@
     "radiation_dose": "Dosisvermogen",
     "select_files": "Selecteer alstublieft minstens één bestand",
     "short_link_tooltip": "Klik om een korte deellink te kopiëren",
+    "sources_full": "Dank aan iedereen die metingen deelt.\n\nAnonieme uploads tekenen stille paden op de kaart.\n<a href=\"https://safecast.org\" target=\"_blank\">Safecast</a> onderhoudt een wereldwijd archief van metingen.\n<a href=\"https://atomfast.net\" target=\"_blank\">Atomfast</a> houdt de Atomcloud brandend.\n<a href=\"https://radiaverse.com\" target=\"_blank\">Radioverse</a> verzamelt inzichten uit Radiacode.\n\nElke bijdrage verbreedt het gezamenlijke beeld; we nodigen je van harte uit om ook de jouwe toe te voegen.",
+    "sources_title": "Databronnen",
     "speed": "Snelheid",
     "speed_filter_tooltip_accuracy": "Langzamere metingen blijven het dichtst bij de grond; voetgangersgegevens zijn dus het nauwkeurigst.",
     "speed_filter_tooltip_car": "Auto: 7–70 km/u voor ritten en mobiele metingen.",
@@ -2371,7 +2465,8 @@
     "upload_button_tooltip": "Voeg uw meettraject toe aan de kaart. Ondersteunde formaten: .kml, .kmz, .gpx, .csv, .rctrk, .json, .log. U kunt meerdere bestanden uploaden en na het uploaden wordt de trajectpagina geopend.",
     "upload_error": "Fout",
     "waiting_for_server": "Wachten op server...",
-    "your_location": "Uw locatie"
+    "your_location": "Uw locatie",
+    "legend_full_en": "This scale shows how likely a spot is safe for folk, water, and food.\nMind: the readings might not be complete, and some rays could be higher or hiding. Treat these numbers as guidance only.\n\nGreen (0–11 µR/h)\nBackground near natural.\n• Water from wells is generally safe.\n• You can grow plants without checks.\n\nYellow (11–30 µR/h)\nRaised background; take care.\n• Check water and soil.\n• Test any veg, mushrooms, or other produce before you eat.\n\nRed (30–100 µR/h)\nSerious contamination.\n• Don't drink the water.\n• Growing or eating produce from here is risky; lab tests are a must.\n\nBlack (>100 µR/h)\nCritical zone.\n• Water and food cannot be used.\n• Staying long-term is out; only short visits with protection.\n"
   },
   "no": {
     "api_example_archive_desc": "Laster ned en tgz-pakke med alle publiserte .cim-filer når JSON-arkivet er aktivert.",
@@ -2432,6 +2527,8 @@
     "legend_full_no": "Denne skalaen viser hvor trygg et sted er for liv, vann og mat.\nHusk: målingene kan være ufullstendige; bruk den kun som veiledning.\n\nGrønn (0–11 µR/h)\nNær naturlig bakgrunn.\n• Brønnvann er vanligvis trygt.\n• Planter kan dyrkes uten tester.\n\nGul (11–30 µR/h)\nBakgrunn økt.\n• Sjekk vann og jord.\n• Test all mat før du spiser.\n\nRød (30–100 µR/h)\nAlvorlig forurensning.\n• Ikke drikk vannet.\n• Dyrking eller spising her er farlig; laboratorietester må til.\n\nSvart (>100 µR/h)\nKritisk sone.\n• Vann og mat ubrukelige.\n• Bare korte besøk med beskyttelse.\n",
     "legend_safe": "Trygt",
     "legend_title": "Forklaring",
+    "license_full": "Dette prosjektet lever under <a href=\"/LICENSE\" target=\"_blank\">GNU GPLv3</a>. Hele teksten ligger i rotkatalogen til repoet og på GNU-nettstedet. Du kan studere, dele og endre koden så lenge disse frihetene følger arbeidet ditt videre. Forskningsdata publiseres under Creative Commons 1.0 slik at målingene forblir i det offentlige domenet.",
+    "license_title": "Lisens",
     "live_chart_all": "All readings",
     "live_chart_averaged": "Averaged over [[window]]",
     "live_chart_close": "Close",
@@ -2481,6 +2578,8 @@
     "radiation_dose": "Dosehastighet",
     "select_files": "Velg minst én fil",
     "short_link_tooltip": "Klikk for å kopiere en kort delingslenke",
+    "sources_full": "Vi takker alle som deler målinger.\n\nAnonyme opplastinger tegner stille spor på kartet.\n<a href=\"https://safecast.org\" target=\"_blank\">Safecast</a> pleier et verdensomspennende arkiv av måledata.\n<a href=\"https://atomfast.net\" target=\"_blank\">Atomfast</a> holder Atomcloud i gang.\n<a href=\"https://radiaverse.com\" target=\"_blank\">Radioverse</a> samler innsikt fra Radiacode.\n\nHver bidrag utvider det felles bildet; vi ønsker ditt bidrag varmt velkommen.",
+    "sources_title": "Datakilder",
     "speed": "Hastighet",
     "speed_filter_tooltip_accuracy": "Saktere målinger holder seg nærmest bakken, derfor er data til fots mest presise.",
     "speed_filter_tooltip_car": "Bil: 7–70 km/t for kjøreturer og mobile målinger.",
@@ -2496,7 +2595,8 @@
     "upload_button_tooltip": "Legg til måleruten din på kartet. Støttede formater: .kml, .kmz, .gpx, .csv, .rctrk, .json, .log. Du kan laste opp flere filer, og etter opplasting åpnes sporsiden.",
     "upload_error": "Feil",
     "waiting_for_server": "Venter på serveren...",
-    "your_location": "Din posisjon"
+    "your_location": "Din posisjon",
+    "legend_full_en": "This scale shows how likely a spot is safe for folk, water, and food.\nMind: the readings might not be complete, and some rays could be higher or hiding. Treat these numbers as guidance only.\n\nGreen (0–11 µR/h)\nBackground near natural.\n• Water from wells is generally safe.\n• You can grow plants without checks.\n\nYellow (11–30 µR/h)\nRaised background; take care.\n• Check water and soil.\n• Test any veg, mushrooms, or other produce before you eat.\n\nRed (30–100 µR/h)\nSerious contamination.\n• Don't drink the water.\n• Growing or eating produce from here is risky; lab tests are a must.\n\nBlack (>100 µR/h)\nCritical zone.\n• Water and food cannot be used.\n• Staying long-term is out; only short visits with protection.\n"
   },
   "pl": {
     "api_example_archive_desc": "Pobiera paczkę tgz ze wszystkimi opublikowanymi plikami .cim, gdy archiwum JSON jest włączone.",
@@ -2557,6 +2657,8 @@
     "legend_full_pl": "Ta skala pokazuje, na ile miejsce jest bezpieczne dla życia, wody i jedzenia.\nPamiętaj: pomiary mogą być niepełne; traktuj je jedynie orientacyjnie.\n\nZielony (0–11 µR/h)\nTło prawie naturalne.\n• Woda ze studni zazwyczaj bezpieczna.\n• Można uprawiać bez testów.\n\nŻółty (11–30 µR/h)\nTło podwyższone.\n• Sprawdź wodę i glebę.\n• Zbadaj żywność przed spożyciem.\n\nCzerwony (30–100 µR/h)\nPoważne skażenie.\n• Wody nie pij.\n• Uprawa lub jedzenie stąd jest ryzykowne; konieczne badania lab.\n\nCzarny (>100 µR/h)\nStrefa krytyczna.\n• Woda i jedzenie bezużyteczne.\n• Tylko krótki pobyt z ochroną.\n",
     "legend_safe": "Bezpieczne",
     "legend_title": "Legenda",
+    "license_full": "Ten projekt rozwija się na licencji <a href=\"/LICENSE\" target=\"_blank\">GNU GPLv3</a>. Pełny tekst znajdziesz w katalogu głównym repozytorium oraz na stronie GNU. Możesz badać, udostępniać i modyfikować kod, o ile te wolności pozostają również przy Twojej pracy. Dane badawcze udostępniamy na licencji Creative Commons 1.0, dzięki czemu pomiary pozostają w domenie publicznej.",
+    "license_title": "Licencja",
     "live_chart_all": "All readings",
     "live_chart_averaged": "Averaged over [[window]]",
     "live_chart_close": "Close",
@@ -2606,6 +2708,8 @@
     "radiation_dose": "Moc dawki",
     "select_files": "Wybierz co najmniej jeden plik",
     "short_link_tooltip": "Kliknij, aby skopiować krótki link do udostępnienia",
+    "sources_full": "Dziękujemy wszystkim, którzy dzielą się pomiarami.\n\nAnonimowe przesłania rysują ciche ścieżki na mapie.\n<a href=\"https://safecast.org\" target=\"_blank\">Safecast</a> opiekuje się globalnym archiwum odczytów.\n<a href=\"https://atomfast.net\" target=\"_blank\">Atomfast</a> podtrzymuje działanie Atomcloud.\n<a href=\"https://radiaverse.com\" target=\"_blank\">Radioverse</a> zbiera wnioski z Radiacode.\n\nKażdy wkład poszerza wspólny obraz; serdecznie zapraszamy, by dodać także swój.",
+    "sources_title": "Źródła danych",
     "speed": "Prędkość",
     "speed_filter_tooltip_accuracy": "Bardziej powolne pomiary pozostają najbliżej ziemi, dlatego dane piesze są najdokładniejsze.",
     "speed_filter_tooltip_car": "Samochód: 7–70 km/h dla przejazdów i mobilnych pomiarów.",
@@ -2621,7 +2725,8 @@
     "upload_button_tooltip": "Dodaj swoją trasę pomiarów do mapy. Obsługiwane formaty: .kml, .kmz, .gpx, .csv, .rctrk, .json, .log. Możesz przesłać wiele plików, a po przesłaniu otworzy się strona trasy.",
     "upload_error": "Błąd",
     "waiting_for_server": "Oczekiwanie na serwer...",
-    "your_location": "Twoja lokalizacja"
+    "your_location": "Twoja lokalizacja",
+    "legend_full_en": "This scale shows how likely a spot is safe for folk, water, and food.\nMind: the readings might not be complete, and some rays could be higher or hiding. Treat these numbers as guidance only.\n\nGreen (0–11 µR/h)\nBackground near natural.\n• Water from wells is generally safe.\n• You can grow plants without checks.\n\nYellow (11–30 µR/h)\nRaised background; take care.\n• Check water and soil.\n• Test any veg, mushrooms, or other produce before you eat.\n\nRed (30–100 µR/h)\nSerious contamination.\n• Don't drink the water.\n• Growing or eating produce from here is risky; lab tests are a must.\n\nBlack (>100 µR/h)\nCritical zone.\n• Water and food cannot be used.\n• Staying long-term is out; only short visits with protection.\n"
   },
   "pt": {
     "api_example_archive_desc": "Baixa um pacote tgz com todos os arquivos .cim publicados quando o arquivo JSON está ativado.",
@@ -2682,6 +2787,8 @@
     "legend_full_pt": "Esta escala mostra quão seguro é um lugar para viver, beber e comer.\nLembre: as leituras podem estar incompletas; use apenas como guia.\n\nVerde (0–11 µR/h)\nFundo natural.\n• Água de poço geralmente segura.\n• Pode-se plantar sem testes.\n\nAmarelo (11–30 µR/h)\nFundo elevado.\n• Verifique água e solo.\n• Analise qualquer alimento antes de comer.\n\nVermelho (30–100 µR/h)\nContaminação séria.\n• Não beba a água.\n• Cultivar ou comer aqui é arriscado; exames laboratoriais obrigatórios.\n\nPreto (>100 µR/h)\nZona crítica.\n• Água e comida inutilizáveis.\n• Ficar muito tempo é impossível; apenas visitas breves com proteção.\n",
     "legend_safe": "Seguro",
     "legend_title": "Legenda",
+    "license_full": "Este projeto cresce sob a <a href=\"/LICENSE\" target=\"_blank\">GNU GPLv3</a>. O texto completo está na raiz do repositório e no site da GNU. Você pode estudar, compartilhar e modificar o código, desde que essas liberdades acompanhem o seu trabalho. Os dados de pesquisa são publicados sob a licença Creative Commons 1.0 para que as medições permaneçam em domínio público.",
+    "license_title": "Licença",
     "live_chart_all": "All readings",
     "live_chart_averaged": "Averaged over [[window]]",
     "live_chart_close": "Close",
@@ -2731,6 +2838,8 @@
     "radiation_dose": "Taxa de dose",
     "select_files": "Selecione pelo menos um arquivo",
     "short_link_tooltip": "Clique para copiar um link curto de compartilhamento",
+    "sources_full": "Agradecemos a todas as pessoas que compartilham medições.\n\nEnvios anônimos traçam caminhos silenciosos no mapa.\n<a href=\"https://safecast.org\" target=\"_blank\">Safecast</a> mantém um arquivo global de leituras.\n<a href=\"https://atomfast.net\" target=\"_blank\">Atomfast</a> mantém a Atomcloud acesa.\n<a href=\"https://radiaverse.com\" target=\"_blank\">Radioverse</a> reúne os aprendizados da Radiacode.\n\nCada contribuição amplia o panorama comum; convidamos você, de coração, a trazer a sua.",
+    "sources_title": "Fontes de dados",
     "speed": "Velocidade",
     "speed_filter_tooltip_accuracy": "Medições mais lentas ficam mais próximas do solo; por isso os dados de pedestres são os mais precisos.",
     "speed_filter_tooltip_car": "Carro: 7–70 km/h para deslocamentos e medições móveis.",
@@ -2746,7 +2855,8 @@
     "upload_button_tooltip": "Adicione a sua rota de medições ao mapa. Formatos suportados: .kml, .kmz, .gpx, .csv, .rctrk, .json, .log. É possível enviar vários ficheiros e, após o envio, abrirá a página da rota.",
     "upload_error": "Erro",
     "waiting_for_server": "Aguardando o servidor...",
-    "your_location": "Sua localização"
+    "your_location": "Sua localização",
+    "legend_full_en": "This scale shows how likely a spot is safe for folk, water, and food.\nMind: the readings might not be complete, and some rays could be higher or hiding. Treat these numbers as guidance only.\n\nGreen (0–11 µR/h)\nBackground near natural.\n• Water from wells is generally safe.\n• You can grow plants without checks.\n\nYellow (11–30 µR/h)\nRaised background; take care.\n• Check water and soil.\n• Test any veg, mushrooms, or other produce before you eat.\n\nRed (30–100 µR/h)\nSerious contamination.\n• Don't drink the water.\n• Growing or eating produce from here is risky; lab tests are a must.\n\nBlack (>100 µR/h)\nCritical zone.\n• Water and food cannot be used.\n• Staying long-term is out; only short visits with protection.\n"
   },
   "ru": {
     "api_example_archive_desc": "Скачивает архив tgz со всеми опубликованными файлами .cim, если включён JSON‑архив.",
@@ -2807,7 +2917,7 @@
     "legend_full_ru": "Эта шкала показывает, насколько место безопасно для людей, воды и еды.\nПомните: измерения могут быть неполными, радиация может быть выше или скрыта. Относитесь к числам как к ориентиру.\n\nЗеленая (0–11 µR/h)\nФон близок к естественному.\n• Вода из скважин обычно безопасна.\n• Можно выращивать растения без проверок.\n\nЖелтая (11–30 µR/h)\nФон повышен; будьте осторожны.\n• Проверяйте воду и почву.\n• Тестируйте овощи, грибы и другие продукты перед употреблением.\n\nКрасная (30–100 µR/h)\nСерьёзное загрязнение.\n• Воду пить нельзя.\n• Выращивать или есть продукты отсюда рискованно; нужны анализы.\n\nЧёрная (>100 µR/h)\nКритическая зона.\n• Воду и пищу использовать нельзя.\n• Долгое пребывание исключено; только короткие визиты с защитой.",
     "legend_safe": "Безопасно",
     "legend_title": "Легенда",
-    "license_full": "Проект живёт под лицензией <a href=\"/LICENSE\" target=\"_blank\">GNU GPLv3</a>. Полный текст лежит в корне репозитория и на сайте GNU. Вы вольны изучать, распространять и менять код, сохраняя эти свободы для других.",
+    "license_full": "Проект живёт под лицензией <a href=\"/LICENSE\" target=\"_blank\">GNU GPLv3</a>. Полный текст лежит в корне репозитория и на сайте GNU. Вы вольны изучать, распространять и менять код, сохраняя эти свободы для других. Исследовательские данные публикуются по лицензии Creative Commons 1.0, чтобы измерения оставались в общественном достоянии.",
     "license_title": "Лицензия",
     "live_chart_all": "Вся история наблюдений",
     "live_chart_averaged": "Среднее за [[window]]",
@@ -2875,7 +2985,8 @@
     "upload_button_tooltip": "Добавьте свой трек замеров на карту. Поддерживаются форматы: .kml, .kmz, .gpx, .csv, .rctrk, .json, .log. Можно загрузить несколько файлов, после чего откроется страница трека.",
     "upload_error": "Ошибка",
     "waiting_for_server": "Ожидание сервера...",
-    "your_location": "Ваше местоположение"
+    "your_location": "Ваше местоположение",
+    "legend_full_en": "This scale shows how likely a spot is safe for folk, water, and food.\nMind: the readings might not be complete, and some rays could be higher or hiding. Treat these numbers as guidance only.\n\nGreen (0–11 µR/h)\nBackground near natural.\n• Water from wells is generally safe.\n• You can grow plants without checks.\n\nYellow (11–30 µR/h)\nRaised background; take care.\n• Check water and soil.\n• Test any veg, mushrooms, or other produce before you eat.\n\nRed (30–100 µR/h)\nSerious contamination.\n• Don't drink the water.\n• Growing or eating produce from here is risky; lab tests are a must.\n\nBlack (>100 µR/h)\nCritical zone.\n• Water and food cannot be used.\n• Staying long-term is out; only short visits with protection.\n"
   },
   "sv": {
     "api_example_archive_desc": "Hämtar ett tgz-paket med alla publicerade .cim-filer när JSON-arkivet är aktiverat.",
@@ -2936,6 +3047,8 @@
     "legend_full_sv": "Denna skala visar hur säker en plats är för liv, vatten och mat.\nKom ihåg: mätningar kan vara ofullständiga; använd den bara som vägledning.\n\nGrön (0–11 µR/h)\nNästan naturlig bakgrund.\n• Brunnsvatten oftast säkert.\n• Växter kan odlas utan tester.\n\nGul (11–30 µR/h)\nFörhöjd bakgrund.\n• Kontrollera vatten och jord.\n• Undersök all mat innan du äter.\n\nRöd (30–100 µR/h)\nAllvarlig förorening.\n• Drick inte vattnet.\n• Odling eller konsumtion här är riskabelt; labbtester krävs.\n\nSvart (>100 µR/h)\nKritisk zon.\n• Vatten och mat oanvändbara.\n• Endast korta besök med skydd.\n",
     "legend_safe": "Säker",
     "legend_title": "Förklaring",
+    "license_full": "Detta projekt verkar under <a href=\"/LICENSE\" target=\"_blank\">GNU GPLv3</a>. Hela texten finns i repots rot och på GNU:s webbplats. Du får studera, dela och förändra koden så länge dessa friheter följer med ditt arbete. Forskningsdata publiceras under licensen Creative Commons 1.0 så att mätningarna förblir i den offentliga domänen.",
+    "license_title": "Licens",
     "live_chart_all": "All readings",
     "live_chart_averaged": "Averaged over [[window]]",
     "live_chart_close": "Close",
@@ -2985,6 +3098,8 @@
     "radiation_dose": "Doshastighet",
     "select_files": "Välj minst en fil",
     "short_link_tooltip": "Klicka för att kopiera en kort delningslänk",
+    "sources_full": "Vi tackar alla som delar mätningar.\n\nAnonyma uppladdningar ritar tysta spår på kartan.\n<a href=\"https://safecast.org\" target=\"_blank\">Safecast</a> vårdar ett globalt arkiv av avläsningar.\n<a href=\"https://atomfast.net\" target=\"_blank\">Atomfast</a> håller Atomcloud vid liv.\n<a href=\"https://radiaverse.com\" target=\"_blank\">Radioverse</a> samlar insikter från Radiacode.\n\nVarje bidrag vidgar den gemensamma bilden; vi välkomnar varmt även ditt.",
+    "sources_title": "Datakällor",
     "speed": "Hastighet",
     "speed_filter_tooltip_accuracy": "Långsammare mätningar ligger närmast marken, därför är data till fots mest precisa.",
     "speed_filter_tooltip_car": "Bil: 7–70 km/h för körningar och mobila mätningar.",
@@ -3000,7 +3115,8 @@
     "upload_button_tooltip": "Lägg till din mätspårning på kartan. Format som stöds: .kml, .kmz, .gpx, .csv, .rctrk, .json, .log. Du kan ladda upp flera filer och efter överföringen öppnas spårsidan.",
     "upload_error": "Fel",
     "waiting_for_server": "Väntar på servern...",
-    "your_location": "Din plats"
+    "your_location": "Din plats",
+    "legend_full_en": "This scale shows how likely a spot is safe for folk, water, and food.\nMind: the readings might not be complete, and some rays could be higher or hiding. Treat these numbers as guidance only.\n\nGreen (0–11 µR/h)\nBackground near natural.\n• Water from wells is generally safe.\n• You can grow plants without checks.\n\nYellow (11–30 µR/h)\nRaised background; take care.\n• Check water and soil.\n• Test any veg, mushrooms, or other produce before you eat.\n\nRed (30–100 µR/h)\nSerious contamination.\n• Don't drink the water.\n• Growing or eating produce from here is risky; lab tests are a must.\n\nBlack (>100 µR/h)\nCritical zone.\n• Water and food cannot be used.\n• Staying long-term is out; only short visits with protection.\n"
   },
   "th": {
     "api_example_archive_desc": "ดาวน์โหลดแพ็กเกจ tgz ที่มีไฟล์ .cim ทั้งหมดเมื่อเปิดใช้งานคลัง JSON",
@@ -3061,6 +3177,8 @@
     "legend_full_th": "สเกลนี้บอกว่าพื้นที่ปลอดภัยต่อชีวิต น้ำ และอาหารแค่ไหน\nจำไว้: การวัดอาจไม่ครบถ้วน ใช้เป็นเพียงแนวทาง\n\nเขียว (0–11 µR/h)\nฉากหลังเกือบธรรมชาติ\n• น้ำบ่อส่วนใหญ่ปลอดภัย\n• ปลูกพืชได้โดยไม่ต้องตรวจ\n\nเหลือง (11–30 µR/h)\nฉากหลังสูงขึ้น\n• ตรวจน้ำและดิน\n• ตรวจอาหารก่อนกิน\n\nแดง (30–100 µR/h)\nปนเปื้อนรุนแรง\n• ห้ามดื่มน้ำ\n• ปลูกหรือกินที่นี่เสี่ยง ต้องตรวจแลบ\n\nดำ (>100 µR/h)\nเขตวิกฤต\n• น้ำและอาหารใช้ไม่ได้\n• อยู่ได้เพียงสั้นๆ พร้อมอุปกรณ์ป้องกัน\n",
     "legend_safe": "ปลอดภัย",
     "legend_title": "คำอธิบาย",
+    "license_full": "โครงการนี้ดำเนินงานภายใต้สัญญาอนุญาต <a href=\"/LICENSE\" target=\"_blank\">GNU GPLv3</a> ข้อความฉบับเต็มอยู่ที่รากของรีโพซิทอรีและบนเว็บไซต์ GNU คุณสามารถศึกษา แชร์ และปรับแก้โค้ดได้ ตราบใดที่เสรีภาพเหล่านี้ติดตามผลงานของคุณไปด้วย ข้อมูลการวิจัยเผยแพร่ภายใต้สัญญาอนุญาต Creative Commons 1.0 เพื่อให้ค่าการวัดยังคงเป็นสาธารณะ.",
+    "license_title": "สัญญาอนุญาต",
     "live_chart_all": "All readings",
     "live_chart_averaged": "Averaged over [[window]]",
     "live_chart_close": "Close",
@@ -3110,6 +3228,8 @@
     "radiation_dose": "อัตราปริมาณรังสี",
     "select_files": "โปรดเลือกอย่างน้อยหนึ่งไฟล์",
     "short_link_tooltip": "คลิกเพื่อคัดลอกลิงก์สั้นสำหรับแชร์",
+    "sources_full": "เราขอขอบคุณทุกคนที่แบ่งปันการวัดค่า\n\nการอัปโหลดแบบไม่ระบุชื่อวาดเส้นทางเงียบ ๆ บนแผนที่\n<a href=\"https://safecast.org\" target=\"_blank\">Safecast</a> ดูแลคลังข้อมูลการอ่านระดับโลก\n<a href=\"https://atomfast.net\" target=\"_blank\">Atomfast</a> รักษาให้ Atomcloud สว่างอยู่เสมอ\n<a href=\"https://radiaverse.com\" target=\"_blank\">Radioverse</a> รวบรวมองค์ความรู้จาก Radiacode\n\nทุกการมีส่วนร่วมช่วยขยายภาพรวมร่วมกัน เราขอเชิญคุณมาร่วมเติมข้อมูลของคุณด้วยนะ",
+    "sources_title": "แหล่งข้อมูล",
     "speed": "ความเร็ว",
     "speed_filter_tooltip_accuracy": "การวัดที่ช้ากว่าจะอยู่ใกล้พื้นที่สุด ดังนั้นข้อมูลการเดินเท้าจึงแม่นยำที่สุด.",
     "speed_filter_tooltip_car": "รถยนต์: 7–70 กม./ชม. สำหรับการขับขี่และการวัดแบบเคลื่อนที่.",
@@ -3125,7 +3245,8 @@
     "upload_button_tooltip": "เพิ่มเส้นทางการวัดของคุณลงในแผนที่ รูปแบบที่รองรับ: .kml, .kmz, .gpx, .csv, .rctrk, .json, .log คุณสามารถอัปโหลดหลายไฟล์ได้ หลังจากอัปโหลดแล้วจะเปิดหน้าของเส้นทาง",
     "upload_error": "ข้อผิดพลาด",
     "waiting_for_server": "กำลังรอเซิร์ฟเวอร์...",
-    "your_location": "ตำแหน่งของคุณ"
+    "your_location": "ตำแหน่งของคุณ",
+    "legend_full_en": "This scale shows how likely a spot is safe for folk, water, and food.\nMind: the readings might not be complete, and some rays could be higher or hiding. Treat these numbers as guidance only.\n\nGreen (0–11 µR/h)\nBackground near natural.\n• Water from wells is generally safe.\n• You can grow plants without checks.\n\nYellow (11–30 µR/h)\nRaised background; take care.\n• Check water and soil.\n• Test any veg, mushrooms, or other produce before you eat.\n\nRed (30–100 µR/h)\nSerious contamination.\n• Don't drink the water.\n• Growing or eating produce from here is risky; lab tests are a must.\n\nBlack (>100 µR/h)\nCritical zone.\n• Water and food cannot be used.\n• Staying long-term is out; only short visits with protection.\n"
   },
   "tr": {
     "api_example_archive_desc": "JSON arşivi etkinse yayımlanmış tüm .cim dosyalarıyla bir tgz paketi indirir.",
@@ -3186,6 +3307,8 @@
     "legend_full_tr": "Bu ölçek, bir yerin yaşam, su ve gıda için ne kadar güvenli olduğunu gösterir.\nUnutma: ölçümler eksik olabilir; yalnızca rehber olarak kullan.\n\nYeşil (0–11 µR/h)\nDoğal arka plan.\n• Kuyu suyu genelde güvenlidir.\n• Test olmadan bitki yetiştirilebilir.\n\nSarı (11–30 µR/h)\nYükselmiş arka plan.\n• Su ve toprağı kontrol et.\n• Her gıdayı yemeden önce test et.\n\nKırmızı (30–100 µR/h)\nCiddi kirlilik.\n• Suyu içme.\n• Burada yetiştirmek veya yemek riskli; lab testleri şart.\n\nSiyah (>100 µR/h)\nKritik bölge.\n• Su ve yiyecek kullanılamaz.\n• Uzun süre kalmak yasak; sadece kısa süre korumayla kal.\n",
     "legend_safe": "Güvenli",
     "legend_title": "Lejant",
+    "license_full": "Bu proje <a href=\"/LICENSE\" target=\"_blank\">GNU GPLv3</a> lisansı altında büyüyor. Tam metin depo kök dizininde ve GNU sitesinde bulunur. Kodunu inceleyebilir, paylaşabilir ve değiştirebilirsin; yeter ki bu özgürlükler çalışmalarına da eşlik etsin. Araştırma verileri Creative Commons 1.0 lisansı ile yayımlanır; böylece ölçümler kamu malı olarak kalır.",
+    "license_title": "Lisans",
     "live_chart_all": "All readings",
     "live_chart_averaged": "Averaged over [[window]]",
     "live_chart_close": "Close",
@@ -3235,6 +3358,8 @@
     "radiation_dose": "Doz hızı",
     "select_files": "Lütfen en az bir dosya seçin",
     "short_link_tooltip": "Kısa paylaşım bağlantısını kopyalamak için tıklayın",
+    "sources_full": "Ölçümlerini paylaşan herkese teşekkür ederiz.\n\nAnonim yüklemeler haritada sessiz izler çizer.\n<a href=\"https://safecast.org\" target=\"_blank\">Safecast</a> küresel bir ölçüm arşivini yaşatır.\n<a href=\"https://atomfast.net\" target=\"_blank\">Atomfast</a> Atomcloud'un ışığını açık tutar.\n<a href=\"https://radiaverse.com\" target=\"_blank\">Radioverse</a> Radiacode deneyimlerini derler.\n\nHer katkı ortak manzarayı genişletir; kendi verini de içtenlikle bekliyoruz.",
+    "sources_title": "Veri kaynakları",
     "speed": "Hız",
     "speed_filter_tooltip_accuracy": "Daha yavaş ölçümler zemine en yakın kalır; bu yüzden yaya verileri en doğrusudur.",
     "speed_filter_tooltip_car": "Araba: sürüşler ve mobil ölçümler için 7–70 km/s.",
@@ -3250,7 +3375,8 @@
     "upload_button_tooltip": "Ölçüm rotanızı haritaya ekleyin. Desteklenen formatlar: .kml, .kmz, .gpx, .csv, .rctrk, .json, .log. Birden fazla dosya yükleyebilir, yükleme sonrası rota sayfası açılır.",
     "upload_error": "Hata",
     "waiting_for_server": "Sunucu bekleniyor...",
-    "your_location": "Konumunuz"
+    "your_location": "Konumunuz",
+    "legend_full_en": "This scale shows how likely a spot is safe for folk, water, and food.\nMind: the readings might not be complete, and some rays could be higher or hiding. Treat these numbers as guidance only.\n\nGreen (0–11 µR/h)\nBackground near natural.\n• Water from wells is generally safe.\n• You can grow plants without checks.\n\nYellow (11–30 µR/h)\nRaised background; take care.\n• Check water and soil.\n• Test any veg, mushrooms, or other produce before you eat.\n\nRed (30–100 µR/h)\nSerious contamination.\n• Don't drink the water.\n• Growing or eating produce from here is risky; lab tests are a must.\n\nBlack (>100 µR/h)\nCritical zone.\n• Water and food cannot be used.\n• Staying long-term is out; only short visits with protection.\n"
   },
   "uk": {
     "api_example_archive_desc": "Завантажує tgz-пакет з усіма опублікованими файлами .cim, коли JSON-архів увімкнено.",
@@ -3311,6 +3437,8 @@
     "legend_full_uk": "Ця шкала показує, наскільки місце безпечне для життя, води й їжі.\nПам’ятайте: вимірювання можуть бути неповними; користуйтеся лише як орієнтиром.\n\nЗелений (0–11 µR/h)\nМайже природний фон.\n• Кринична вода здебільшого безпечна.\n• Рослини можна вирощувати без перевірок.\n\nЖовтий (11–30 µR/h)\nПідвищений фон.\n• Перевіряйте воду й ґрунт.\n• Тестуйте будь-яку їжу перед споживанням.\n\nЧервоний (30–100 µR/h)\nСерйозне забруднення.\n• Воду пити не можна.\n• Вирощування чи вживання продуктів тут небезпечно; потрібні лабораторні дослідження.\n\nЧорний (>100 µR/h)\nКритична зона.\n• Вода й їжа непридатні.\n• Лише коротке перебування з захистом.\n",
     "legend_safe": "Безпечно",
     "legend_title": "Легенда",
+    "license_full": "Цей проєкт розвивається під ліцензією <a href=\"/LICENSE\" target=\"_blank\">GNU GPLv3</a>. Повний текст лежить у корені репозиторію та на сайті GNU. Ви можете вивчати, поширювати й змінювати код, якщо ці свободи залишаються разом із вашою роботою. Дані досліджень публікуються за ліцензією Creative Commons 1.0, тож вимірювання залишаються у суспільному надбанні.",
+    "license_title": "Ліцензія",
     "live_chart_all": "All readings",
     "live_chart_averaged": "Averaged over [[window]]",
     "live_chart_close": "Close",
@@ -3360,6 +3488,8 @@
     "radiation_dose": "Потужність дози",
     "select_files": "Будь ласка, виберіть щонайменше один файл",
     "short_link_tooltip": "Натисніть, щоб скопіювати коротке посилання для поширення",
+    "sources_full": "Дякуємо всім, хто ділиться вимірюваннями.\n\nАнонімні завантаження малюють на мапі тихі стежки.\n<a href=\"https://safecast.org\" target=\"_blank\">Safecast</a> підтримує світовий архів показників.\n<a href=\"https://atomfast.net\" target=\"_blank\">Atomfast</a> тримає Atomcloud у строю.\n<a href=\"https://radiaverse.com\" target=\"_blank\">Radioverse</a> збирає напрацювання Radiacode.\n\nКожен внесок розширює спільну картину; щиро запрошуємо додати й ваші дані.",
+    "sources_title": "Джерела даних",
     "speed": "Швидкість",
     "speed_filter_tooltip_accuracy": "Повільніші вимірювання залишаються найближче до землі, тому пішохідні дані найточніші.",
     "speed_filter_tooltip_car": "Авто: 7–70 км/год для поїздок і мобільних вимірювань.",
@@ -3375,7 +3505,8 @@
     "upload_button_tooltip": "Додайте свій трек вимірювань на карту. Підтримувані формати: .kml, .kmz, .gpx, .csv, .rctrk, .json, .log. Можна завантажити кілька файлів, після чого відкриється сторінка треку.",
     "upload_error": "Помилка",
     "waiting_for_server": "Очікування сервера...",
-    "your_location": "Ваше розташування"
+    "your_location": "Ваше розташування",
+    "legend_full_en": "This scale shows how likely a spot is safe for folk, water, and food.\nMind: the readings might not be complete, and some rays could be higher or hiding. Treat these numbers as guidance only.\n\nGreen (0–11 µR/h)\nBackground near natural.\n• Water from wells is generally safe.\n• You can grow plants without checks.\n\nYellow (11–30 µR/h)\nRaised background; take care.\n• Check water and soil.\n• Test any veg, mushrooms, or other produce before you eat.\n\nRed (30–100 µR/h)\nSerious contamination.\n• Don't drink the water.\n• Growing or eating produce from here is risky; lab tests are a must.\n\nBlack (>100 µR/h)\nCritical zone.\n• Water and food cannot be used.\n• Staying long-term is out; only short visits with protection.\n"
   },
   "vi": {
     "api_example_archive_desc": "Tải gói tgz chứa mọi tệp .cim đã công bố khi bật lưu trữ JSON.",
@@ -3436,6 +3567,8 @@
     "legend_full_vi": "Thang này cho biết mức an toàn của nơi ở đối với đời sống, nước và thực phẩm.\nNhớ rằng: đo đạc có thể chưa đầy đủ; chỉ dùng để tham khảo.\n\nXanh (0–11 µR/h)\nNền gần tự nhiên.\n• Nước giếng thường an toàn.\n• Có thể trồng trọt không cần thử nghiệm.\n\nVàng (11–30 µR/h)\nNền cao.\n• Kiểm tra nước và đất.\n• Thử mọi thực phẩm trước khi ăn.\n\nĐỏ (30–100 µR/h)\nÔ nhiễm nghiêm trọng.\n• Không uống nước.\n• Trồng hoặc ăn ở đây nguy hiểm; cần xét nghiệm.\n\nĐen (>100 µR/h)\nVùng cực nguy.\n• Nước và thức ăn không dùng được.\n• Chỉ ở lại ngắn với bảo hộ.\n",
     "legend_safe": "An toàn",
     "legend_title": "Chú thích",
+    "license_full": "Dự án này phát triển dưới <a href=\"/LICENSE\" target=\"_blank\">GNU GPLv3</a>. Toàn văn nằm ở thư mục gốc của kho và trên trang GNU. Bạn có thể nghiên cứu, chia sẻ và chỉnh sửa mã miễn là những quyền tự do này theo sát sản phẩm của bạn. Dữ liệu nghiên cứu được phát hành theo giấy phép Creative Commons 1.0 để các phép đo luôn thuộc phạm vi công cộng.",
+    "license_title": "Giấy phép",
     "live_chart_all": "All readings",
     "live_chart_averaged": "Averaged over [[window]]",
     "live_chart_close": "Close",
@@ -3485,6 +3618,8 @@
     "radiation_dose": "Suất liều",
     "select_files": "Vui lòng chọn ít nhất một tệp",
     "short_link_tooltip": "Nhấn để sao chép liên kết chia sẻ ngắn",
+    "sources_full": "Chúng tôi cảm ơn tất cả những ai chia sẻ phép đo.\n\nCác lượt tải ẩn danh vẽ nên những đường mòn lặng lẽ trên bản đồ.\n<a href=\"https://safecast.org\" target=\"_blank\">Safecast</a> nuôi dưỡng kho lưu trữ số liệu toàn cầu.\n<a href=\"https://atomfast.net\" target=\"_blank\">Atomfast</a> giữ cho Atomcloud luôn sáng.\n<a href=\"https://radiaverse.com\" target=\"_blank\">Radioverse</a> gom góp hiểu biết từ Radiacode.\n\nMỗi đóng góp đều mở rộng bức tranh chung; rất mong bạn cũng góp phần của mình.",
+    "sources_title": "Nguồn dữ liệu",
     "speed": "Tốc độ",
     "speed_filter_tooltip_accuracy": "Các phép đo chậm sát mặt đất hơn, vì vậy dữ liệu đi bộ là chính xác nhất.",
     "speed_filter_tooltip_car": "Ô tô: 7–70 km/h cho các chuyến đi và phép đo di động.",
@@ -3500,7 +3635,8 @@
     "upload_button_tooltip": "Thêm hành trình đo đạc của bạn vào bản đồ. Định dạng hỗ trợ: .kml, .kmz, .gpx, .csv, .rctrk, .json, .log. Bạn có thể tải lên nhiều tệp; sau khi tải lên sẽ mở trang hành trình.",
     "upload_error": "Lỗi",
     "waiting_for_server": "Đang chờ máy chủ...",
-    "your_location": "Vị trí của bạn"
+    "your_location": "Vị trí của bạn",
+    "legend_full_en": "This scale shows how likely a spot is safe for folk, water, and food.\nMind: the readings might not be complete, and some rays could be higher or hiding. Treat these numbers as guidance only.\n\nGreen (0–11 µR/h)\nBackground near natural.\n• Water from wells is generally safe.\n• You can grow plants without checks.\n\nYellow (11–30 µR/h)\nRaised background; take care.\n• Check water and soil.\n• Test any veg, mushrooms, or other produce before you eat.\n\nRed (30–100 µR/h)\nSerious contamination.\n• Don't drink the water.\n• Growing or eating produce from here is risky; lab tests are a must.\n\nBlack (>100 µR/h)\nCritical zone.\n• Water and food cannot be used.\n• Staying long-term is out; only short visits with protection.\n"
   },
   "zh": {
     "api_example_archive_desc": "在启用 JSON 归档时，下载包含所有已发布 .cim 文件的 tgz 包。",
@@ -3561,6 +3697,8 @@
     "legend_full_zh": "此刻度展示一个地点对生命、水和食物的安全程度。\n请记住：读数可能不完整；仅作参考。\n\n绿色 (0–11 µR/h)\n背景接近自然。\n• 井水通常安全。\n• 可放心种植。\n\n黄色 (11–30 µR/h)\n背景升高。\n• 检查水和土。\n• 食物食用前需检测。\n\n红色 (30–100 µR/h)\n严重污染。\n• 不可饮用水。\n• 种植或食用此地产品危险；需实验室检测。\n\n黑色 (>100 µR/h)\n危急区域。\n• 水和食物不可用。\n• 仅短暂停留且需防护。\n",
     "legend_safe": "安全",
     "legend_title": "图例",
+    "license_full": "本项目遵循<a href=\"/LICENSE\" target=\"_blank\">GNU GPLv3</a>许可。完整文本位于仓库根目录以及 GNU 官网。只要这些自由随你的作品同行，你就可以学习、共享并修改代码。研究数据以 Creative Commons 1.0 许可发布，让测量结果保持在公共领域。",
+    "license_title": "许可",
     "live_chart_all": "All readings",
     "live_chart_averaged": "Averaged over [[window]]",
     "live_chart_close": "Close",
@@ -3610,6 +3748,8 @@
     "radiation_dose": "剂量率",
     "select_files": "请至少选择一个文件",
     "short_link_tooltip": "点击复制简短的分享链接",
+    "sources_full": "感谢所有分享测量数据的伙伴。\n\n匿名上传在地图上勾勒出静静的足迹。\n<a href=\"https://safecast.org\" target=\"_blank\">Safecast</a> 维护着全球读数档案。\n<a href=\"https://atomfast.net\" target=\"_blank\">Atomfast</a> 让 Atomcloud 保持在线。\n<a href=\"https://radiaverse.com\" target=\"_blank\">Radioverse</a> 汇聚 Radiacode 的见解。\n\n每一份贡献都拓宽共同的图景；诚挚邀请你也加入。",
+    "sources_title": "数据来源",
     "speed": "速度",
     "speed_filter_tooltip_accuracy": "速度越慢的测量越贴近地面，因此步行数据最精确。",
     "speed_filter_tooltip_car": "汽车：7–70 公里/小时，用于驾车和移动测量。",
@@ -3625,6 +3765,7 @@
     "upload_button_tooltip": "将您的测量轨迹添加到地图。支持的格式：.kml、.kmz、.gpx、.csv、.rctrk、.json、.log。您可以上传多个文件，上传完成后将打开轨迹页面。",
     "upload_error": "错误",
     "waiting_for_server": "正在等待服务器...",
-    "your_location": "您的位置"
+    "your_location": "您的位置",
+    "legend_full_en": "This scale shows how likely a spot is safe for folk, water, and food.\nMind: the readings might not be complete, and some rays could be higher or hiding. Treat these numbers as guidance only.\n\nGreen (0–11 µR/h)\nBackground near natural.\n• Water from wells is generally safe.\n• You can grow plants without checks.\n\nYellow (11–30 µR/h)\nRaised background; take care.\n• Check water and soil.\n• Test any veg, mushrooms, or other produce before you eat.\n\nRed (30–100 µR/h)\nSerious contamination.\n• Don't drink the water.\n• Growing or eating produce from here is risky; lab tests are a must.\n\nBlack (>100 µR/h)\nCritical zone.\n• Water and food cannot be used.\n• Staying long-term is out; only short visits with protection.\n"
   }
 }


### PR DESCRIPTION
## Summary
- update every locale's `license_full` copy so it states the software is under GNU GPLv3
- document in each translation that research data is released under Creative Commons 1.0 to stay in the public domain

## Testing
- go test ./... *(hangs and was interrupted with Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_68d2fadd2f548332b2a2a635c7b1b1cc