### PR TITLE
Set month slider as default date mode

### DIFF
--- a/public_html/map.html
+++ b/public_html/map.html
@@ -3542,7 +3542,7 @@ function createDateRangeSlider(){
 
   let sliderBox, yearSlider, monthSlider;
   // Default to the last known mode so shared links keep the same UI affordance.
-  let mode  = loadDateRangeMode() || 'year';                // 'year' | 'month'
+  let mode  = loadDateRangeMode() || 'month';               // 'year' | 'month'
   saveDateRangeMode(mode); // persist default so URL state stays explicit
   updateUrl(); // publish the default mode before any slider interaction
   let initY = false, initM = false;  // lazy init flags


### PR DESCRIPTION
### Motivation
- Default the date-range UI to month mode so users see the monthly slider when no saved `dateMode` is present.

### Description
- Change the fallback initialization in `createDateRangeSlider()` from `loadDateRangeMode() || 'year'` to `loadDateRangeMode() || 'month'` in `public_html/map.html` so month becomes the default.

### Testing
- Verified the change with `rg -n "let mode\s+= loadDateRangeMode\(\)" public_html/map.html` and inspected the `git diff`, and committed the single-line update; these checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce891412f48332b382f34cdc089b16)