### PR TITLE
Add AppRun and portable .desktop to Linux AppDir packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,6 +262,14 @@ jobs:
           cp "dist/${BIN}" "${APP_DIR}/usr/bin/chicha-isotope-map"
           chmod +x "${APP_DIR}/usr/bin/chicha-isotope-map"
           cp "public_html/images/apple-touch-icon.png" "${APP_DIR}/usr/share/icons/hicolor/256x256/apps/chicha-isotope-map.png"
+          cp "public_html/images/apple-touch-icon.png" "${APP_DIR}/chicha-isotope-map.png"
+
+          cat > "${APP_DIR}/AppRun" <<'APP_RUN'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          APP_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+          exec "${APP_DIR}/usr/bin/chicha-isotope-map" "$@"
+          APP_RUN
 
           cat > "${APP_DIR}/usr/share/applications/chicha-isotope-map.desktop" <<'DESKTOP'
           [Desktop Entry]
@@ -273,6 +281,19 @@ jobs:
           Terminal=false
           Categories=Science;Utility;
           DESKTOP
+
+          cat > "${APP_DIR}/chicha-isotope-map.desktop" <<'DESKTOP_PORTABLE'
+          [Desktop Entry]
+          Type=Application
+          Name=Chicha Isotope Map
+          Comment=Desktop webview launcher for Chicha Isotope Map
+          Exec=/bin/sh -c '"$(dirname "$1")/AppRun"' sh %k
+          Icon=chicha-isotope-map
+          Terminal=false
+          Categories=Science;Utility;
+          DESKTOP_PORTABLE
+
+          chmod +x "${APP_DIR}/AppRun" "${APP_DIR}/chicha-isotope-map.desktop"
 
           tar -czf "dist/${BIN}.tar.gz" -C dist "$(basename "${APP_DIR}")"
 


### PR DESCRIPTION
### Motivation

- Improve the Linux desktop distribution by making the AppDir self-contained and launchable as a portable application.
- Ensure the app icon is available both in the `.AppDir/usr/share/icons` path and at the AppDir root for portable launchers.

### Description

- Copy the application icon to the AppDir root by adding `cp "public_html/images/apple-touch-icon.png" "${APP_DIR}/chicha-isotope-map.png"` to the packaging step.
- Create an `AppRun` wrapper script that resolves the AppDir directory and executes the bundled binary via `exec "${APP_DIR}/usr/bin/chicha-isotope-map" "$@"` and write it to `${APP_DIR}/AppRun`.
- Add a portable desktop file at `${APP_DIR}/chicha-isotope-map.desktop` with `Exec=/bin/sh -c '"$(dirname "$1")/AppRun"' sh %k` so the AppDir can be launched directly, and mark `AppRun` and the portable desktop file executable with `chmod +x`.
- Continue packaging the AppDir into `dist/${BIN}.tar.gz` as before.

### Testing

- No automated tests were added or modified for this change.
- Existing CI unit/test jobs were not changed by this patch and were not executed as part of this edit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3769d3e4c8332be91f3e8e5be9bdd)