### PR TITLE
Fix stable release workflow trigger by commit message

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,14 @@ name: Stable Release
 
 on:
   push:
+    branches:
+      - '**'
     tags:
       - stable-release
+  workflow_dispatch:
+
+# Run automatically for commits containing "stable release" (any commit in the push),
+# or for explicit stable-release tag pushes / manual dispatch.
 
 permissions:
   contents: write
@@ -13,6 +19,7 @@ jobs:
   # GitHub-hosted Debian runners are unavailable, so Linux-hosted jobs use Ubuntu 22.04 LTS
   # as the closest stable base with broad package compatibility.
   build_portable:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/stable-release') || contains(join(github.event.commits.*.message, ' || '), 'stable release') || contains(join(github.event.commits.*.message, ' || '), 'Stable Release')
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -96,6 +103,7 @@ jobs:
 
 # ---------- DUCKDB: Linux/amd64 (glibc 2.28) в контейнере + macOS (amd64/arm64) ----------
   build_duckdb:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/stable-release') || contains(join(github.event.commits.*.message, ' || '), 'stable release') || contains(join(github.event.commits.*.message, ' || '), 'Stable Release')
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -150,6 +158,7 @@ jobs:
 
 # ---------- DESKTOP WEBVIEW: macOS / Linux / Windows ----------
   build_desktop:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/stable-release') || contains(join(github.event.commits.*.message, ' || '), 'stable release') || contains(join(github.event.commits.*.message, ' || '), 'Stable Release')
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -257,6 +266,7 @@ jobs:
           path: dist/
 
   release:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/stable-release') || contains(join(github.event.commits.*.message, ' || '), 'stable release') || contains(join(github.event.commits.*.message, ' || '), 'Stable Release')
     needs: [build_portable, build_duckdb, build_desktop]
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
### Motivation
- The release workflow only ran for tag pushes, which stopped builds triggered by commit messages containing `stable release` and prevented the automated release pipeline from running on normal pushes.
- A manual fallback trigger was needed to allow explicit recovery runs when automatic detection fails.

### Description
- Updated `/.github/workflows/release.yml` to also listen to branch pushes and added `workflow_dispatch` for manual runs. 
- Added a unified job-level `if` condition to `build_portable`, `build_duckdb`, `build_desktop`, and `release` so jobs run only when `github.event_name == 'workflow_dispatch'` OR the ref starts with `refs/tags/stable-release` OR any commit message in the push contains `stable release` or `Stable Release`.
- The change preserves tag-based releases while restoring the former behavior of triggering releases by commit message and avoids running heavy matrices on unrelated pushes.

### Testing
- Verified the modified workflow file content with `sed -n` to ensure the new triggers and `workflow_dispatch` were added and the file structure is intact, which succeeded.
- Used `rg` to confirm the new `if:` conditions are present on all release jobs, which succeeded.
- Reviewed the diff with `git diff` to confirm the intended changes to `/.github/workflows/release.yml`, which succeeded.
- Confirmed repository status with `git status` to ensure only the expected workflow file was modified, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db97f0a2c883329bebf7064936ce76)