### PR TITLE
Serve embedded license text offline

### DIFF
--- a/LICENSE.CC0
+++ b/LICENSE.CC0
@@ -1,0 +1,120 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+    i. the right to reproduce, adapt, distribute, perform, display,
+       communicate, and translate a Work;
+   ii. moral rights retained by the original author(s) and/or performer(s);
+  iii. publicity and privacy rights pertaining to a person's image or
+       likeness depicted in a Work;
+   iv. rights protecting against unfair competition in regards to a Work,
+       subject to the limitations in paragraph 4(a), below;
+    v. rights protecting the extraction, dissemination, use and reuse of
+       data in a Work;
+   vi. database rights (such as those arising under Directive 96/9/EC of
+       the European Parliament and of the Council of 11 March 1996 on the
+       legal protection of databases, and under any national implementation
+       thereof, including any amended or successor version of such
+       directive); and
+  vii. other similar, equivalent or corresponding rights throughout the
+       world based on applicable law or treaty, and any national
+       implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -1382,7 +1382,74 @@ body, html {
   </div>
 </div>
 
+<!-- Provide dedicated modal for reading the full MIT License directly on the map. -->
+<div class="license-modal" data-license="mit" style="
+  display:none;
+  position:fixed;
+  top:0; left:0; width:100%; height:100%;
+  background:rgba(0,0,0,0.6);
+  z-index:2000;
+  justify-content:center;
+  align-items:center;">
+  <div style="
+    background:var(--modal-bg);
+    color:var(--modal-text);
+    border:var(--modal-border);
+    max-width:720px;
+    max-height:80vh;
+    overflow-y:auto;
+    padding:20px;
+    border-radius:10px;
+    font-size: var(--font-size-base);
+    line-height:1.6em;
+    box-shadow:0 0 10px rgba(0,0,0,0.5);
+    font-family: var(--font-family-base);">
+    <h3 style="margin-top:0;">MIT License</h3>
+    <pre class="license-modal-body" data-license-url="/licenses/mit" data-license-loaded="false" data-license-loading="false" style="white-space:pre-wrap; margin:0; font-family: var(--font-family-base);">Loading…</pre>
+    <div style="margin-top:12px; text-align:right;">
+      <button class="license-modal-close" data-license="mit" style="padding:6px 12px; background: var(--control-bg); border: var(--legend-border); border-radius:4px; cursor:pointer; font-family: inherit;">
+        OK
+      </button>
+    </div>
+  </div>
+</div>
+
+<!-- Provide dedicated modal for reading the full CC0 1.0 Universal text. -->
+<div class="license-modal" data-license="cc0" style="
+  display:none;
+  position:fixed;
+  top:0; left:0; width:100%; height:100%;
+  background:rgba(0,0,0,0.6);
+  z-index:2000;
+  justify-content:center;
+  align-items:center;">
+  <div style="
+    background:var(--modal-bg);
+    color:var(--modal-text);
+    border:var(--modal-border);
+    max-width:720px;
+    max-height:80vh;
+    overflow-y:auto;
+    padding:20px;
+    border-radius:10px;
+    font-size: var(--font-size-base);
+    line-height:1.6em;
+    box-shadow:0 0 10px rgba(0,0,0,0.5);
+    font-family: var(--font-family-base);">
+    <h3 style="margin-top:0;">CC0 1.0 Universal</h3>
+    <pre class="license-modal-body" data-license-url="/licenses/cc0" data-license-loaded="false" data-license-loading="false" style="white-space:pre-wrap; margin:0; font-family: var(--font-family-base);">Loading…</pre>
+    <div style="margin-top:12px; text-align:right;">
+      <button class="license-modal-close" data-license="cc0" style="padding:6px 12px; background: var(--control-bg); border: var(--legend-border); border-radius:4px; cursor:pointer; font-family: inherit;">
+        OK
+      </button>
+    </div>
+  </div>
+
+</div>
+
+
 <!-- Modal with Grafana-style stacked charts for Safecast realtime sensors -->
+
 <div id="liveModal">
   <div class="live-modal-content">
     <div class="live-modal-header">
@@ -4202,6 +4269,93 @@ function centerMapToLocation() {
     }).join('');
   }
 
