### PR TITLE
fix: update webview_go checksum in go.sum

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -45,7 +45,7 @@ github.com/klauspost/cpuid/v2 v2.2.9 h1:66ze0taIn2H33fBvCkXuv9BmCwDfafmiIVpKV9kK
 github.com/klauspost/cpuid/v2 v2.2.9/go.mod h1:rqkxqrZ1EhYM9G+hXH7YdowN5R5RGN6NK4QwQ3WMXF8=
 github.com/marcboeker/go-duckdb v1.8.5 h1:tkYp+TANippy0DaIOP5OEfBEwbUINqiFqgwMQ44jME0=
 github.com/marcboeker/go-duckdb v1.8.5/go.mod h1:6mK7+WQE4P4u5AFLvVBmhFxY5fvhymFptghgJX6B+/8=
-github.com/matveynator/webview_go v0.0.0-20240831120633-6173450d4dd6 h1:VQpB2SpK88C6B5lPHTuSZKb2Qee1QWwiFlC5CKY4AW0=
+github.com/matveynator/webview_go v0.0.0-20240831120633-6173450d4dd6 h1:DG+MBai9DumgQj68+qDCpzx9G5cGiB+QwO2LXvlDkTg=
 github.com/matveynator/webview_go v0.0.0-20240831120633-6173450d4dd6/go.mod h1:yE65LFCeWf4kyWD5re+h4XNvOHJEXOCOuJZ4v8l5sgk=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=


### PR DESCRIPTION
### Motivation
- Fix a `checksum mismatch` produced by `go mod tidy` for `github.com/matveynator/webview_go v0.0.0-20240831120633-6173450d4dd6` so CI dependency validation can pass.

### Description
- Replace the `go.sum` entry for `github.com/matveynator/webview_go v0.0.0-20240831120633-6173450d4dd6` with checksum `h1:DG+MBai9DumgQj68+qDCpzx9G5cGiB+QwO2LXvlDkTg=` and commit the change to the repository.

### Testing
- Ran `go mod tidy` and `GOPROXY=direct go mod tidy` in this environment and both could not complete due to `proxy.golang.org` / network `Forbidden` errors, so end-to-end verification of the module fetch could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e265f77a788332a9e2835df2240b57)