### PR TITLE
Highlight single-track playback reset button when zoom changes

### DIFF
--- a/public_html/map.html
+++ b/public_html/map.html
@@ -893,6 +893,16 @@ body, html {
           margin-top:4px;
         }
 
+        .track-reset-btn.is-attention{
+          background: var(--action-attention-bg);
+          color: var(--action-attention-text);
+          border: 1px solid #fff;
+        }
+
+        .track-reset-btn.is-attention:hover{
+          background: var(--action-attention-bg-hover);
+        }
+
         .loading-overlay{
           position:absolute;
           top:50%;left:50%;
@@ -2569,6 +2579,13 @@ function setTrackViewPlaybackButtonState(state) {
   trackViewPlaybackButton.setAttribute('aria-label', translate(labelKey));
 }
 
+function setTrackViewResetButtonAttention(isAttention) {
+  if (!trackViewResetButton) {
+    return;
+  }
+  trackViewResetButton.classList.toggle('is-attention', isAttention);
+}
+
 function refreshTrackViewPlaybackControl() {
   if (!trackViewPlaybackContainer || !trackViewPlaybackButton) {
     return;
@@ -2609,7 +2626,7 @@ function createTrackViewPlaybackControl() {
   control.addTo(map);
   trackViewPlaybackContainer = control.getContainer();
   trackViewPlaybackButton = trackViewPlaybackContainer.querySelector('#trackPlaybackButton');
-  const trackViewResetButton = trackViewPlaybackContainer.querySelector('#trackPlaybackResetButton');
+  trackViewResetButton = trackViewPlaybackContainer.querySelector('#trackPlaybackResetButton');
   if (trackViewPlaybackButton) {
     trackViewPlaybackButton.addEventListener('click', function () {
       toggleTrackViewPlayback();
@@ -2623,6 +2640,7 @@ function createTrackViewPlaybackControl() {
       updateMarkers(true);
     });
   }
+  setTrackViewResetButtonAttention(trackViewZoomChanged);
   refreshTrackViewPlaybackControl();
 }
 
@@ -2869,6 +2887,8 @@ function resetTrackViewPlaybackForZoom() {
   if (!isTrackView || !currentTrackID) {
     return;
   }
+  trackViewZoomChanged = false;
+  setTrackViewResetButtonAttention(false);
   // Zooming changes the visible bounds, so clear state before re-streaming.
   trackViewPlaybackGeneration += 1;
   stopTrackViewPlayback(false);
@@ -2930,9 +2950,11 @@ let trackViewPlaybackGeneration = 0;
 const trackViewPlaybackConfig = { pointDelayMs: 70 };
 let trackViewPlaybackButton = null;
 let trackViewPlaybackContainer = null;
+let trackViewResetButton = null;
 let trackViewMarkers = [];
 let trackViewMarkersReady = false;
 let trackViewReloadTimer = null;
+let trackViewZoomChanged = false;
 
 var liveHistoryCache = new Map();
 
@@ -3354,6 +3376,8 @@ document.addEventListener('DOMContentLoaded', function () {
 
     // Adjust marker size on zoom
     map.on('zoomend', function() {
+      trackViewZoomChanged = true;
+      setTrackViewResetButtonAttention(true);
       adjustMarkerRadius();
       scheduleTrackViewReload();
     });

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -2636,7 +2636,7 @@ function createTrackViewPlaybackControl() {
     trackViewResetButton.setAttribute('title', 'Reset track playback');
     trackViewResetButton.setAttribute('aria-label', 'Reset track playback');
     trackViewResetButton.addEventListener('click', function () {
-      resetTrackViewPlaybackForZoom();
+      resetTrackViewPlaybackForZoom(true);
       updateMarkers(true);
     });
   }
@@ -2883,12 +2883,14 @@ function toggleTrackViewPlayback() {
   startTrackViewPlayback();
 }
 
-function resetTrackViewPlaybackForZoom() {
+function resetTrackViewPlaybackForZoom(clearZoomAttention) {
   if (!isTrackView || !currentTrackID) {
     return;
   }
-  trackViewZoomChanged = false;
-  setTrackViewResetButtonAttention(false);
+  if (clearZoomAttention) {
+    trackViewZoomChanged = false;
+    setTrackViewResetButtonAttention(false);
+  }
   // Zooming changes the visible bounds, so clear state before re-streaming.
   trackViewPlaybackGeneration += 1;
   stopTrackViewPlayback(false);


### PR DESCRIPTION
### Motivation
- Users need the single-track playback reset button to receive the same orange attention styling as other reset/back controls when the map zoom changes so the UI clearly indicates a state change requiring reset.
- The highlight should trigger only when zoom actually changes in single-track view and be removed when the reset action is performed.

### Description
- Added CSS rules for `.track-reset-btn.is-attention` to match the existing orange attention styling used elsewhere.
- Introduced `trackViewResetButton` and `trackViewZoomChanged` state variables and a helper `setTrackViewResetButtonAttention(isAttention)` to toggle the visual attention state.
- Wired attention toggling so `zoomend` in track view sets the attention state to `true` and the reset action (`resetTrackViewPlaybackForZoom`) clears it.
- Ensured the control initialises the reset button reference and applies the current attention state when the track playback control is created (all changes in `public_html/map.html`).

### Testing
- Ran `go test ./...` and the command completed successfully with package tests reporting expected results and non-test packages skipped.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce832efc88833297c4e28e42fc315d)