### PR TITLE
Simplify network database configuration flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,13 +168,11 @@ If you’re launching the `chicha-isotope-map` binary directly, here’s what ma
 
   * Example: `-db-type sqlite -db-path /var/lib/chicha/chicha.sqlite`
 
-* `-db-host string`, `-db-port int` (default 5432), `-db-name string`, `-db-user string`, `-db-pass string` — PostgreSQL connection params for `pgx`.
+* `-db-conn string` — single connection URI for network databases (`pgx`/PostgreSQL or `clickhouse`).
 
-  * Example: `-db-type pgx -db-host 127.0.0.1 -db-port 5432 -db-name chicha_isotope_map -db-user postgres -db-pass secret`
+  * PostgreSQL example: `-db-type pgx -db-conn postgres://postgres@127.0.0.1:5432/chicha_isotope_map?sslmode=require`
 
-* `-pg-ssl-mode string` — PostgreSQL SSL mode: `disable`, `allow`, `prefer` (default), `require`, `verify-ca`, `verify-full`.
-
-  * Example: `-pg-ssl-mode require`
+  * ClickHouse example: `-db-type clickhouse -db-conn clickhouse://default@127.0.0.1:9000/IsotopePathways?secure=true`
 
 ### Utility
 
@@ -216,9 +214,7 @@ If you’re launching the `chicha-isotope-map` binary directly, here’s what ma
   ```bash
   chicha-isotope-map \
     -db-type pgx \
-    -db-host 127.0.0.1 -db-port 5432 \
-    -db-name chicha_isotope_map -db-user postgres -db-pass secret \
-    -pg-ssl-mode require \
+    -db-conn postgres://postgres:secret@127.0.0.1:5432/chicha_isotope_map?sslmode=verify-full \
     -default-lat 44.08832 -default-lon 42.97577 -default-zoom 11
   ```
 

--- a/chicha-isotope-map.go
+++ b/chicha-isotope-map.go
@@ -125,10 +125,14 @@ func resolveCLIColorTheme(out io.Writer) cliColorTheme {
 	}
 
 	theme.Enabled = true
-	theme.Section = "\033[1;36m"
-	theme.Flag = "\033[1;33m"
-	theme.Usage = "\033[0;37m"
-	theme.Default = "\033[0;32m"
+	// We prefer muted accents so the help text stays elegant on both light and dark
+	// terminals. 38;5 codes give us a refined teal for section titles, a warm sand for
+	// flag names, a soft graphite for usage text, and a gentle sage for defaults. This
+	// palette avoids harsh contrasts while still guiding the reader's eye.
+	theme.Section = "\033[38;5;38m"
+	theme.Flag = "\033[38;5;180m"
+	theme.Usage = "\033[38;5;244m"
+	theme.Default = "\033[38;5;114m"
 	theme.Reset = "\033[0m"
 	return theme
 }

--- a/doc/README_FR.md
+++ b/doc/README_FR.md
@@ -168,13 +168,11 @@ Si vous lancez directement le binaire `chicha-isotope-map`, voici les options im
 
   * Exemple : `-db-type sqlite -db-path /var/lib/chicha/chicha.sqlite`
 
-* `-db-host string`, `-db-port int` (par défaut 5432), `-db-name string`, `-db-user string`, `-db-pass string` — paramètres de connexion PostgreSQL pour `pgx`.
+* `-db-conn string` — URI unique pour les bases réseau (`pgx`/PostgreSQL ou `clickhouse`).
 
-  * Exemple : `-db-type pgx -db-host 127.0.0.1 -db-port 5432 -db-name chicha_isotope_map -db-user postgres -db-pass secret`
+  * Exemple PostgreSQL : `-db-type pgx -db-conn postgres://postgres@127.0.0.1:5432/chicha_isotope_map?sslmode=require`
 
-* `-pg-ssl-mode string` — mode SSL PostgreSQL : `disable`, `allow`, `prefer` (par défaut), `require`, `verify-ca`, `verify-full`.
-
-  * Exemple : `-pg-ssl-mode require`
+  * Exemple ClickHouse : `-db-type clickhouse -db-conn clickhouse://default@127.0.0.1:9000/IsotopePathways?secure=true`
 
 ### Utilitaires
 
@@ -216,9 +214,7 @@ Si vous lancez directement le binaire `chicha-isotope-map`, voici les options im
   ```bash
   chicha-isotope-map \
     -db-type pgx \
-    -db-host 127.0.0.1 -db-port 5432 \
-    -db-name chicha_isotope_map -db-user postgres -db-pass secret \
-    -pg-ssl-mode require \
+    -db-conn postgres://postgres:secret@127.0.0.1:5432/chicha_isotope_map?sslmode=verify-full \
     -default-lat 44.08832 -default-lon 42.97577 -default-zoom 11
   ```
 

--- a/doc/README_RU.md
+++ b/doc/README_RU.md
@@ -158,9 +158,11 @@ sudo curl -L https://github.com/matveynator/chicha-isotope-map/releases/download
 
 * `-db-path string` — путь к файлу базы для `duckdb`/`chai`/`sqlite`.
 
-* `-db-host string`, `-db-port int`, `-db-name string`, `-db-user string`, `-db-pass string` — параметры подключения к PostgreSQL (`pgx`).
+* `-db-conn string` — единый URI подключения для сетевых баз (`pgx`/PostgreSQL или `clickhouse`).
 
-* `-pg-ssl-mode string` — режим SSL для PostgreSQL: `disable`, `allow`, `prefer` (по умолчанию), `require`, `verify-ca`, `verify-full`.
+  * Пример PostgreSQL: `-db-type pgx -db-conn postgres://postgres@127.0.0.1:5432/chicha_isotope_map?sslmode=require`
+
+  * Пример ClickHouse: `-db-type clickhouse -db-conn clickhouse://default@127.0.0.1:9000/IsotopePathways?secure=true`
 
 ### Служебные
 

--- a/scripts/docker/entrypoint.sh
+++ b/scripts/docker/entrypoint.sh
@@ -68,9 +68,7 @@ fi
 # ----------- аргументы приложения --------------
 ARGS=(
   -db-type pgx
-  -db-host 127.0.0.1 -db-port 5432
-  -db-user "${DB_USER}" -db-pass '' -db-name "${DB_NAME}"
-  -pg-ssl-mode disable
+  -db-conn "postgres://${DB_USER}@127.0.0.1:5432/${DB_NAME}?sslmode=disable"
   -default-lat   "${DEFAULT_LAT:-51.389}"
   -default-lon   "${DEFAULT_LON:-30.099}"
   -default-zoom  "${DEFAULT_ZOOM:-4}"


### PR DESCRIPTION
## Summary
- replace multiple PostgreSQL/ClickHouse CLI flags with a single `-db-conn` URI option and add grouped `--help` output for better readability
- parse network DSNs into the database configuration and reuse them wherever DSNs are needed
- refresh documentation and Docker entrypoint examples to describe the new flag in English, French, and Russian

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68d504c0e18c8332921bc2a5e72bccaf