### PR TITLE
Ensure DuckDB release binaries target glibc 2.31

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,8 +149,8 @@ jobs:
     if: contains(toJson(github.event.head_commit.message), 'stable release')
     runs-on: ubuntu-24.04
     container:
-      # Keep the DuckDB container on a supported Debian release so apt sources remain valid.
-      image: debian:12-slim
+      # Build DuckDB binaries on Debian 11 (glibc 2.31) so the released binary works on older hosts.
+      image: debian:11-slim
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -180,6 +180,15 @@ jobs:
           set -euo pipefail
           go get github.com/marcboeker/go-duckdb/v2@latest
           go mod tidy
+
+      - name: Rebuild DuckDB static library for glibc 2.31
+        shell: bash
+        run: |
+          set -euo pipefail
+          module_dir=$(go list -f '{{.Dir}}' -m github.com/marcboeker/go-duckdb)
+          # Rebuild the bundled static lib against Debian 11's toolchain to avoid
+          # newer GLIBC/GLIBCXX requirements in released binaries.
+          make -C "$module_dir" deps.linux.amd64
 
       - name: Build (Linux duckdb)
         shell: bash

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ sudo curl -L https://github.com/matveynator/chicha-isotope-map/releases/download
   && chicha-isotope-map
 ```
 
+> DuckDB builds are compiled on Debian 11 (glibc 2.31) so they keep running on older distros without needing newer system libc versions.
+
 **macOS Intel (x86\_64)**
 
 ```bash


### PR DESCRIPTION
## Summary
- build the Linux DuckDB artifact inside a Debian 11 container to match glibc 2.31
- rebuild the bundled DuckDB static library during CI to avoid newer GLIBC/GLIBCXX requirements
- document that DuckDB binaries target Debian 11 for broader compatibility

## Testing
- not run (CI only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ef557b1908332a3e3b6c7e39e90ac)