### PR TITLE
Fix desktop/web titles to chicha-isotope-map and include version

### DIFF
--- a/chicha-isotope-map.go
+++ b/chicha-isotope-map.go
@@ -7273,7 +7273,7 @@ func main() {
 	desktopFallbackActive := false
 	if *desktopMode {
 		address := fmt.Sprintf("127.0.0.1:%d", *port)
-		if err := desktop.RunWebviewWindow(address); err != nil {
+		if err := desktop.RunWebviewWindow(address, resolveDisplayVersion()); err != nil {
 			if errors.Is(err, desktop.ErrExternalBrowserLaunched) {
 				log.Printf("desktop mode: launched system browser fallback; keeping server running")
 				desktopFallbackActive = true

--- a/pkg/desktop/webview_disabled.go
+++ b/pkg/desktop/webview_disabled.go
@@ -6,7 +6,8 @@ import "fmt"
 
 // RunWebviewWindow returns a clear error in non-desktop builds so release binaries
 // can keep CGO disabled while exposing an explicit runtime message.
-func RunWebviewWindow(address string) error {
+func RunWebviewWindow(address, appVersion string) error {
 	_ = address
+	_ = appVersion
 	return fmt.Errorf("desktop mode is unavailable in this binary; rebuild with -tags desktop")
 }

--- a/pkg/desktop/webview_enabled.go
+++ b/pkg/desktop/webview_enabled.go
@@ -11,14 +11,15 @@ import (
 
 // RunWebviewWindow opens a native desktop window bound to the running local HTTP server.
 // The function is isolated behind the desktop build tag so server-only builds stay CGO-free.
-func RunWebviewWindow(address string) error {
+func RunWebviewWindow(address, appVersion string) error {
 	window := webview.New(false)
 	if window == nil {
 		return fmt.Errorf("webview: failed to create window")
 	}
 	defer window.Destroy()
 
-	window.SetTitle("chicha-astro-control")
+	windowTitle := fmt.Sprintf("chicha-isotope-map: world radiation map (%s)", appVersion)
+	window.SetTitle(windowTitle)
 	window.SetSize(1120, 760, webview.HintNone)
 	window.Navigate("http://" + address)
 

--- a/pkg/desktop/webview_enabled_nocgo.go
+++ b/pkg/desktop/webview_enabled_nocgo.go
@@ -6,7 +6,8 @@ import "fmt"
 
 // RunWebviewWindow returns a clear error when desktop builds are compiled
 // without CGO. Native webview backends require CGO on all supported desktop OSes.
-func RunWebviewWindow(address string) error {
+func RunWebviewWindow(address, appVersion string) error {
 	_ = address
+	_ = appVersion
 	return fmt.Errorf("desktop mode requires CGO_ENABLED=1; rebuild with CGO and -tags desktop or run with -desktop=false")
 }

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -4,7 +4,7 @@
     <!-- Set metadata and link CSS -->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{translate "title"}}</title>
+    <title>chicha-isotope-map: {{translate "title"}} ({{ .Version }})</title>
     <!-- Keep SEO metadata localized so crawlers understand the map in every language. -->
     <meta name="ai:purpose" content="global environmental radiation map">
     <!-- Provide explicit query parameters so AI agents and crawlers can reconstruct map views. -->


### PR DESCRIPTION
### Motivation
- Fix the incorrect desktop window title (`chicha-astro-control`) and make UI titles display the canonical app name and build version. 
- Ensure the desktop window title always shows the resolved application version so users can see the running build.

### Description
- Replaced the hardcoded desktop window title with a formatted title `chicha-isotope-map: world radiation map (<version>)` and set it from `RunWebviewWindow` in `pkg/desktop/webview_enabled.go`.
- Extended `RunWebviewWindow` signature to accept `appVersion` and updated the non-desktop and nocgo stubs in `pkg/desktop/webview_disabled.go` and `pkg/desktop/webview_enabled_nocgo.go` to keep signatures consistent.
- Passed the resolved display version from `main` by calling `desktop.RunWebviewWindow(address, resolveDisplayVersion())` in `chicha-isotope-map.go`.
- Updated the HTML page title in `public_html/map.html` to include `chicha-isotope-map: {{translate "title"}} ({{ .Version }})` so the web UI tab also shows the canonical name and version.

### Testing
- Ran `go test ./...`; tests completed successfully with `pkg/countryresolver`, `pkg/desktop`, and `pkg/safecast-realtime` reporting `ok` and other packages reporting `[no test files]`.
- No automated UI/browser screenshot tests were available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2979e81f8833295dca0ee6f8f890b)