### PR TITLE
ci: improve Linux desktop packaging for double-click launch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,17 +262,28 @@ jobs:
           cp "dist/${BIN}" "${APP_DIR}/usr/bin/chicha-isotope-map"
           chmod +x "${APP_DIR}/usr/bin/chicha-isotope-map"
           cp "public_html/images/apple-touch-icon.png" "${APP_DIR}/usr/share/icons/hicolor/256x256/apps/chicha-isotope-map.png"
+          cp "public_html/images/apple-touch-icon.png" "${APP_DIR}/chicha-isotope-map.png"
+
+          cat > "${APP_DIR}/AppRun" <<'APP_RUN'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          APP_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+          exec "${APP_DIR}/usr/bin/chicha-isotope-map" "$@"
+          APP_RUN
 
           cat > "${APP_DIR}/usr/share/applications/chicha-isotope-map.desktop" <<'DESKTOP'
           [Desktop Entry]
           Type=Application
           Name=Chicha Isotope Map
           Comment=Desktop webview launcher for Chicha Isotope Map
-          Exec=chicha-isotope-map
+          Exec=AppRun
           Icon=chicha-isotope-map
           Terminal=false
           Categories=Science;Utility;
           DESKTOP
+
+          cp "${APP_DIR}/usr/share/applications/chicha-isotope-map.desktop" "${APP_DIR}/chicha-isotope-map.desktop"
+          chmod +x "${APP_DIR}/AppRun" "${APP_DIR}/chicha-isotope-map.desktop"
 
           tar -czf "dist/${BIN}.tar.gz" -C dist "$(basename "${APP_DIR}")"
 


### PR DESCRIPTION
### Motivation
- Make the Linux desktop artifact immediately runnable after extraction by providing a bundled launcher and ensuring the launcher file has the executable bit.
- Keep Linux app icon and branding consistent with the macOS universal desktop package by reusing the same icon.

### Description
- Add a top-level `AppRun` script into the `.AppDir` that invokes `usr/bin/chicha-isotope-map` so the extracted package can be launched by double-clicking the AppDir root launcher.
- Copy `public_html/images/apple-touch-icon.png` into the AppDir as `chicha-isotope-map.png` and keep the icon under `usr/share/icons` for desktop discovery.
- Change the desktop entry `Exec` field to `AppRun`, duplicate the `.desktop` file at the AppDir root, and set executable bits with `chmod +x` for `AppRun` and the top-level `.desktop` during packaging.
- Update the `.github/workflows/release.yml` packaging step to include the new launcher, icon, and desktop file when creating the tarball.

### Testing
- Ran `git diff --check` and it passed with no issues.
- Ran `git status --short` to confirm working tree changes were as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3769d3e4c8332be91f3e8e5be9bdd)