### PR TITLE
Fix template JSON escaping for map view

### DIFF
--- a/public_html/map.html
+++ b/public_html/map.html
@@ -1136,7 +1136,9 @@ body, html {
     <!-- Translation script -->
     <script id="translations-script">
       // Translation object passed from Go
-      var translations = JSON.parse('{{ .Translations | toJSON }}');
+      // We emit ready-made JS literals to keep html/template from misdetecting
+      // the surrounding string context when translations contain quotes.
+      var translations = {{ .Translations | toJS }};
         var currentLang = '{{ .Lang }}'; // Current language
 
         // Get translation by key
@@ -1159,7 +1161,7 @@ body, html {
         lat:  {{printf "%.6f" .DefaultLat}},
         lon:  {{printf "%.6f" .DefaultLon}},
         zoom: {{.DefaultZoom}},
-        layer: {{ .DefaultLayer | toJSON }}
+        layer: {{ .DefaultLayer | toJS }}
       };
     </script>
     <script>
@@ -2354,7 +2356,9 @@ document.addEventListener('DOMContentLoaded', function () {
   );
 
   // Track view initialization
-  var initialMarkers = JSON.parse('{{ .Markers | toJSON }}');
+  // Inject markers as literal JSON so the first render avoids the template parse error
+  // and the frontend can inspect the slice immediately.
+  var initialMarkers = {{ .Markers | toJS }};
   if (Array.isArray(initialMarkers) && initialMarkers.length > 0) {
     isTrackView = true;
 

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -1536,13 +1536,13 @@ body, html {
 
       // Compute marker color from radiation level
       function getGradientColor(doseRate) {
-        if (doseRate <= 0.04) return "#006400"; // Dark green
+        if (doseRate <= 0.04) return '#006400'; // Dark green
         else if (doseRate <= 0.08) return interpolateColor([0, 100, 0], [173, 255, 47], (doseRate - 0.04) / (0.08 - 0.04));
         else if (doseRate <= 0.11) return interpolateColor([173, 255, 47], [255, 255, 0], (doseRate - 0.08) / (0.11 - 0.08));
         else if (doseRate <= 0.20) return interpolateColor([255, 255, 0], [255, 165, 0], (doseRate - 0.11) / (0.20 - 0.11));
         else if (doseRate <= 0.30) return interpolateColor([255, 165, 0], [255, 0, 0], (doseRate - 0.20) / (0.30 - 0.20));
         else if (doseRate <= 0.99) return interpolateColor([255, 0, 0], [0, 0, 0], (doseRate - 0.30) / (0.99 - 0.30));
-        else return "#000000"; // Black for very high values
+        else return '#000000'; // Black for very high values
       }
 
 // Interpolate between two colors
@@ -1647,17 +1647,20 @@ function formatMicroRoentgenValue(value) {
 }
 
 // escapeHtml protects popups against user-supplied strings like device names.
+// We rely on explicit lookup tables instead of quoting " inside the regex so
+// Go's html/template parser keeps the surrounding <script> in a neutral state.
+const ESCAPE_HTML_RE = /[&<>\u0022\u0027]/g;
+const ESCAPE_HTML_LOOKUP = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+};
+ESCAPE_HTML_LOOKUP['\u0022'] = '&quot;';
+ESCAPE_HTML_LOOKUP['\u0027'] = '&#39;';
 function escapeHtml(value) {
   if (value === null || value === undefined) return '';
-  return String(value).replace(/[&<>"']/g, function(ch) {
-    switch (ch) {
-      case '&': return '&amp;';
-      case '<': return '&lt;';
-      case '>': return '&gt;';
-      case '"': return '&quot;';
-      case "'": return '&#39;';
-      default: return ch;
-    }
+  return String(value).replace(ESCAPE_HTML_RE, function(ch) {
+    return ESCAPE_HTML_LOOKUP[ch] || ch;
   });
 }
 
@@ -4278,7 +4281,7 @@ function centerMapToLocation() {
     if (typeof txt !== 'string' || !txt) {
       return txt;
     }
-    var withMitAnchor = txt.replace(/<a[^>]*href="\\/LICENSE"[^>]*>([\s\S]*?)<\\/a>/gi, function(_, label) {
+    var withMitAnchor = txt.replace(/<a[^>]*href=\u0022\/LICENSE\u0022[^>]*>([\s\S]*?)<\/a>/gi, function(_, label) {
       return '<a href="#" class="license-link" data-license="mit">' + label + '</a>';
     });
     var withCc0Anchor = withMitAnchor.replace(/Creative Commons 1\.0(\s*\(CC0\))?/gi, function(match) {

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -1138,7 +1138,7 @@ body, html {
       // Translation object passed from Go
       // We emit ready-made JS literals to keep html/template from misdetecting
       // the surrounding string context when translations contain quotes.
-      var translations = {{ .Translations | toJS }};
+      var translations = {{ .TranslationsJSON }};
         var currentLang = '{{ .Lang }}'; // Current language
 
         // Get translation by key
@@ -1161,7 +1161,7 @@ body, html {
         lat:  {{printf "%.6f" .DefaultLat}},
         lon:  {{printf "%.6f" .DefaultLon}},
         zoom: {{.DefaultZoom}},
-        layer: {{ .DefaultLayer | toJS }}
+        layer: {{ printf "%q" .DefaultLayer }}
       };
     </script>
     <script>
@@ -2358,7 +2358,7 @@ document.addEventListener('DOMContentLoaded', function () {
   // Track view initialization
   // Inject markers as literal JSON so the first render avoids the template parse error
   // and the frontend can inspect the slice immediately.
-  var initialMarkers = {{ .Markers | toJS }};
+  var initialMarkers = {{ .MarkersJSON }};
   if (Array.isArray(initialMarkers) && initialMarkers.length > 0) {
     isTrackView = true;
 


### PR DESCRIPTION
## Summary
- marshal template data to template.JS so map.html receives safe JavaScript literals
- update map.html to consume the new helper and avoid JSON.parse wrappers that broke template execution
- document why the literals are injected directly to keep html/template happy

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d52156cb3483328172b4a3fa64ff6e