### PR TITLE
Fix Linux desktop webview dependency installation on GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,8 +175,13 @@ jobs:
         if: runner.os == 'Linux'
         shell: bash
         run: |
+          set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y build-essential pkg-config libgtk-3-dev libwebkit2gtk-4.0-dev
+          WEBKIT_DEV_PACKAGE="libwebkit2gtk-4.1-dev"
+          if ! apt-cache show "${WEBKIT_DEV_PACKAGE}" >/dev/null 2>&1; then
+            WEBKIT_DEV_PACKAGE="libwebkit2gtk-4.0-dev"
+          fi
+          sudo apt-get install -y build-essential pkg-config libgtk-3-dev "${WEBKIT_DEV_PACKAGE}"
 
       - name: go mod tidy (POSIX)
         if: runner.os != 'Windows'


### PR DESCRIPTION
### Motivation
- The Linux desktop build on Ubuntu 24.04 fails because `libwebkit2gtk-4.0-dev` is not available on newer runners, so the workflow must select the correct WebKitGTK dev package at runtime.

### Description
- Update `.github/workflows/release.yml` to prefer `libwebkit2gtk-4.1-dev` and fall back to `libwebkit2gtk-4.0-dev` if `4.1` is not present, and add `set -euo pipefail` to the install step for more robust shell execution.

### Testing
- Verified package availability with `apt-cache policy libwebkit2gtk-4.1-dev libwebkit2gtk-4.0-dev` which indicated `4.1` is present on the runner; the check succeeded.
- Committed and inspected the change with `git add` / `git commit` and `git show`, and those operations completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da678b42dc8332a7f01e339c0676d7)