### PR TITLE
Add polished stable release download page and publish it via workflow

### DIFF
--- a/.github/release/stable-release.md
+++ b/.github/release/stable-release.md
@@ -1,0 +1,108 @@
+<div align="center">
+  <img src="https://raw.githubusercontent.com/matveynator/chicha-isotope-map/main/public_html/images/chicha-isotope-map-round-logo.png" alt="Chicha Isotope Map logo" width="120" />
+
+# Chicha Isotope Map — Stable Download Page
+
+Download and run in minutes on **Windows**, **macOS**, and **Linux**.
+</div>
+
+---
+
+## 🖥️ Desktop app (GUI)
+
+> Best choice for personal use: click, launch, and use the map locally.
+
+### Windows
+[⬇️ Download Desktop for Windows (amd64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_windows_amd64_desktop.exe)
+
+1. Download the `.exe` file.
+2. Double-click to launch.
+3. If Windows SmartScreen appears, click **More info → Run anyway**.
+
+### macOS
+- [⬇️ Download Desktop for macOS Apple Silicon (arm64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_darwin_arm64_desktop)
+- [⬇️ Download Desktop for macOS Intel (amd64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_darwin_amd64_desktop)
+
+1. Download the right binary for your Mac.
+2. Open Terminal in the download folder.
+3. Run:
+
+```bash
+chmod +x ./chicha-isotope-map_darwin_*_desktop
+./chicha-isotope-map_darwin_*_desktop
+```
+
+If Gatekeeper blocks launch, open **System Settings → Privacy & Security** and allow the app.
+
+### Linux
+[⬇️ Download Desktop for Linux (amd64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64_desktop)
+
+```bash
+curl -fL https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64_desktop -o chicha-isotope-map-desktop
+chmod +x ./chicha-isotope-map-desktop
+./chicha-isotope-map-desktop
+```
+
+---
+
+## 🛠️ Server app (self-hosted node)
+
+> Best choice for VPS/server deployment and always-on public/private node.
+
+### Linux quick install (curl + run)
+
+```bash
+curl -fL https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64 -o chicha-isotope-map
+chmod +x ./chicha-isotope-map
+./chicha-isotope-map
+```
+
+Then open: http://localhost:8765
+
+### macOS server binary
+- [⬇️ Download server for macOS Apple Silicon (arm64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_darwin_arm64)
+- [⬇️ Download server for macOS Intel (amd64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_darwin_amd64)
+
+Run in Terminal:
+
+```bash
+chmod +x ./chicha-isotope-map_darwin_*
+./chicha-isotope-map_darwin_*
+```
+
+### Windows server binary
+[⬇️ Download server for Windows (amd64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_windows_amd64.exe)
+
+PowerShell quick run:
+
+```powershell
+Invoke-WebRequest -Uri "https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_windows_amd64.exe" -OutFile "chicha-isotope-map.exe"
+.\chicha-isotope-map.exe
+```
+
+---
+
+## 📦 More binaries
+
+Need another platform or architecture (arm64, FreeBSD, OpenBSD, etc.)?
+Open **Assets** in this release and pick the matching file name.
+
+- Stable URL (always current):
+  https://github.com/matveynator/chicha-isotope-map/releases/tag/stable-release
+
+---
+
+## 🚀 First launch tips
+
+- Default local URL: `http://localhost:8765`
+- Public domain mode with HTTPS (Let's Encrypt):
+
+```bash
+./chicha-isotope-map -domain your-domain.example
+```
+
+- Linux guided service setup:
+
+```bash
+./chicha-isotope-map -setup
+```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,6 +282,7 @@ jobs:
         with:
           tag_name: stable-release
           name: "Stable Release"
+          body_path: .github/release/stable-release.md
           make_latest: true
           prerelease: false
           overwrite_files: true


### PR DESCRIPTION
### Motivation
- Provide a clear, OS-first download and run experience for Desktop and Server binaries so users can quickly install on Windows, macOS, and Linux.
- Make the `stable-release` GitHub Release actionable and consistent by shipping a maintained release body instead of an empty/auto-generated description.

### Description
- Add a new release body file at `.github/release/stable-release.md` containing a centered hero block with the project logo and separate `Desktop app` and `Server app` sections with platform-specific download links and copy/paste commands.
- Wire the release job in `.github/workflows/release.yml` to use `body_path: .github/release/stable-release.md` so the file is used as the release body when publishing the `stable-release` tag.
- Include quick `curl`/`chmod` examples for Linux, PowerShell quick-run for Windows, and macOS Terminal instructions to make first-run steps explicit.

### Testing
- Ran `go test ./...` and the test run completed with no failing packages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dce92ccb90833282f79b18244869a2)