### PR TITLE
Desktop: use per-user DB path when launched from Finder; fix Windows ICO in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,7 +281,8 @@ jobs:
           $ErrorActionPreference = "Stop"
           go install github.com/akavel/rsrc@latest
           $rsrcBin = Join-Path (go env GOPATH) "bin/rsrc.exe"
-          & $rsrcBin -ico "public_html/images/app-icon.ico" -arch amd64 -o "zz_chicha_icon_windows_amd64.syso"
+          # rsrc requires a real ICO container; app-icon.ico currently stores PNG bytes.
+          & $rsrcBin -ico "public_html/images/favicon.ico" -arch amd64 -o "zz_chicha_icon_windows_amd64.syso"
 
       - name: Build desktop (Windows)
         if: runner.os == 'Windows'

--- a/chicha-isotope-map.go
+++ b/chicha-isotope-map.go
@@ -6976,6 +6976,37 @@ func realtimeHistoryHandler(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
+// resolveDesktopDefaultDBPath returns a writable per-user DB path for desktop
+// launches when operators did not pass -db-path explicitly.
+func resolveDesktopDefaultDBPath(driverName string, port int, logf func(string, ...any)) string {
+	var extension string
+	switch driverName {
+	case "sqlite", "chai":
+		extension = driverName
+	case "duckdb":
+		extension = "duckdb"
+	default:
+		return ""
+	}
+
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		logf("desktop mode: user config dir unavailable, keeping implicit DB path: %v", err)
+		return ""
+	}
+
+	appDir := filepath.Join(configDir, "chicha-isotope-map")
+	if mkErr := os.MkdirAll(appDir, 0o755); mkErr != nil {
+		logf("desktop mode: cannot prepare DB directory %s: %v", appDir, mkErr)
+		return ""
+	}
+
+	defaultFile := fmt.Sprintf("database-%d.%s", port, extension)
+	resolvedPath := filepath.Join(appDir, defaultFile)
+	logf("desktop mode: resolved default DB path to %s", resolvedPath)
+	return resolvedPath
+}
+
 // =====================
 // MAIN
 // =====================
@@ -7052,9 +7083,19 @@ func main() {
 	// Persist the normalized driver back into the flag so downstream helpers never
 	// miss engine-specific branches because of incidental casing or whitespace.
 	*dbType = driverName
+	resolvedDBPath := strings.TrimSpace(*dbPath)
+	if *desktopMode && resolvedDBPath == "" {
+		// Finder-launched desktop apps often start outside writable project folders.
+		// We place file-based databases in a per-user config directory to keep
+		// startup deterministic regardless of the current working directory.
+		if autoPath := resolveDesktopDefaultDBPath(driverName, *port, log.Printf); autoPath != "" {
+			resolvedDBPath = autoPath
+		}
+	}
+	*dbPath = resolvedDBPath
 	dbCfg := database.Config{
 		DBType: driverName,
-		DBPath: *dbPath,
+		DBPath: resolvedDBPath,
 		Port:   *port,
 	}
 	switch driverName {


### PR DESCRIPTION
### Motivation

- Desktop-launched apps may start outside writable project folders, so file-based DBs need a deterministic per-user writable default path.
- The Windows resource bundler (`rsrc`) requires a real ICO container and the previous asset contained PNG bytes, which broke icon embedding.

### Description

- Add `resolveDesktopDefaultDBPath(driverName, port, logf)` to compute a per-user config DB file under `os.UserConfigDir()` named `database-<port>.<ext>` for `sqlite`/`chai`/`duckdb`, with logging and safe fallback to an empty path.
- Update `main()` to use the resolved path when `-desktop-mode` is enabled and `-db-path` is empty, and persist the resolved value into `database.Config` via `*dbPath`.
- Ensure directory creation is attempted with `os.MkdirAll` and errors are logged without hard-failing desktop startups.
- Update `.github/workflows/release.yml` Windows packaging step to use `public_html/images/favicon.ico` for `rsrc` and include a comment explaining the change.

### Testing

- Ran `go build` for desktop and server targets locally and executed `go test ./...`; builds and tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e28da67dec8332906bf64f5a10b64d)