### PR TITLE
Add Linux duckdb build to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
           name: bin-${{ matrix.goos }}-${{ matrix.goarch }}
           path: dist/
 
-  # ---------- DUCKDB: Linux/amd64 (glibc 2.28) в контейнере + macOS (amd64/arm64) ----------
+# ---------- DUCKDB: Linux/amd64 (glibc 2.28) в контейнере + macOS (amd64/arm64) ----------
   build_duckdb:
     if: contains(toJson(github.event.head_commit.message), 'stable release')
     runs-on: ${{ matrix.runner }}
@@ -145,8 +145,64 @@ jobs:
           name: bin-${{ matrix.target }}
           path: dist/
 
+  build_duckdb_linux:
+    if: contains(toJson(github.event.head_commit.message), 'stable release')
+    runs-on: ubuntu-24.04
+    container:
+      image: debian:10-slim
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          set -euo pipefail
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            ca-certificates \
+            curl \
+            git \
+            build-essential
+          update-ca-certificates
+
+      - name: Set up Go (Linux)
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.23"
+          cache: true
+          cache-dependency-path: go.sum
+
+      - name: go mod tidy (Linux)
+        shell: bash
+        run: |
+          set -euo pipefail
+          go get github.com/marcboeker/go-duckdb/v2@latest
+          go mod tidy
+
+      - name: Build (Linux duckdb)
+        shell: bash
+        env:
+          GOOS: linux
+          GOARCH: amd64
+        run: |
+          set -euo pipefail
+          export CGO_ENABLED=1
+          VERSION=${{ github.run_number }}
+          mkdir -p dist
+          BIN="chicha-isotope-map_${GOOS}_${GOARCH}_duckdb"
+          GOFLAGS="-trimpath -buildvcs=false" \
+          go build -tags "netgo,osusergo,duckdb" \
+                   -ldflags "-s -w -X main.CompileVersion=$VERSION" \
+                   -o "dist/${BIN}"
+
+      - name: Upload duckdb artifact (Linux)
+        uses: actions/upload-artifact@v4
+        with:
+          name: bin-linux_amd64_duckdb
+          path: dist/
+
   release:
-    needs: [build_portable, build_duckdb]
+    needs: [build_portable, build_duckdb, build_duckdb_linux]
     runs-on: ubuntu-24.04
     steps:
       - name: Download all artifacts


### PR DESCRIPTION
## Summary
- add a Debian-based Linux/amd64 duckdb build job alongside the existing macOS duckdb matrix
- install build dependencies in the container and build the CGO-enabled duckdb binary with release metadata
- include the new Linux artifact in the release dependencies so it is published with other outputs

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ec2257aa883328364b3c653f611d0)