### PR TITLE
Add track registry for faster track pagination

### DIFF
--- a/chicha-isotope-map.go
+++ b/chicha-isotope-map.go
@@ -3526,6 +3526,11 @@ func processAndStoreMarkersWithContext(
 		return bbox, trackID, fmt.Errorf("all markers filtered out")
 	}
 
+	// Keep the track registry in sync so pagination queries avoid expensive DISTINCT scans.
+	if err := db.EnsureTrackPresence(ctx, trackID, dbType); err != nil {
+		return bbox, trackID, err
+	}
+
 	// ── step 4: speed calculation (pure Go) ─────────────────────────
 	markers = calculateSpeedForMarkers(markers)
 	if err := observeContext(ctx); err != nil {


### PR DESCRIPTION
## Summary
- add a portable tracks registry table and indexes to speed track pagination queries
- keep the registry in sync during ingest and backfill existing databases asynchronously
- switch track index/count lookups to reuse the registry instead of DISTINCT scans

## Testing
- go test ./... *(hangs in this environment; aborted)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c2e38257883329334b535e1c9207e)