### PR TITLE
Improve Linux desktop release packaging for icon and executable behavior

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -288,7 +288,7 @@ jobs:
           Name=Chicha Isotope Map
           Comment=Desktop webview launcher for Chicha Isotope Map
           Exec=/bin/sh -c '"$(dirname "$1")/AppRun"' sh %k
-          Icon=chicha-isotope-map
+          Icon=chicha-isotope-map.png
           Terminal=false
           Categories=Science;Utility;
           DESKTOP_PORTABLE
@@ -296,6 +296,7 @@ jobs:
           chmod +x "${APP_DIR}/AppRun" "${APP_DIR}/chicha-isotope-map.desktop"
 
           tar -czf "dist/${BIN}.tar.gz" -C dist "$(basename "${APP_DIR}")"
+          rm -rf "${APP_DIR}" "dist/${BIN}"
 
       - name: Prepare Windows icon resource
         if: runner.os == 'Windows'

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Best for personal local use.
 - [Desktop for Windows (arm64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_windows_arm64_desktop.exe)
 - [Desktop for macOS Apple Silicon (arm64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_darwin_arm64_desktop)
 - [Desktop for macOS Intel (amd64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_darwin_amd64_desktop)
-- [Desktop for Linux (amd64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64_desktop)
-- [Desktop for Linux (arm64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_arm64_desktop)
+- [Desktop for Linux (amd64, AppDir tar.gz)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64_desktop.tar.gz)
+- [Desktop for Linux (arm64, AppDir tar.gz)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_arm64_desktop.tar.gz)
 
 ### Run
 Windows:
@@ -42,10 +42,11 @@ chmod +x ./chicha-isotope-map_darwin_*_desktop
 
 Linux:
 ```bash
-curl -fL https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64_desktop -o chicha-isotope-map-desktop
-chmod +x ./chicha-isotope-map-desktop
-./chicha-isotope-map-desktop
+curl -fL https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64_desktop.tar.gz -o chicha-isotope-map-desktop.tar.gz
+tar -xzf chicha-isotope-map-desktop.tar.gz
+./chicha-isotope-map_linux_amd64_desktop.AppDir/AppRun
 ```
+The extracted folder also contains `chicha-isotope-map.desktop` and `chicha-isotope-map.png` so Linux file managers can show an app icon for the launcher.
 
 ### Build desktop from source
 
@@ -130,4 +131,3 @@ This project was conceived to grant people a clear and immediate understanding o
 The Chicha Isotope Map finds its roots in the field research of [Dmitry Ignatenko](https://www.youtube.com/@MrDrimogemon) and has been profoundly shaped by the insights of Rob Oudendijk and the [Safecast community](https://safecast.org). We extend our sincere appreciation to [Safecast](https://simplemap.safecast.org), [AtomFast](https://atomfast.net), [Radiacode](https://radiacode.com), [DoseMap](https://dosemap.org), and the many contributors to open dosimetry whose efforts made this possible.
 
 Should this work serve to safeguard even a single living being, its purpose shall be fully justified.
-


### PR DESCRIPTION
### Motivation
- Linux users downloading the raw ELF desktop binary often get a file without an icon and without the execute bit set, which prevents double-click launching and shows a generic file icon.
- The release workflow should publish a portable AppDir tarball that preserves the launcher executable bit and includes a `.desktop` and image so file managers can show the app icon.

### Description
- Set the portable launcher `.desktop` `Icon` entry to `chicha-isotope-map.png` in the Linux packaging step so file managers find the PNG icon reliably (`.github/workflows/release.yml`).
- After creating the AppDir tarball, remove the temporary `AppDir` folder and the raw ELF desktop binary from `dist/` so releases do not expose a non-executable-by-default binary (`.github/workflows/release.yml`).
- Update `README.md` to point Linux desktop download links to the AppDir `.tar.gz` artifacts and change the Linux run instructions to extract the tarball and run `AppRun`, with a note that `chicha-isotope-map.desktop` and `chicha-isotope-map.png` are included so file managers show the app icon.

### Testing
- Ran `go test ./...` and unit tests completed successfully for tested packages (no test files for many packages), with `ok` results for `pkg/countryresolver`, `pkg/desktop`, and `pkg/safecast-realtime`.
- No release workflow execution was run here; changes to packaging behavior are limited to the GitHub Actions workflow and README documentation and will be validated during the next release build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e38cd5f35c8332b6304aaebb6a25f2)