### PR TITLE
Use Ubuntu 22.04 runners and add webkit2gtk pkg-config shim for Linux desktop builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ permissions:
 
 # ---------- PORTABLE: всё без CGO и без DuckDB ----------
 jobs:
+  # GitHub-hosted Debian runners are unavailable, so Linux-hosted jobs use Ubuntu 22.04 LTS
+  # as the closest stable base with broad package compatibility.
   build_portable:
     if: contains(toJson(github.event.head_commit.message), 'stable release')
     runs-on: ${{ matrix.runner }}
@@ -17,18 +19,18 @@ jobs:
       matrix:
         include:
           # Linux
-          - { goos: linux,  goarch: amd64, goversion: "1.23", runner: "ubuntu-24.04" }
-          - { goos: linux,  goarch: arm64, goversion: "1.23", runner: "ubuntu-24.04" }
-          - { goos: linux,  goarch: 386,   goversion: "1.23", runner: "ubuntu-24.04" }
+          - { goos: linux,  goarch: amd64, goversion: "1.23", runner: "ubuntu-22.04" }
+          - { goos: linux,  goarch: arm64, goversion: "1.23", runner: "ubuntu-22.04" }
+          - { goos: linux,  goarch: 386,   goversion: "1.23", runner: "ubuntu-22.04" }
           # macOS
           - { goos: darwin, goarch: amd64, goversion: "1.23", runner: "macos-14" }
           - { goos: darwin, goarch: arm64, goversion: "1.23", runner: "macos-14" }
           # *BSD
-          - { goos: freebsd, goarch: amd64, goversion: "1.23", runner: "ubuntu-24.04" }
-          - { goos: freebsd, goarch: arm64, goversion: "1.23", runner: "ubuntu-24.04" }
-          - { goos: openbsd, goarch: amd64, goversion: "1.23", runner: "ubuntu-24.04" }
-          - { goos: openbsd, goarch: arm64, goversion: "1.23", runner: "ubuntu-24.04" }
-          - { goos: netbsd,  goarch: amd64, goversion: "1.23", runner: "ubuntu-24.04" }
+          - { goos: freebsd, goarch: amd64, goversion: "1.23", runner: "ubuntu-22.04" }
+          - { goos: freebsd, goarch: arm64, goversion: "1.23", runner: "ubuntu-22.04" }
+          - { goos: openbsd, goarch: amd64, goversion: "1.23", runner: "ubuntu-22.04" }
+          - { goos: openbsd, goarch: arm64, goversion: "1.23", runner: "ubuntu-22.04" }
+          - { goos: netbsd,  goarch: amd64, goversion: "1.23", runner: "ubuntu-22.04" }
           # Windows
           - { goos: windows, goarch: amd64, goversion: "1.23", runner: "windows-latest" }
           - { goos: windows, goarch: arm64, goversion: "1.23", runner: "windows-latest" }
@@ -155,7 +157,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { goos: linux, goarch: amd64, goversion: "1.23", runner: "ubuntu-24.04" }
+          # go-webview-selector resolves webkit2gtk via pkg-config name "webkit2gtk-4.0",
+          # so Linux desktop builds provide a webkit2gtk-4.0 pkg-config target.
+          - { goos: linux, goarch: amd64, goversion: "1.23", runner: "ubuntu-22.04" }
           - { goos: darwin, goarch: amd64, goversion: "1.23", runner: "macos-14" }
           - { goos: darwin, goarch: arm64, goversion: "1.23", runner: "macos-14" }
           - { goos: windows, goarch: amd64, goversion: "1.23", runner: "windows-latest" }
@@ -175,8 +179,35 @@ jobs:
         if: runner.os == 'Linux'
         shell: bash
         run: |
+          set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y build-essential pkg-config libgtk-3-dev libwebkit2gtk-4.0-dev
+          WEBKIT_DEV_PACKAGE="libwebkit2gtk-4.0-dev"
+          if ! apt-cache show "${WEBKIT_DEV_PACKAGE}" >/dev/null 2>&1; then
+            WEBKIT_DEV_PACKAGE="libwebkit2gtk-4.1-dev"
+          fi
+          sudo apt-get install -y build-essential pkg-config libgtk-3-dev "${WEBKIT_DEV_PACKAGE}"
+
+          if ! pkg-config --exists webkit2gtk-4.0 && pkg-config --exists webkit2gtk-4.1; then
+            # go-webview-selector currently asks pkg-config for webkit2gtk-4.0.
+            # This compatibility shim maps that lookup to webkit2gtk-4.1 on newer distros.
+            sudo install -d /usr/local/lib/pkgconfig
+            sudo tee /usr/local/lib/pkgconfig/webkit2gtk-4.0.pc >/dev/null <<'EOF'
+prefix=/usr
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: webkit2gtk-4.0
+Description: Compatibility shim for webkit2gtk-4.1
+Version: 4.0
+Requires: webkit2gtk-4.1
+Libs:
+Cflags:
+EOF
+            echo "PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:${PKG_CONFIG_PATH:-}" >> "$GITHUB_ENV"
+          fi
+
+          pkg-config --exists webkit2gtk-4.0
 
       - name: go mod tidy (POSIX)
         if: runner.os != 'Windows'
@@ -229,7 +260,7 @@ jobs:
 
   release:
     needs: [build_portable, build_duckdb, build_desktop]
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
### Motivation

- GitHub-hosted Debian runners are unavailable so Linux and *BSD CI should use a stable Ubuntu base with broad package compatibility.  
- Desktop builds need to resolve `webkit2gtk-4.0` via `pkg-config` while some newer distros only provide `webkit2gtk-4.1`, so a compatibility shim is required.

### Description

- Updated `.github/workflows/release.yml` to replace `ubuntu-24.04` with `ubuntu-22.04` for Linux and *BSD matrix entries and the `release` job.  
- In the `build_desktop` job, added logic to prefer `libwebkit2gtk-4.0-dev` and fall back to `libwebkit2gtk-4.1-dev` when 4.0 is not available.  
- Added a compatibility shim that writes `/usr/local/lib/pkgconfig/webkit2gtk-4.0.pc` when only `webkit2gtk-4.1` is present and exports `PKG_CONFIG_PATH` to make `pkg-config --exists webkit2gtk-4.0` succeed.  
- Hardened Linux install steps with `set -euo pipefail` and documented the reason for the shim in comments.

### Testing

- No automated tests were executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da678b42dc8332a7f01e339c0676d7)