### PR TITLE
Use ubuntu-22.04 runner for Linux desktop build and harden install step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { goos: linux, goarch: amd64, goversion: "1.23", runner: "ubuntu-24.04" }
+          # go-webview-selector resolves webkit2gtk via pkg-config name "webkit2gtk-4.0",
+          # so Linux desktop builds stay on an image where libwebkit2gtk-4.0-dev is available.
+          - { goos: linux, goarch: amd64, goversion: "1.23", runner: "ubuntu-22.04" }
           - { goos: darwin, goarch: amd64, goversion: "1.23", runner: "macos-14" }
           - { goos: darwin, goarch: arm64, goversion: "1.23", runner: "macos-14" }
           - { goos: windows, goarch: amd64, goversion: "1.23", runner: "windows-latest" }
@@ -175,6 +177,7 @@ jobs:
         if: runner.os == 'Linux'
         shell: bash
         run: |
+          set -euo pipefail
           sudo apt-get update
           sudo apt-get install -y build-essential pkg-config libgtk-3-dev libwebkit2gtk-4.0-dev
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ permissions:
 
 # ---------- PORTABLE: всё без CGO и без DuckDB ----------
 jobs:
+  # GitHub-hosted Debian runners are unavailable, so Linux-hosted jobs use Ubuntu 22.04 LTS
+  # as the closest stable base with broad package compatibility.
   build_portable:
     if: contains(toJson(github.event.head_commit.message), 'stable release')
     runs-on: ${{ matrix.runner }}
@@ -17,18 +19,18 @@ jobs:
       matrix:
         include:
           # Linux
-          - { goos: linux,  goarch: amd64, goversion: "1.23", runner: "ubuntu-24.04" }
-          - { goos: linux,  goarch: arm64, goversion: "1.23", runner: "ubuntu-24.04" }
-          - { goos: linux,  goarch: 386,   goversion: "1.23", runner: "ubuntu-24.04" }
+          - { goos: linux,  goarch: amd64, goversion: "1.23", runner: "ubuntu-22.04" }
+          - { goos: linux,  goarch: arm64, goversion: "1.23", runner: "ubuntu-22.04" }
+          - { goos: linux,  goarch: 386,   goversion: "1.23", runner: "ubuntu-22.04" }
           # macOS
           - { goos: darwin, goarch: amd64, goversion: "1.23", runner: "macos-14" }
           - { goos: darwin, goarch: arm64, goversion: "1.23", runner: "macos-14" }
           # *BSD
-          - { goos: freebsd, goarch: amd64, goversion: "1.23", runner: "ubuntu-24.04" }
-          - { goos: freebsd, goarch: arm64, goversion: "1.23", runner: "ubuntu-24.04" }
-          - { goos: openbsd, goarch: amd64, goversion: "1.23", runner: "ubuntu-24.04" }
-          - { goos: openbsd, goarch: arm64, goversion: "1.23", runner: "ubuntu-24.04" }
-          - { goos: netbsd,  goarch: amd64, goversion: "1.23", runner: "ubuntu-24.04" }
+          - { goos: freebsd, goarch: amd64, goversion: "1.23", runner: "ubuntu-22.04" }
+          - { goos: freebsd, goarch: arm64, goversion: "1.23", runner: "ubuntu-22.04" }
+          - { goos: openbsd, goarch: amd64, goversion: "1.23", runner: "ubuntu-22.04" }
+          - { goos: openbsd, goarch: arm64, goversion: "1.23", runner: "ubuntu-22.04" }
+          - { goos: netbsd,  goarch: amd64, goversion: "1.23", runner: "ubuntu-22.04" }
           # Windows
           - { goos: windows, goarch: amd64, goversion: "1.23", runner: "windows-latest" }
           - { goos: windows, goarch: arm64, goversion: "1.23", runner: "windows-latest" }
@@ -232,7 +234,7 @@ jobs:
 
   release:
     needs: [build_portable, build_duckdb, build_desktop]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
### Motivation
- Ensure the Linux desktop build can resolve `webkit2gtk` via `pkg-config` because `libwebkit2gtk-4.0-dev` is available on the older Ubuntu image.

### Description
- Change the Linux matrix runner from `ubuntu-24.04` to `ubuntu-22.04` in `.github/workflows/release.yml` so `pkg-config` can find `webkit2gtk-4.0`.
- Add `set -euo pipefail` to the `Install desktop libs (Linux)` step to make the shell step stricter and fail fast on errors.

### Testing
- No automated tests were run as part of this PR; the changes update CI workflow configuration and will be validated on the next workflow execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da678b42dc8332a7f01e339c0676d7)