### PR TITLE
Ensure cmake available for duckdb build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,8 @@ jobs:
             ca-certificates \
             curl \
             git \
-            build-essential
+            build-essential \
+            cmake
           update-ca-certificates
 
       - name: Set up Go (Linux)


### PR DESCRIPTION
## Summary
- install cmake in the DuckDB Linux build job so the bundled library rebuild succeeds

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ef92b81e8833299243faa05a0fba6)