### PR TITLE
Hide QR and short-link UI in desktop WebView mode

### DIFF
--- a/chicha-isotope-map.go
+++ b/chicha-isotope-map.go
@@ -5292,6 +5292,7 @@ func mapHandler(w http.ResponseWriter, r *http.Request) {
 		LogoImageURL       string
 		LogoLink           string
 		ShowGithubTooltip  bool
+		DesktopWebView     bool
 		ChichaGitHubURL    string
 	}{
 		Version:           displayVersion,
@@ -5316,6 +5317,7 @@ func mapHandler(w http.ResponseWriter, r *http.Request) {
 		LogoImageURL:       activeLogoConfig.ImageURL,
 		LogoLink:           activeLogoConfig.LinkURL,
 		ShowGithubTooltip:  activeLogoConfig.ShowGithubLinkTooltip,
+		DesktopWebView:     *desktopMode,
 		ChichaGitHubURL:    chichaGitHubURL,
 	}
 
@@ -5588,6 +5590,7 @@ func trackHandler(w http.ResponseWriter, r *http.Request) {
 		LogoImageURL       string
 		LogoLink           string
 		ShowGithubTooltip  bool
+		DesktopWebView     bool
 		ChichaGitHubURL    string
 	}{
 		Version:           displayVersion,
@@ -5612,6 +5615,7 @@ func trackHandler(w http.ResponseWriter, r *http.Request) {
 		LogoImageURL:       activeLogoConfig.ImageURL,
 		LogoLink:           activeLogoConfig.LinkURL,
 		ShowGithubTooltip:  activeLogoConfig.ShowGithubLinkTooltip,
+		DesktopWebView:     *desktopMode,
 		ChichaGitHubURL:    chichaGitHubURL,
 	}
 

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -1415,30 +1415,32 @@ body, html {
         <img src="/static/images/marker-icon-2x.png" alt="Locate" style="width:20px;">
       </button>
       <br>
-      <!-- Small QR button under geolocate -->
-      <button id="qrButton" class="qr-btn" aria-label="{{translate "qr_button_tooltip"}}">
-        <svg viewBox="0 0 100 100" role="img" aria-hidden="true">
-          <rect x="0" y="0" width="100" height="100" fill="#fff"/>
-          <rect x="8" y="8" width="28" height="28" fill="#000"/>
-          <rect x="12" y="12" width="20" height="20" fill="#fff"/>
-          <rect x="16" y="16" width="12" height="12" fill="#000"/>
-          <rect x="64" y="8" width="28" height="28" fill="#000"/>
-          <rect x="68" y="12" width="20" height="20" fill="#fff"/>
-          <rect x="72" y="16" width="12" height="12" fill="#000"/>
-          <rect x="8" y="64" width="28" height="28" fill="#000"/>
-          <rect x="12" y="68" width="20" height="20" fill="#fff"/>
-          <rect x="16" y="72" width="12" height="12" fill="#000"/>
-          <rect x="48" y="12" width="8" height="8" fill="#000"/>
-          <rect x="40" y="28" width="8" height="8" fill="#000"/>
-          <rect x="56" y="28" width="8" height="8" fill="#000"/>
-          <rect x="44" y="44" width="8" height="8" fill="#000"/>
-          <rect x="60" y="44" width="8" height="8" fill="#000"/>
-          <rect x="44" y="60" width="8" height="8" fill="#000"/>
-          <rect x="60" y="60" width="8" height="8" fill="#000"/>
-          <rect x="76" y="60" width="8" height="8" fill="#000"/>
-          <rect x="28" y="44" width="8" height="8" fill="#000"/>
-        </svg>
-      </button>
+      {{if not .DesktopWebView}}
+        <!-- Small QR button under geolocate -->
+        <button id="qrButton" class="qr-btn" aria-label="{{translate "qr_button_tooltip"}}">
+          <svg viewBox="0 0 100 100" role="img" aria-hidden="true">
+            <rect x="0" y="0" width="100" height="100" fill="#fff"/>
+            <rect x="8" y="8" width="28" height="28" fill="#000"/>
+            <rect x="12" y="12" width="20" height="20" fill="#fff"/>
+            <rect x="16" y="16" width="12" height="12" fill="#000"/>
+            <rect x="64" y="8" width="28" height="28" fill="#000"/>
+            <rect x="68" y="12" width="20" height="20" fill="#fff"/>
+            <rect x="72" y="16" width="12" height="12" fill="#000"/>
+            <rect x="8" y="64" width="28" height="28" fill="#000"/>
+            <rect x="12" y="68" width="20" height="20" fill="#fff"/>
+            <rect x="16" y="72" width="12" height="12" fill="#000"/>
+            <rect x="48" y="12" width="8" height="8" fill="#000"/>
+            <rect x="40" y="28" width="8" height="8" fill="#000"/>
+            <rect x="56" y="28" width="8" height="8" fill="#000"/>
+            <rect x="44" y="44" width="8" height="8" fill="#000"/>
+            <rect x="60" y="44" width="8" height="8" fill="#000"/>
+            <rect x="44" y="60" width="8" height="8" fill="#000"/>
+            <rect x="60" y="60" width="8" height="8" fill="#000"/>
+            <rect x="76" y="60" width="8" height="8" fill="#000"/>
+            <rect x="28" y="44" width="8" height="8" fill="#000"/>
+          </svg>
+        </button>
+      {{end}}
     </div>
 
     <!-- Container for "Back to all tracks" button -->
@@ -1468,13 +1470,15 @@ body, html {
       <span class="map-logo-text">{{translate "logo_title"}}</span>
     </h1>
 
-    <!-- Short link pill shows the shareable URL and copies it on click -->
-    <div
-      id="shortLinkDisplay"
-      role="button"
-      tabindex="0"
-      aria-live="polite"
-      aria-label="{{translate "short_link_tooltip"}}"></div>
+    {{if not .DesktopWebView}}
+      <!-- Short link pill shows the shareable URL and copies it on click -->
+      <div
+        id="shortLinkDisplay"
+        role="button"
+        tabindex="0"
+        aria-live="polite"
+        aria-label="{{translate "short_link_tooltip"}}"></div>
+    {{end}}
 
     <!-- Map container -->
     <div id="map"></div>


### PR DESCRIPTION
### Motivation
- Desktop/WebView builds open a local server (127.0.0.1) and QR codes / persistent short links resolve to localhost, so exposing those share controls in the embedded WebView is confusing and pointless. 
- The short-link and QR flows must remain available for normal server deployments, so the change must be scoped to desktop/WebView builds only.

### Description
- Added a `DesktopWebView` boolean to the template data in both `mapHandler` and `trackHandler`, populated from `*desktopMode` so templates can distinguish desktop/WebView runs. 
- Wrapped the QR control (`#qrButton`) and the persistent short-link pill (`#shortLinkDisplay`) in `{{if not .DesktopWebView}} ... {{end}}` in `public_html/map.html` so they are not rendered when `DesktopWebView` is true. 
- Left backend handlers and endpoints (for example `/qrpng` and `/api/shorten`) unchanged so server deployments keep full sharing functionality.

### Testing
- Ran `gofmt` to normalize formatting and `go test ./...` which completed successfully (tests passed or reported no test files where applicable).
- Verified the template variables compile and render paths in the modified handlers (no template execution errors during local checks).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db627f870c8332a2c1660abd4b032e)