### PR TITLE
Wrap PostgreSQL COPY temp tables in transactions

### DIFF
--- a/pkg/database/postgresql_copy.go
+++ b/pkg/database/postgresql_copy.go
@@ -32,39 +32,6 @@ func (db *Database) insertMarkersPostgreSQLCopy(ctx context.Context, chunk []Mar
 	}
 	defer conn.Close()
 
-	// The timestamp-based suffix keeps names unique per call while staying
-	// predictable for debugging. Temporary scope avoids cross-connection
-	// contention and mirrors "A little copying is better than a little
-	// dependency" by keeping the helper self-contained.
-	tempTable := fmt.Sprintf("temp_markers_%d", time.Now().UnixNano())
-	// Avoid ON COMMIT DROP so the temporary table survives PostgreSQL's
-	// autocommit mode long enough for COPY and the final INSERT to finish.
-	createTemp := fmt.Sprintf(`CREATE TEMP TABLE %s (
-doseRate DOUBLE PRECISION,
-date BIGINT,
-lon DOUBLE PRECISION,
-lat DOUBLE PRECISION,
-countRate DOUBLE PRECISION,
-zoom INT,
-speed DOUBLE PRECISION,
-trackID TEXT,
-altitude DOUBLE PRECISION,
-detector TEXT,
-radiation TEXT,
-temperature DOUBLE PRECISION,
-humidity DOUBLE PRECISION
-)`, tempTable)
-	if _, err := conn.ExecContext(ctx, createTemp); err != nil {
-		return fmt.Errorf("create temp table: %w", err)
-	}
-
-	// Ensure cleanup even if the COPY or final insert fails; use a detached
-	// context to avoid blocking shutdown when the caller's context is already
-	// cancelled.
-	dropCtx, dropCancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer dropCancel()
-	defer conn.ExecContext(dropCtx, fmt.Sprintf("DROP TABLE IF EXISTS %s", tempTable))
-
 	rows := make([][]interface{}, 0, len(chunk))
 	for _, m := range chunk {
 		rows = append(rows, []interface{}{
@@ -82,24 +49,72 @@ humidity DOUBLE PRECISION
 		if !ok {
 			return fmt.Errorf("unexpected postgres driver %T", driverConn)
 		}
-		_, err := direct.Conn().CopyFrom(
+
+		// Keep the temporary table alive during COPY by placing it inside a
+		// single transaction. ON COMMIT DROP handles cleanup even when the
+		// caller exits early, mirroring "Clear is better than clever" by
+		// letting PostgreSQL manage scope.
+		pgConn := direct.Conn()
+		tx, err := pgConn.BeginTx(ctx, pgx.TxOptions{})
+		if err != nil {
+			return fmt.Errorf("begin postgres transaction: %w", err)
+		}
+		committed := false
+		defer func() {
+			if !committed {
+				_ = tx.Rollback(ctx)
+			}
+		}()
+
+		// The timestamp-based suffix keeps names unique per call while staying
+		// predictable for debugging. Temporary scope avoids cross-connection
+		// contention and mirrors "A little copying is better than a little
+		// dependency" by keeping the helper self-contained.
+		tempTable := fmt.Sprintf("temp_markers_%d", time.Now().UnixNano())
+		createTemp := fmt.Sprintf(`CREATE TEMP TABLE %s (
+ doseRate DOUBLE PRECISION,
+ date BIGINT,
+ lon DOUBLE PRECISION,
+ lat DOUBLE PRECISION,
+ countRate DOUBLE PRECISION,
+ zoom INT,
+ speed DOUBLE PRECISION,
+ trackID TEXT,
+ altitude DOUBLE PRECISION,
+ detector TEXT,
+ radiation TEXT,
+ temperature DOUBLE PRECISION,
+ humidity DOUBLE PRECISION
+ ) ON COMMIT DROP`, tempTable)
+		if _, err := tx.Exec(ctx, createTemp); err != nil {
+			return fmt.Errorf("create temp table: %w", err)
+		}
+
+		if _, err := tx.CopyFrom(
 			ctx,
 			pgx.Identifier{tempTable},
 			[]string{"doseRate", "date", "lon", "lat", "countRate", "zoom", "speed", "trackID", "altitude", "detector", "radiation", "temperature", "humidity"},
 			pgx.CopyFromRows(rows),
-		)
-		return err
+		); err != nil {
+			return fmt.Errorf("copy markers into temp table: %w", err)
+		}
+
+		insertFromTemp := fmt.Sprintf(`INSERT INTO markers
+ (doseRate,date,lon,lat,countRate,zoom,speed,trackID,altitude,detector,radiation,temperature,humidity)
+ SELECT doseRate,date,lon,lat,countRate,zoom,speed,trackID,altitude,detector,radiation,temperature,humidity FROM %s
+ ON CONFLICT ON CONSTRAINT markers_unique DO NOTHING`, tempTable)
+		if _, err := tx.Exec(ctx, insertFromTemp); err != nil {
+			return fmt.Errorf("merge temp markers: %w", err)
+		}
+
+		if err := tx.Commit(ctx); err != nil {
+			return fmt.Errorf("commit temp markers: %w", err)
+		}
+		committed = true
+		return nil
 	})
 	if copyErr != nil {
-		return fmt.Errorf("copy markers into temp table: %w", copyErr)
-	}
-
-	insertFromTemp := fmt.Sprintf(`INSERT INTO markers
-(doseRate,date,lon,lat,countRate,zoom,speed,trackID,altitude,detector,radiation,temperature,humidity)
-SELECT doseRate,date,lon,lat,countRate,zoom,speed,trackID,altitude,detector,radiation,temperature,humidity FROM %s
-ON CONFLICT ON CONSTRAINT markers_unique DO NOTHING`, tempTable)
-	if _, err := conn.ExecContext(ctx, insertFromTemp); err != nil {
-		return fmt.Errorf("merge temp markers: %w", err)
+		return copyErr
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- wrap the PostgreSQL COPY fast path in a single transaction so the temporary table survives until insert
- keep ON COMMIT DROP cleanup while performing COPY and merge from the same pgx transaction

## Testing
- go test ./... *(hangs locally; interrupted)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b6af3d1a88332a422a5b6d9b80d48)