### PR TITLE
Add BSD arm64 targets to release matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,9 @@ jobs:
           - { goos: darwin, goarch: arm64, goversion: "1.23", runner: "macos-14" }
           # *BSD
           - { goos: freebsd, goarch: amd64, goversion: "1.23", runner: "ubuntu-24.04" }
+          - { goos: freebsd, goarch: arm64, goversion: "1.23", runner: "ubuntu-24.04" }
           - { goos: openbsd, goarch: amd64, goversion: "1.23", runner: "ubuntu-24.04" }
+          - { goos: openbsd, goarch: arm64, goversion: "1.23", runner: "ubuntu-24.04" }
           - { goos: netbsd,  goarch: amd64, goversion: "1.23", runner: "ubuntu-24.04" }
           # Windows
           - { goos: windows, goarch: amd64, goversion: "1.23", runner: "windows-latest" }


### PR DESCRIPTION
## Summary
- add FreeBSD and OpenBSD arm64 build targets to the portable release matrix

## Testing
- go test ./... *(fails locally due to manual interruption for long build time)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692317708fe48332a372841b14aaffb8)