### PR TITLE
Sort track markers by time then radiation (draw higher-dose markers on top)

### DIFF
--- a/public_html/map.html
+++ b/public_html/map.html
@@ -2774,43 +2774,28 @@ function markerDoseRateForSort(marker) {
   return typeof marker.doseRate === 'number' ? marker.doseRate : 0;
 }
 
-function markerOverlapCellKeyForSort(marker) {
-  if (!marker || typeof marker.lat !== 'number' || typeof marker.lon !== 'number') {
-    return 'unknown';
+function compareMarkersByZoomPriority(a, b, zoomLevel) {
+  // On low zoom we prioritize hotspot visibility. On close zoom we prioritize
+  // chronological layering so fresh points stay on top.
+  if (zoomLevel <= 10) {
+    const byDoseRate = markerDoseRateForSort(a) - markerDoseRateForSort(b);
+    if (byDoseRate !== 0) {
+      return byDoseRate;
+    }
+    return markerTimestampForSort(a) - markerTimestampForSort(b);
   }
-  const overlapMeters = 10;
-  const latitudeMetersPerDegree = 111320;
-  const latitudeStepDegrees = overlapMeters / latitudeMetersPerDegree;
-  const normalizedLatitude = Math.max(-85, Math.min(85, marker.lat));
-  const longitudeMetersPerDegree = latitudeMetersPerDegree * Math.cos(normalizedLatitude * Math.PI / 180);
-  const longitudeStepDegrees = longitudeMetersPerDegree > 0
-    ? overlapMeters / longitudeMetersPerDegree
-    : 360;
-  const latitudeCell = Math.round(marker.lat / latitudeStepDegrees);
-  const longitudeCell = Math.round(marker.lon / longitudeStepDegrees);
-  return `${latitudeCell}:${longitudeCell}`;
+
+  const byTimestamp = markerTimestampForSort(a) - markerTimestampForSort(b);
+  if (byTimestamp !== 0) {
+    return byTimestamp;
+  }
+  return markerDoseRateForSort(a) - markerDoseRateForSort(b);
 }
 
-function compareMarkersByFreshnessAndRadiation(a, b) {
-  const aCellKey = markerOverlapCellKeyForSort(a);
-  const bCellKey = markerOverlapCellKeyForSort(b);
-
-  if (aCellKey === bCellKey) {
-    // Markers from the same ~10m area can physically overlap, so time decides
-    // which one should stay on top to preserve the temporal narrative.
-    const byTimestamp = markerTimestampForSort(a) - markerTimestampForSort(b);
-    if (byTimestamp !== 0) {
-      return byTimestamp;
-    }
-    return markerDoseRateForSort(a) - markerDoseRateForSort(b);
-  }
-
-  // Markers from different places should prioritize hotspot visibility.
-  const byDoseRate = markerDoseRateForSort(a) - markerDoseRateForSort(b);
-  if (byDoseRate !== 0) {
-    return byDoseRate;
-  }
-  return markerTimestampForSort(a) - markerTimestampForSort(b);
+function createMarkerSortComparatorForZoom(zoomLevel) {
+  return function compareMarkersForZoom(a, b) {
+    return compareMarkersByZoomPriority(a, b, zoomLevel);
+  };
 }
 
 async function playTrackViewPoints(state, points) {
@@ -2875,13 +2860,14 @@ async function startTrackViewPlayback() {
   trackViewPlaybackState = createTrackViewPlaybackState();
   const playbackGeneration = trackViewPlaybackState.generation;
   try {
-    // Sort markers with an overlap-aware strategy:
-    // 1) same ~10m cell -> timestamp first,
-    // 2) different cells -> radiation first.
+    // Layering priority depends on zoom:
+    // zoom <= 10  -> radiation first,
+    // zoom >= 11  -> timestamp first.
+    const trackViewZoomLevel = map && typeof map.getZoom === 'function' ? map.getZoom() : 11;
     const normalized = trackViewMarkers
       .map(normalizeTrackViewPlaybackMarker)
       .filter(Boolean)
-      .sort(compareMarkersByFreshnessAndRadiation);
+      .sort(createMarkerSortComparatorForZoom(trackViewZoomLevel));
     await playTrackViewPoints(trackViewPlaybackState, normalized);
   } catch (err) {
     return;
@@ -5306,9 +5292,9 @@ function updateMarkers(forceReload){
     finalizeTrackStream();
     es.close();
     if (isTrackView) {
-      // Keep layering deterministic using the same overlap-aware comparator as
-      // playback so snapshot and animation produce identical z-order.
-      trackViewMarkers.sort(compareMarkersByFreshnessAndRadiation);
+      // Use the same zoom-aware sorting as playback so both modes stay aligned.
+      const trackViewZoomLevel = map && typeof map.getZoom === 'function' ? map.getZoom() : 11;
+      trackViewMarkers.sort(createMarkerSortComparatorForZoom(trackViewZoomLevel));
       trackViewMarkersReady = true;
       if (!trackViewAutoplayRequested) {
         renderTrackViewSnapshot();

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -4840,6 +4840,7 @@ function updateMapMarkers(loadingEl, forceReload, loadToken) {
 
   const renderQueue = [];
   let renderScheduled = false;
+  let renderQueueNeedsSort = false;
   let pendingRenderItems = 0;
   let streamsFinalized = false;
 
@@ -4852,11 +4853,28 @@ function updateMapMarkers(loadingEl, forceReload, loadToken) {
       return;
     }
     renderQueue.push({ marker: marker, layerName: layerName });
+    renderQueueNeedsSort = true;
     pendingRenderItems += 1;
     if (!renderScheduled) {
       renderScheduled = true;
       requestAnimationFrame(drainRenderQueue);
     }
+  }
+
+  function compareRenderQueueEntriesByZoomPriority(a, b) {
+    const compareResult = compareMarkersByZoomPriority(a.marker, b.marker, zoom);
+    if (compareResult !== 0) {
+      return compareResult;
+    }
+    const aLayerName = typeof a.layerName === 'string' ? a.layerName : '';
+    const bLayerName = typeof b.layerName === 'string' ? b.layerName : '';
+    if (aLayerName < bLayerName) {
+      return -1;
+    }
+    if (aLayerName > bLayerName) {
+      return 1;
+    }
+    return 0;
   }
 
   function drainRenderQueue() {
@@ -4865,6 +4883,11 @@ function updateMapMarkers(loadingEl, forceReload, loadToken) {
       renderQueue.length = 0;
       pendingRenderItems = 0;
       return;
+    }
+    if (renderQueueNeedsSort && renderQueue.length > 1) {
+      // Sort before drawing so z-order follows zoom-specific priority rules.
+      renderQueue.sort(compareRenderQueueEntriesByZoomPriority);
+      renderQueueNeedsSort = false;
     }
     const start = performance.now();
     while (renderQueue.length && performance.now() - start < 12) {

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -2774,12 +2774,43 @@ function markerDoseRateForSort(marker) {
   return typeof marker.doseRate === 'number' ? marker.doseRate : 0;
 }
 
-function compareMarkersByFreshnessAndRadiation(a, b) {
-  const byTimestamp = markerTimestampForSort(a) - markerTimestampForSort(b);
-  if (byTimestamp !== 0) {
-    return byTimestamp;
+function markerOverlapCellKeyForSort(marker) {
+  if (!marker || typeof marker.lat !== 'number' || typeof marker.lon !== 'number') {
+    return 'unknown';
   }
-  return markerDoseRateForSort(a) - markerDoseRateForSort(b);
+  const overlapMeters = 10;
+  const latitudeMetersPerDegree = 111320;
+  const latitudeStepDegrees = overlapMeters / latitudeMetersPerDegree;
+  const normalizedLatitude = Math.max(-85, Math.min(85, marker.lat));
+  const longitudeMetersPerDegree = latitudeMetersPerDegree * Math.cos(normalizedLatitude * Math.PI / 180);
+  const longitudeStepDegrees = longitudeMetersPerDegree > 0
+    ? overlapMeters / longitudeMetersPerDegree
+    : 360;
+  const latitudeCell = Math.round(marker.lat / latitudeStepDegrees);
+  const longitudeCell = Math.round(marker.lon / longitudeStepDegrees);
+  return `${latitudeCell}:${longitudeCell}`;
+}
+
+function compareMarkersByFreshnessAndRadiation(a, b) {
+  const aCellKey = markerOverlapCellKeyForSort(a);
+  const bCellKey = markerOverlapCellKeyForSort(b);
+
+  if (aCellKey === bCellKey) {
+    // Markers from the same ~10m area can physically overlap, so time decides
+    // which one should stay on top to preserve the temporal narrative.
+    const byTimestamp = markerTimestampForSort(a) - markerTimestampForSort(b);
+    if (byTimestamp !== 0) {
+      return byTimestamp;
+    }
+    return markerDoseRateForSort(a) - markerDoseRateForSort(b);
+  }
+
+  // Markers from different places should prioritize hotspot visibility.
+  const byDoseRate = markerDoseRateForSort(a) - markerDoseRateForSort(b);
+  if (byDoseRate !== 0) {
+    return byDoseRate;
+  }
+  return markerTimestampForSort(a) - markerTimestampForSort(b);
 }
 
 async function playTrackViewPoints(state, points) {
@@ -2844,8 +2875,9 @@ async function startTrackViewPlayback() {
   trackViewPlaybackState = createTrackViewPlaybackState();
   const playbackGeneration = trackViewPlaybackState.generation;
   try {
-    // Sort by timestamp first, then by radiation, so higher dose markers from the
-    // same moment are rendered later and stay visible above lower values.
+    // Sort markers with an overlap-aware strategy:
+    // 1) same ~10m cell -> timestamp first,
+    // 2) different cells -> radiation first.
     const normalized = trackViewMarkers
       .map(normalizeTrackViewPlaybackMarker)
       .filter(Boolean)
@@ -5274,8 +5306,8 @@ function updateMarkers(forceReload){
     finalizeTrackStream();
     es.close();
     if (isTrackView) {
-      // Keep track view layering deterministic: older and lower-dose markers are
-      // drawn first, newer and higher-dose markers are drawn last.
+      // Keep layering deterministic using the same overlap-aware comparator as
+      // playback so snapshot and animation produce identical z-order.
       trackViewMarkers.sort(compareMarkersByFreshnessAndRadiation);
       trackViewMarkersReady = true;
       if (!trackViewAutoplayRequested) {

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -2766,6 +2766,22 @@ function normalizeTrackViewPlaybackMarker(marker) {
   return marker;
 }
 
+function markerTimestampForSort(marker) {
+  return typeof marker.date === 'number' ? marker.date : 0;
+}
+
+function markerDoseRateForSort(marker) {
+  return typeof marker.doseRate === 'number' ? marker.doseRate : 0;
+}
+
+function compareMarkersByFreshnessAndRadiation(a, b) {
+  const byTimestamp = markerTimestampForSort(a) - markerTimestampForSort(b);
+  if (byTimestamp !== 0) {
+    return byTimestamp;
+  }
+  return markerDoseRateForSort(a) - markerDoseRateForSort(b);
+}
+
 async function playTrackViewPoints(state, points) {
   for (let i = state.pointIndex; i < points.length; i++) {
     if (!trackViewPlaybackActive) {
@@ -2828,15 +2844,12 @@ async function startTrackViewPlayback() {
   trackViewPlaybackState = createTrackViewPlaybackState();
   const playbackGeneration = trackViewPlaybackState.generation;
   try {
-    // Sort by timestamp so playback always runs from the first marker to the last.
+    // Sort by timestamp first, then by radiation, so higher dose markers from the
+    // same moment are rendered later and stay visible above lower values.
     const normalized = trackViewMarkers
       .map(normalizeTrackViewPlaybackMarker)
       .filter(Boolean)
-      .sort(function(a, b) {
-        const aDate = typeof a.date === 'number' ? a.date : 0;
-        const bDate = typeof b.date === 'number' ? b.date : 0;
-        return aDate - bDate;
-      });
+      .sort(compareMarkersByFreshnessAndRadiation);
     await playTrackViewPoints(trackViewPlaybackState, normalized);
   } catch (err) {
     return;
@@ -5261,11 +5274,9 @@ function updateMarkers(forceReload){
     finalizeTrackStream();
     es.close();
     if (isTrackView) {
-      trackViewMarkers.sort(function(a, b) {
-        const aDate = typeof a.date === 'number' ? a.date : 0;
-        const bDate = typeof b.date === 'number' ? b.date : 0;
-        return aDate - bDate;
-      });
+      // Keep track view layering deterministic: older and lower-dose markers are
+      // drawn first, newer and higher-dose markers are drawn last.
+      trackViewMarkers.sort(compareMarkersByFreshnessAndRadiation);
       trackViewMarkersReady = true;
       if (!trackViewAutoplayRequested) {
         renderTrackViewSnapshot();


### PR DESCRIPTION
### Motivation
- Markers with lower radiation were sometimes rendered above higher-radiation markers and obscured contamination hotspots. 
- The desired behavior is deterministic layering where newer markers are above older ones and, for identical timestamps, higher-dose markers are drawn later (on top).

### Description
- Added helper functions `markerTimestampForSort`, `markerDoseRateForSort` and `compareMarkersByFreshnessAndRadiation` in `public_html/map.html` to encapsulate the two-key comparator.
- Switched the playback sorting in `startTrackViewPlayback` to use `compareMarkersByFreshnessAndRadiation` so playback renders in time order and, for equal timestamps, by radiation.
- Switched the post-stream track snapshot sort (in the `es.addEventListener('done')` path) to use the same comparator so the track view snapshot layering is deterministic.

### Testing
- Ran `git diff --check` and inspected the diff with `git diff -- public_html/map.html`, both commands completed successfully with no check failures.
- No automated JS unit tests were available for this area, so changes were verified by automated diff checks and manual code inspection of updated sort call sites.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d37d74d848833282016170fd2d28dd)