+  // Turn license mentions into modal triggers so readers stay on the map page.
+  function decorateLicenseLinks(txt) {
+    if (typeof txt !== 'string' || !txt) {
+      return txt;
+    }
+    var withMitAnchor = txt.replace(/<a[^>]*href="\\/LICENSE"[^>]*>([\s\S]*?)<\\/a>/gi, function(_, label) {
+      return '<a href="#" class="license-link" data-license="mit">' + label + '</a>';
+    });
+    var withCc0Anchor = withMitAnchor.replace(/Creative Commons 1\.0(\s*\(CC0\))?/gi, function(match) {
+      return '<a href="#" class="license-link" data-license="cc0">' + match + '</a>';
+    });
+    return withCc0Anchor;
+  }
+
+  // Open a specific license modal based on the identifier requested by the user.
+  // We fetch the source file lazily so embedded binaries stay in sync with
+  // the repository licenses even when served offline.
+  function openLicenseModal(code) {
+    if (!code) return;
+    var selector = '.license-modal[data-license="' + code + '"]';
+    var modal = document.querySelector(selector);
+    if (!modal) return;
+
+    var body = modal.querySelector('[data-license-url]');
+    if (body) {
+      var loadedState = body.getAttribute('data-license-loaded');
+      var loadingState = body.getAttribute('data-license-loading');
+      if (loadedState !== 'true' && loadingState !== 'true') {
+        var url = body.getAttribute('data-license-url');
+        if (url) {
+          body.textContent = 'Loading…';
+          body.setAttribute('data-license-loading', 'true');
+
+          var handleSuccess = function(text) {
+            body.textContent = text;
+            body.setAttribute('data-license-loaded', 'true');
+            body.setAttribute('data-license-loading', 'false');
+          };
+
+          var handleError = function(err) {
+            if (window.console && console.error) {
+              console.error('Failed to load license text for', code, err);
+            }
+            body.textContent = 'Unable to load the license text. Please download it from the repository.';
+            body.setAttribute('data-license-loaded', 'error');
+            body.setAttribute('data-license-loading', 'false');
+          };
+
+          if (window.fetch) {
+            fetch(url, { cache: 'no-store' })
+              .then(function(resp) {
+                if (!resp.ok) {
+                  throw new Error('HTTP ' + resp.status);
+                }
+                return resp.text();
+              })
+              .then(handleSuccess)
+              .catch(handleError);
+          } else {
+            var xhr = new XMLHttpRequest();
+            xhr.open('GET', url, true);
+            xhr.onreadystatechange = function() {
+              if (xhr.readyState === 4) {
+                if (xhr.status >= 200 && xhr.status < 300) {
+                  handleSuccess(xhr.responseText);
+                } else {
+                  handleError(new Error('HTTP ' + xhr.status));
+                }
+              }
+            };
+            xhr.onerror = function() { handleError(new Error('network error')); };
+            xhr.send();
+          }
+        }
+      }
+    }
+
+    modal.style.display = 'flex';
+  }
+
+  // Close the provided license modal so the overlay disappears cleanly.
+  function closeLicenseModal(modal) {
+    if (modal) {
+      modal.style.display = 'none';
+    }
+  }
+
   // Example definitions stay in code so translations only supply human text.
   const apiExamples = [
     { key: 'root', method: 'api_method_get', methodFallback: 'GET', path: '/api', url: '/api' },
@@ -4293,6 +4447,9 @@ function centerMapToLocation() {
     if (topic === 'legal' && typeof window.supportEmail === 'string' && window.supportEmail.trim() !== '') {
       infoText += '\n\n' + translate('legal_contact') + ' ' + window.supportEmail.trim();
     }
+    if (topic === 'license') {
+      infoText = decorateLicenseLinks(infoText);
+    }
     if (box) box.innerHTML = buildInfoHTML(infoText);
     var head = document.getElementById('infoTitle');
     if (head) head.textContent = translate(topic + '_title');
@@ -4332,6 +4489,10 @@ function centerMapToLocation() {
       ev.preventDefault();
       openInfoModal(ev.target.dataset.info);
     }
+    if (ev.target.classList.contains('license-link')) {
+      ev.preventDefault();
+      openLicenseModal(ev.target.dataset.license);
+    }
   });
 
   (function(){
@@ -4351,6 +4512,30 @@ function centerMapToLocation() {
       infoModal.addEventListener('click', function(e){
         if (e.target === infoModal) infoModal.style.display = 'none';
       });
+    }
+    var licenseModals = document.querySelectorAll('.license-modal');
+    if (licenseModals && licenseModals.length) {
+      for (var i = 0; i < licenseModals.length; i++) {
+        (function(modalEl){
+          modalEl.addEventListener('click', function(e){
+            if (e.target === modalEl) closeLicenseModal(modalEl);
+          });
+        })(licenseModals[i]);
+      }
+    }
+    var licenseCloseButtons = document.querySelectorAll('.license-modal-close');
+    if (licenseCloseButtons && licenseCloseButtons.length) {
+      for (var j = 0; j < licenseCloseButtons.length; j++) {
+        (function(btn){
+          btn.addEventListener('click', function(){
+            var modalEl = btn;
+            while (modalEl && (!modalEl.classList || !modalEl.classList.contains('license-modal'))) {
+              modalEl = modalEl.parentNode;
+            }
+            closeLicenseModal(modalEl);
+          });
+        })(licenseCloseButtons[j]);
+      }
     }
     var liveModal = document.getElementById('liveModal');
     if (liveModal) {


### PR DESCRIPTION
## Summary
- embed the MIT and CC0 root license files into the application filesystem and expose them via a /licenses endpoint for offline access
- update the map license modals to lazily fetch their text from the embedded files so the UI stays in sync without duplicating the legal copy

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d512f40f548332b329c5003e7c4d29