### PR TITLE
fix: use valid ICO file in Windows release resource generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,7 +281,8 @@ jobs:
           $ErrorActionPreference = "Stop"
           go install github.com/akavel/rsrc@latest
           $rsrcBin = Join-Path (go env GOPATH) "bin/rsrc.exe"
-          & $rsrcBin -ico "public_html/images/app-icon.ico" -arch amd64 -o "zz_chicha_icon_windows_amd64.syso"
+          # rsrc requires a real ICO container; app-icon.ico currently stores PNG bytes.
+          & $rsrcBin -ico "public_html/images/favicon.ico" -arch amd64 -o "zz_chicha_icon_windows_amd64.syso"
 
       - name: Build desktop (Windows)
         if: runner.os == 'Windows'


### PR DESCRIPTION
### Motivation
- The Windows release step using `rsrc` failed with `bad magic number` because `public_html/images/app-icon.ico` contains PNG bytes rather than a real ICO container, so the workflow must use a valid ICO file.

### Description
- Updated `.github/workflows/release.yml` to use `public_html/images/favicon.ico` for the `rsrc -ico` invocation and added an inline comment explaining that `rsrc` requires a real ICO container.

### Testing
- Ran a byte-magic check with Python to compare file signatures and confirmed `public_html/images/favicon.ico` has ICO magic while `public_html/images/app-icon.ico` contains PNG bytes using `Path(...).read_bytes()[:8]` (succeeded). 
- Attempted to run `go install github.com/akavel/rsrc@latest` and `rsrc` locally but Go proxy access is blocked (`Forbidden`), so generation of the `.syso` file could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e28da67dec8332906bf64f5a10b64d)