### PR TITLE
Run release pipeline only on `stable-release` tag and add Stable Release download URLs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
-name: stable release
+name: Stable Release
 
 on:
   push:
-    branches: [ main ]
+    tags:
+      - stable-release
 
 permissions:
   contents: write
@@ -12,7 +13,6 @@ jobs:
   # GitHub-hosted Debian runners are unavailable, so Linux-hosted jobs use Ubuntu 22.04 LTS
   # as the closest stable base with broad package compatibility.
   build_portable:
-    if: contains(toJson(github.event.head_commit.message), 'stable release')
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -96,7 +96,6 @@ jobs:
 
 # ---------- DUCKDB: Linux/amd64 (glibc 2.28) в контейнере + macOS (amd64/arm64) ----------
   build_duckdb:
-    if: contains(toJson(github.event.head_commit.message), 'stable release')
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -151,7 +150,6 @@ jobs:
 
 # ---------- DESKTOP WEBVIEW: macOS / Linux / Windows ----------
   build_desktop:
-    if: contains(toJson(github.event.head_commit.message), 'stable release')
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -267,12 +265,14 @@ jobs:
         with:
           path: dist-raw/
 
-      - name: Publish GitHub Release (tag latest)
+      - name: Publish GitHub Release (stable tag)
         uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: latest
-          name: "download stable version"
+          tag_name: stable-release
+          name: "Stable Release"
+          make_latest: true
           prerelease: false
+          overwrite_files: true
           files: dist-raw/**/*

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If this map protects even one person or animal, building it was worth it. Let it
 
 Live demo: [https://pelora.org/](https://pelora.org/) — your node will look the same.
 
-👉 [Unified download page](https://github.com/matveynator/chicha-isotope-map/releases) (all platforms, latest builds)
+👉 [Stable Release download page](https://github.com/matveynator/chicha-isotope-map/releases/tag/stable-release) (constant URL, always points to the latest stable binaries)
 
 👉 [DeepWiki: Chicha Isotope Map](https://deepwiki.com/matveynator/chicha-isotope-map)
 
@@ -56,7 +56,15 @@ The project grows thanks to careful support from the **Safecast** community, the
 Fastest path: download the binary. No Docker, no databases, no extra tools — download, run, done.
 
 ### Option 1. Binary (recommended)
-1) Open the [releases page](https://github.com/matveynator/chicha-isotope-map/releases) and download the build for your system.
+1) Open the [Stable Release page](https://github.com/matveynator/chicha-isotope-map/releases/tag/stable-release) and download the build for your system.
+
+Direct stable server binaries (constant URLs):
+- FreeBSD amd64: `https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_freebsd_amd64`
+- FreeBSD arm64: `https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_freebsd_arm64`
+- OpenBSD amd64: `https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_openbsd_amd64`
+- OpenBSD arm64: `https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_openbsd_arm64`
+- macOS amd64: `https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_darwin_amd64`
+- macOS arm64: `https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_darwin_arm64`
 2) Make it executable and run:
 ```bash
 chmod +x ./chicha-isotope-map
@@ -95,7 +103,7 @@ On Linux only, run the short wizard. It starts by asking if HTTPS is needed (the
 
 After writing the unit it reloads systemd, starts the service, tails the log for you, and drops a tiny reminder into your `~/.profile` so SSH logins show how to restart, stop, edit, or tail logs. User sessions install to `~/.config/systemd/user`; running as root targets `/etc/systemd/system`, and each unit is named `chicha-isotope-map-<port>.service` so multiple ports can coexist.
 
-The wizard also writes `/usr/local/bin/chicha-update`, a helper that stops the freshly provisioned service, downloads the latest GitHub release, restarts the service, and tails the log — one command to refresh the node.
+The wizard also writes `/usr/local/bin/chicha-update`, a helper that stops the freshly provisioned service, downloads the latest Stable Release, restarts the service, and tails the log — one command to refresh the node.
 
 Quick refresher for later:
 - edit the unit: `sudo nano /etc/systemd/system/chicha-isotope-map-<port>.service` (drop `sudo` for user units)

--- a/doc/README_RU.md
+++ b/doc/README_RU.md
@@ -23,7 +23,7 @@
 
 Живая демо: [https://pelora.org/](https://pelora.org/) — ваш узел будет выглядеть так же.
 
-👉 [Единая страница скачивания](https://github.com/matveynator/chicha-isotope-map/releases) (все платформы, свежие версии)
+👉 [Страница Stable Release](https://github.com/matveynator/chicha-isotope-map/releases/tag/stable-release) (постоянный URL, всегда ведёт на актуальные стабильные бинарники)
 
 👉 [DeepWiki: Chicha Isotope Map](https://deepwiki.com/matveynator/chicha-isotope-map)
 
@@ -61,7 +61,15 @@
 Самый быстрый путь — готовый бинарник. Никакой Docker, БД или внешние инструменты не нужны: скачали, запустили, карта готова.
 
 ### Вариант 1. Готовый бинарник (рекомендуется)
-1. Откройте [страницу релизов](https://github.com/matveynator/chicha-isotope-map/releases) и скачайте файл под свою систему.
+1. Откройте [страницу Stable Release](https://github.com/matveynator/chicha-isotope-map/releases/tag/stable-release) и скачайте файл под свою систему.
+
+Постоянные ссылки на серверные бинарники (не меняются между релизами):
+- FreeBSD amd64: `https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_freebsd_amd64`
+- FreeBSD arm64: `https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_freebsd_arm64`
+- OpenBSD amd64: `https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_openbsd_amd64`
+- OpenBSD arm64: `https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_openbsd_arm64`
+- macOS amd64: `https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_darwin_amd64`
+- macOS arm64: `https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_darwin_arm64`
 2. Сделайте файл исполняемым и запустите:
    ```bash
    chmod +x ./chicha-isotope-map


### PR DESCRIPTION
### Motivation
- Prevent accidental builds from Dependabot or branch commits by making the release pipeline run only from a single stable tag.
- Provide a permanent download endpoint so server/install scripts can reference fixed URLs that always point to the latest stable binaries.

### Description
- Changed `.github/workflows/release.yml` to trigger on `push` to the `stable-release` tag and removed the commit-message gates that previously gated job execution.
- Updated the release publishing step to use `tag_name: stable-release`, `name: "Stable Release"`, and enabled `make_latest: true` and `overwrite_files: true` so the same release endpoint stays current.
- Updated `README.md` and `doc/README_RU.md` to link to the Stable Release page (`/releases/tag/stable-release`), added direct stable server binary URLs for FreeBSD/OpenBSD/macOS, and clarified that the `chicha-update` helper fetches the Stable Release.
- Renamed workflow title to `Stable Release` and kept existing artifact naming conventions for portable/duckdb/desktop builds unchanged.

### Testing
- Ran repository checks (`git diff --check`) which reported no whitespace/patch errors and succeeded.
- Verified working tree status with `git status --short` before committing and committed the changes (commit recorded locally).
- Did not run GitHub Actions here, so CI workflow execution and artifact publishing were not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db662609c48332be2fe9cedd7c8232)