### PR TITLE
Fix Linux desktop workflow webkit shim generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,19 +191,19 @@ jobs:
             # go-webview-selector currently asks pkg-config for webkit2gtk-4.0.
             # This compatibility shim maps that lookup to webkit2gtk-4.1 on newer distros.
             sudo install -d /usr/local/lib/pkgconfig
-            sudo tee /usr/local/lib/pkgconfig/webkit2gtk-4.0.pc >/dev/null <<EOF
-prefix=/usr
-exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
-includedir=${prefix}/include
-
-Name: webkit2gtk-4.0
-Description: Compatibility shim for webkit2gtk-4.1
-Version: 4.0
-Requires: webkit2gtk-4.1
-Libs:
-Cflags:
-EOF
+            printf '%s\n' \
+              'prefix=/usr' \
+              'exec_prefix=${prefix}' \
+              'libdir=${exec_prefix}/lib' \
+              'includedir=${prefix}/include' \
+              '' \
+              'Name: webkit2gtk-4.0' \
+              'Description: Compatibility shim for webkit2gtk-4.1' \
+              'Version: 4.0' \
+              'Requires: webkit2gtk-4.1' \
+              'Libs:' \
+              'Cflags:' \
+              | sudo tee /usr/local/lib/pkgconfig/webkit2gtk-4.0.pc >/dev/null
             echo "PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:${PKG_CONFIG_PATH:-}" >> "$GITHUB_ENV"
           fi
 


### PR DESCRIPTION
### Motivation
- Replace a fragile heredoc used to generate `webkit2gtk-4.0.pc` in the Linux desktop release job to avoid YAML block-scalar parsing issues and accidental shell interpolation of `${prefix}`.

### Description
- Replace `sudo tee /usr/local/lib/pkgconfig/webkit2gtk-4.0.pc <<EOF` heredoc with a `printf '%s\n' ... | sudo tee /usr/local/lib/pkgconfig/webkit2gtk-4.0.pc` pipeline so the pkg-config shim is emitted reliably and `${prefix}` remains literal.

### Testing
- Ran `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'YAML_OK'"` which succeeded.
- Ran `go build ./...` which succeeded.
- Attempted a Python `yaml.safe_load` check but it could not run in this environment due to missing `PyYAML` (automated check skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db4fca06c483329ffaa7efd11a7dd6)