### PR TITLE
Add Linux arm64 and Windows arm64 desktop release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,9 +167,11 @@ jobs:
           # go-webview-selector resolves webkit2gtk via pkg-config name "webkit2gtk-4.0",
           # so Linux desktop builds provide a webkit2gtk-4.0 pkg-config target.
           - { goos: linux, goarch: amd64, goversion: "1.23", runner: "ubuntu-22.04" }
+          - { goos: linux, goarch: arm64, goversion: "1.23", runner: "ubuntu-24.04-arm" }
           - { goos: darwin, goarch: amd64, goversion: "1.23", runner: "macos-14" }
           - { goos: darwin, goarch: arm64, goversion: "1.23", runner: "macos-14" }
           - { goos: windows, goarch: amd64, goversion: "1.23", runner: "windows-latest" }
+          - { goos: windows, goarch: arm64, goversion: "1.23", runner: "windows-latest" }
 
     steps:
       - name: Checkout
@@ -282,7 +284,8 @@ jobs:
           go install github.com/akavel/rsrc@latest
           $rsrcBin = Join-Path (go env GOPATH) "bin/rsrc.exe"
           # rsrc requires a real ICO container; app-icon.ico currently stores PNG bytes.
-          & $rsrcBin -ico "public_html/images/favicon.ico" -arch amd64 -o "zz_chicha_icon_windows_amd64.syso"
+          $resourceArch = if ("${{ matrix.goarch }}" -eq "arm64") { "arm64" } else { "amd64" }
+          & $rsrcBin -ico "public_html/images/favicon.ico" -arch $resourceArch -o "zz_chicha_icon_windows_${{ matrix.goarch }}.syso"
 
       - name: Build desktop (Windows)
         if: runner.os == 'Windows'

--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ Best for personal local use.
 
 ### Download
 - [Desktop for Windows (amd64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_windows_amd64_desktop.exe)
+- [Desktop for Windows (arm64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_windows_arm64_desktop.exe)
 - [Desktop for macOS Apple Silicon (arm64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_darwin_arm64_desktop)
 - [Desktop for macOS Intel (amd64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_darwin_amd64_desktop)
 - [Desktop for Linux (amd64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64_desktop)
+- [Desktop for Linux (arm64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_arm64_desktop)
 
 ### Run
 Windows:
@@ -129,5 +131,4 @@ This project was conceived to grant people a clear and immediate understanding o
 The Chicha Isotope Map finds its roots in the field research of [Dmitry Ignatenko](https://www.youtube.com/@MrDrimogemon) and has been profoundly shaped by the insights of Rob Oudendijk and the [Safecast community](https://safecast.org). We extend our sincere appreciation to [Safecast](https://simplemap.safecast.org), [AtomFast](https://atomfast.net), [Radiacode](https://radiacode.com), [DoseMap](https://dosemap.org), and the many contributors to open dosimetry whose efforts made this possible.
 
 Should this work serve to safeguard even a single living being, its purpose shall be fully justified.
-
 


### PR DESCRIPTION
### Motivation
- Provide official desktop GUI builds for Linux `arm64` and Windows `arm64` so arm64 users have native release binaries.
- Ensure Windows desktop artifacts include a matching `.syso` resource for the target architecture to avoid mismatched icon embedding.
- Keep release workflow and documentation in sync so CI produces artifacts that users can download directly.

### Description
- Extended the `build_desktop` matrix in `.github/workflows/release.yml` to include `linux/arm64` (runner `ubuntu-24.04-arm`) and `windows/arm64` entries. 
- Made Windows icon resource generation architecture-aware by passing `matrix.goarch` to `rsrc` and producing `zz_chicha_icon_windows_${{ matrix.goarch }}.syso` so `arm64` desktop builds get a correct `.syso`. 
- Updated `README.md` download list to add direct links for `chicha-isotope-map_windows_arm64_desktop.exe` and `chicha-isotope-map_linux_arm64_desktop`.

### Testing
- Ran `go test ./...` and all test packages with tests passed; packages without test files are reported as skipped.
- No CI run included here, but changes are limited to the release workflow and documentation and do not alter runtime code paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e36ce34b2c833299be165aa8361efe)