### PR TITLE
Add stable downloads landing page and update README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # Chicha Isotope Map
 
-Download page for the latest stable build. <br>
+Download page for the latest stable build: <a href="https://matveynator.github.io/chicha-isotope-map/doc/pages/">matveynator.github.io/chicha-isotope-map/doc/pages</a>. <br>
 Radiacode, AtomFast, BGeigie Safecast devices supported.
 
 [![Latest stable release build](https://github.com/matveynator/chicha-isotope-map/actions/workflows/release.yml/badge.svg)](https://github.com/matveynator/chicha-isotope-map/actions/workflows/release.yml)

--- a/doc/pages/index.html
+++ b/doc/pages/index.html
@@ -1,0 +1,302 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Chicha Isotope Map — Stable Downloads</title>
+  <meta name="description" content="Download the latest stable desktop and server builds of Chicha Isotope Map." />
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #0b1220;
+      --bg-soft: #131d31;
+      --surface: #1a2942;
+      --surface-strong: #22365a;
+      --text: #e9f1ff;
+      --muted: #9cb0d4;
+      --accent: #5fa8ff;
+      --accent-strong: #7fbeff;
+      --ok: #5fe0a1;
+      --warn: #ffd280;
+      --border: #2f4b79;
+      --shadow: rgba(0, 0, 0, 0.35);
+      --radius-lg: 16px;
+      --radius-sm: 12px;
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      background:
+        radial-gradient(90rem 70rem at -20% -10%, #2f4b79 0%, transparent 45%),
+        radial-gradient(80rem 60rem at 120% 0%, #2d5ca6 0%, transparent 45%),
+        var(--bg);
+      color: var(--text);
+      font-family: Inter, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+      line-height: 1.5;
+      min-height: 100vh;
+    }
+
+    .container {
+      margin: 0 auto;
+      max-width: 1080px;
+      padding: 2.5rem 1.25rem 4rem;
+    }
+
+    .hero {
+      background: linear-gradient(160deg, rgba(34, 54, 90, 0.95), rgba(18, 31, 53, 0.95));
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      box-shadow: 0 20px 40px -24px var(--shadow);
+      display: grid;
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+      padding: 1.5rem;
+    }
+
+    .hero-main {
+      align-items: center;
+      display: flex;
+      gap: 1rem;
+    }
+
+    .hero-main img {
+      width: 72px;
+      height: 72px;
+      border-radius: 20px;
+      box-shadow: 0 8px 18px -12px #000;
+      background: rgba(255,255,255,0.08);
+      padding: 0.35rem;
+    }
+
+    h1 {
+      font-size: clamp(1.35rem, 3vw, 2rem);
+      letter-spacing: 0.01em;
+    }
+
+    .subtitle {
+      color: var(--muted);
+      margin-top: 0.2rem;
+    }
+
+    .chips {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.55rem;
+      margin-top: 0.55rem;
+    }
+
+    .chip {
+      background: rgba(95, 168, 255, 0.13);
+      border: 1px solid rgba(127, 190, 255, 0.4);
+      border-radius: 999px;
+      color: #cae0ff;
+      font-size: 0.87rem;
+      padding: 0.25rem 0.7rem;
+    }
+
+    .links-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      margin-top: 0.35rem;
+    }
+
+    .button {
+      align-items: center;
+      background: linear-gradient(180deg, var(--accent-strong), var(--accent));
+      border: 0;
+      border-radius: 11px;
+      color: #0b1426;
+      display: inline-flex;
+      font-weight: 650;
+      gap: 0.45rem;
+      justify-content: center;
+      min-height: 2.65rem;
+      padding: 0.6rem 1rem;
+      text-decoration: none;
+      transition: transform 120ms ease, filter 120ms ease;
+    }
+
+    .button:hover {
+      filter: brightness(1.08);
+      transform: translateY(-1px);
+    }
+
+    .button.secondary {
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid var(--border);
+      color: var(--text);
+    }
+
+    .grid {
+      display: grid;
+      gap: 1rem;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      margin-top: 1rem;
+    }
+
+    .card {
+      background: linear-gradient(180deg, rgba(26, 41, 66, 0.94), rgba(17, 27, 45, 0.95));
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      padding: 1.25rem;
+      box-shadow: 0 18px 35px -25px var(--shadow);
+    }
+
+    .card-header {
+      align-items: baseline;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.6rem;
+      justify-content: space-between;
+      margin-bottom: 0.8rem;
+    }
+
+    h2 {
+      font-size: 1.1rem;
+    }
+
+    .label {
+      color: #12213a;
+      background: var(--ok);
+      border-radius: 999px;
+      font-size: 0.74rem;
+      font-weight: 700;
+      letter-spacing: 0.03em;
+      padding: 0.2rem 0.6rem;
+      text-transform: uppercase;
+    }
+
+    .label.warn {
+      background: var(--warn);
+    }
+
+    .note {
+      color: var(--muted);
+      font-size: 0.95rem;
+      margin-bottom: 1rem;
+    }
+
+    .download-list {
+      display: grid;
+      gap: 0.6rem;
+      margin-bottom: 1rem;
+    }
+
+    .download-link {
+      background: rgba(255, 255, 255, 0.03);
+      border: 1px solid rgba(156, 176, 212, 0.25);
+      border-radius: var(--radius-sm);
+      color: var(--text);
+      display: block;
+      font-weight: 550;
+      padding: 0.62rem 0.8rem;
+      text-decoration: none;
+    }
+
+    .download-link:hover {
+      border-color: var(--accent);
+      color: #ffffff;
+    }
+
+    .code-block {
+      background: #0a1427;
+      border: 1px solid #29426a;
+      border-radius: var(--radius-sm);
+      color: #cae0ff;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 0.87rem;
+      overflow-x: auto;
+      padding: 0.75rem;
+      white-space: pre;
+    }
+
+    .footer {
+      color: var(--muted);
+      font-size: 0.9rem;
+      margin-top: 1.35rem;
+      text-align: center;
+    }
+
+    @media (max-width: 900px) {
+      .grid {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="container">
+    <section class="hero">
+      <div class="hero-main">
+        <img src="../../public_html/images/chicha-isotope-map-round-logo.png" alt="Chicha Isotope Map logo" />
+        <div>
+          <h1>Chicha Isotope Map — Stable Downloads</h1>
+          <p class="subtitle">Desktop and server binaries for Radiacode, AtomFast and Safecast workflows.</p>
+          <div class="chips">
+            <span class="chip">Windows</span>
+            <span class="chip">macOS</span>
+            <span class="chip">Linux</span>
+            <span class="chip">FreeBSD</span>
+            <span class="chip">OpenBSD</span>
+            <span class="chip">amd64 & arm64</span>
+          </div>
+        </div>
+      </div>
+      <div class="links-row">
+        <a class="button" href="https://github.com/matveynator/chicha-isotope-map/releases/tag/stable-release">Open all release assets</a>
+        <a class="button secondary" href="https://github.com/matveynator/chicha-isotope-map">View source on GitHub</a>
+      </div>
+    </section>
+
+    <section class="grid">
+      <article class="card">
+        <div class="card-header">
+          <h2>Desktop app (GUI)</h2>
+          <span class="label">Recommended</span>
+        </div>
+        <p class="note">Best for local personal use. Download, run, and work with map UI immediately.</p>
+
+        <div class="download-list">
+          <a class="download-link" href="https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_windows_amd64_desktop.exe">Windows (amd64) desktop</a>
+          <a class="download-link" href="https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_darwin_arm64_desktop">macOS Apple Silicon (arm64) desktop</a>
+          <a class="download-link" href="https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_darwin_amd64_desktop">macOS Intel (amd64) desktop</a>
+          <a class="download-link" href="https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64_desktop">Linux (amd64) desktop</a>
+        </div>
+
+        <div class="code-block"># Linux quick start
+curl -fL https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64_desktop -o chicha-isotope-map-desktop
+chmod +x ./chicha-isotope-map-desktop
+./chicha-isotope-map-desktop</div>
+      </article>
+
+      <article class="card">
+        <div class="card-header">
+          <h2>Server app (self-hosted)</h2>
+          <span class="label warn">Headless</span>
+        </div>
+        <p class="note">Run as local or remote server. Open the map from any browser at <code>localhost:8765</code>.</p>
+
+        <div class="download-list">
+          <a class="download-link" href="https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_windows_amd64.exe">Windows (amd64) server</a>
+          <a class="download-link" href="https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_darwin_arm64">macOS Apple Silicon (arm64) server</a>
+          <a class="download-link" href="https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_darwin_amd64">macOS Intel (amd64) server</a>
+          <a class="download-link" href="https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64">Linux (amd64) server</a>
+        </div>
+
+        <div class="code-block"># Linux quick start (server)
+sudo curl -fL https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64 -o /usr/local/bin/chicha-isotope-map
+sudo chmod +x /usr/local/bin/chicha-isotope-map
+/usr/local/bin/chicha-isotope-map</div>
+      </article>
+    </section>
+
+    <p class="footer">Stable assets are replaced on each <strong>stable-release</strong> build, so links always point to the latest version.</p>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a dedicated, user-friendly stable downloads landing page for the project and make it discoverable from the repository `README.md`.

### Description
- Add `doc/pages/index.html`, a self-contained, styled HTML page listing stable desktop and server download assets and quick-start commands.
- Update `README.md` to point to the new stable downloads page URL and adjust the download description.
- Include direct links to the release assets for Windows, macOS (arm64/amd64) and Linux in the new page and provide quick start commands for desktop and server usage.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e13154776c8332ba9632d564ee82ce)