### PR TITLE
Improve PostgreSQL bulk import throughput

### DIFF
--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -1488,6 +1488,22 @@ func (db *Database) InsertMarkersBulk(ctx context.Context, tx *sql.Tx, markers [
 		}
 	}
 
+	// PostgreSQL imports suffer when each chunk creates and drops a fresh temporary
+	// table because the catalog churn compounds with database size. By running one
+	// long-lived COPY session per bulk call we keep throughput closer to linear even
+	// on very large datasets. We attempt the streaming COPY path up front so callers
+	// keep the familiar progress reporting while avoiding per-chunk schema churn. If
+	// the server rejects COPY we gracefully fall back to the multi-row VALUES path
+	// below so archive imports continue instead of stalling.
+	if driver == "pgx" && tx == nil {
+		copyErr := db.insertMarkersPostgreSQLCopyBatched(ctx, markers, batch, progress)
+		if copyErr == nil {
+			return nil
+		}
+		// Preserve the previous behaviour on COPY errors to keep imports resilient
+		// even when PostgreSQL blocks temporary tables or COPY on the connection.
+	}
+
 	i := 0
 	for i < len(markers) {
 		select {
@@ -1512,20 +1528,6 @@ func (db *Database) InsertMarkersBulk(ctx context.Context, tx *sql.Tx, markers [
 
 		switch driver {
 		case "pgx":
-			if txn == nil && db.DB != nil && len(chunk) >= 128 {
-				if copyErr := db.insertMarkersPostgreSQLCopy(ctx, chunk); copyErr == nil {
-					mode = "copy"
-					done += len(chunk)
-					if progress != nil {
-						select {
-						case progress <- MarkerBatchProgress{Total: total, Done: done, Batch: len(chunk), Mode: mode, Duration: time.Since(chunkStart)}:
-						default:
-						}
-					}
-					i = end
-					continue
-				}
-			}
 			// PostgreSQL: BIGSERIAL fills id, so we only ship the payload columns.
 			sb.WriteString("INSERT INTO markers (doseRate,date,lon,lat,countRate,zoom,speed,trackID,altitude,detector,radiation,temperature,humidity) VALUES ")
 			argn := 0
@@ -2404,19 +2406,19 @@ func (db *Database) PromoteStaleRealtime(cutoff int64, dbType string) error {
 	// correct placeholder syntax for the current driver once and reuse it for every
 	// realtime marker promotion. This keeps the insert statement portable without
 	// sprinkling switch statements through the loop.
-        var staleMarkerInsert string
-        {
-                // Keep the placeholder count aligned with the 19 insert columns so drivers
-                // never see mismatched argument errors when reusing the rendered statement.
-                ph := make([]string, 19)
-                for i := range ph {
-                        ph[i] = placeholder(db.Driver, i+1)
-                }
-                staleMarkerInsert = fmt.Sprintf(`
+	var staleMarkerInsert string
+	{
+		// Keep the placeholder count aligned with the 19 insert columns so drivers
+		// never see mismatched argument errors when reusing the rendered statement.
+		ph := make([]string, 19)
+		for i := range ph {
+			ph[i] = placeholder(db.Driver, i+1)
+		}
+		staleMarkerInsert = fmt.Sprintf(`
 INSERT INTO markers
       (id,doseRate,date,lon,lat,countRate,zoom,speed,trackID,altitude,detector,radiation,temperature,humidity,device_id,transport,device_name,tube,country)
 VALUES (%s)`, strings.Join(ph, ","))
-        }
+	}
 	for _, id := range ids {
 		ms, err := db.fetchRealtimeByDevice(id, dbType)
 		if err != nil {


### PR DESCRIPTION
## Summary
- add a batched PostgreSQL COPY path that reuses a single temp table to keep imports linear on large databases
- fall back to the existing multi-row insert path when COPY is unavailable while keeping progress updates intact

## Testing
- go test ./... *(hangs in this environment; interrupted)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bfeac5220833291b99d92def35ea3)