### PR TITLE
Fix initial marker and date-slider loading when map tiles are delayed

### DIFF
--- a/public_html/map.html
+++ b/public_html/map.html
@@ -3349,8 +3349,10 @@ document.addEventListener('DOMContentLoaded', function () {
   if (Array.isArray(initialMarkers) && initialMarkers.length > 0) {
     isTrackView = true;
 
-    // Don't show initialMarkers immediately; load them in parts via get_markers
-    map.on('load', debounceUpdateMarkers);
+    // Rely on whenReady so marker loading does not depend on tile fetch success.
+    map.whenReady(function() {
+      debounceUpdateMarkers();
+    });
 
     // Adjust marker size on zoom
     map.on('zoomend', function() {
@@ -3360,7 +3362,9 @@ document.addEventListener('DOMContentLoaded', function () {
     map.on('moveend', scheduleTrackViewReload);
   } else {
     // Dynamic marker updates in global mode
-    map.on('load', debounceUpdateMarkers);
+    map.whenReady(function() {
+      debounceUpdateMarkers();
+    });
     map.on('zoomend', function() {
       adjustMarkerRadius();
       if (trackPlaybackActive || playbackMarkersRendered) {
@@ -3378,7 +3382,6 @@ document.addEventListener('DOMContentLoaded', function () {
       }
       debounceUpdateMarkers();
     });
-    debounceUpdateMarkers;
   }
 
   // Load map state from URL


### PR DESCRIPTION
### Motivation
- In restrictive or "safe" browser modes Leaflet's `load` event can be delayed or suppressed while tiles are blocked, preventing the first marker fetch and date-slider initialization until a manual page reload.

### Description
- Replace `map.on('load', debounceUpdateMarkers)` with `map.whenReady(function() { debounceUpdateMarkers(); })` in both track-view and global initialization so marker loading does not depend on tile fetch timing in `public_html/map.html`.
- Remove a stray no-op `debounceUpdateMarkers;` line that never executed.
- Changes are limited to the map initialization logic and do not alter other marker streaming or slider code paths.

### Testing
- Ran `go test ./...` and the test run completed successfully (packages that include tests passed and other packages reported no test files).
- Verified repository status shows the modified file `public_html/map.html` as updated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce8b5a70988332a08d1da7e1f5cbd9)