### PR TITLE
Add Linux AppImage packaging to release workflow and update README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,8 +279,36 @@ jobs:
           Exec=AppRun
           Icon=chicha-isotope-map
           Terminal=false
-          Categories=Science;Utility;
+          Categories=Science;
           DESKTOP
+
+          # AppImage tooling validates the desktop entry from APP_DIR root.
+          # Keep it spec-compliant and equivalent to the installed launcher file.
+          cp "${APP_DIR}/usr/share/applications/chicha-isotope-map.desktop" "${APP_DIR}/chicha-isotope-map.desktop"
+
+          chmod +x "${APP_DIR}/AppRun"
+
+          tar -czf "dist/${BIN}.tar.gz" -C dist "$(basename "${APP_DIR}")"
+          TOOL_ARCH="x86_64"
+          if [ "${GOARCH}" = "arm64" ]; then
+            TOOL_ARCH="aarch64"
+          fi
+          curl -fL "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${TOOL_ARCH}.AppImage" -o appimagetool.AppImage
+          chmod +x appimagetool.AppImage
+          ARCH="${TOOL_ARCH}" ./appimagetool.AppImage "${APP_DIR}" "dist/${BIN}.AppImage"
+          rm -rf "${APP_DIR}" "dist/${BIN}"
+
+      - name: Build portable desktop launcher (Linux tar.gz helper)
+        if: runner.os == 'Linux'
+        shell: bash
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          set -euo pipefail
+          BIN="chicha-isotope-map_${GOOS}_${GOARCH}_desktop"
+          APP_DIR="dist/chicha-isotope-map_${GOOS}_${GOARCH}_desktop.AppDir"
+          tar -xzf "dist/${BIN}.tar.gz" -C dist
 
           cat > "${APP_DIR}/chicha-isotope-map.desktop" <<'DESKTOP_PORTABLE'
           [Desktop Entry]
@@ -290,12 +318,12 @@ jobs:
           Exec=/bin/sh -c '"$(dirname "$1")/AppRun"' sh %k
           Icon=chicha-isotope-map
           Terminal=false
-          Categories=Science;Utility;
+          Categories=Science;
           DESKTOP_PORTABLE
 
-          chmod +x "${APP_DIR}/AppRun" "${APP_DIR}/chicha-isotope-map.desktop"
-
+          chmod +x "${APP_DIR}/chicha-isotope-map.desktop"
           tar -czf "dist/${BIN}.tar.gz" -C dist "$(basename "${APP_DIR}")"
+          rm -rf "${APP_DIR}" "dist/${BIN}"
 
       - name: Prepare Windows icon resource
         if: runner.os == 'Windows'

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Best for personal local use.
 - [Desktop for Windows (arm64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_windows_arm64_desktop.exe)
 - [Desktop for macOS Apple Silicon (arm64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_darwin_arm64_desktop)
 - [Desktop for macOS Intel (amd64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_darwin_amd64_desktop)
-- [Desktop for Linux (amd64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64_desktop)
-- [Desktop for Linux (arm64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_arm64_desktop)
+- [Desktop for Linux (amd64, single-file AppImage)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64_desktop.AppImage)
+- [Desktop for Linux (arm64, single-file AppImage)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_arm64_desktop.AppImage)
 
 ### Run
 Windows:
@@ -42,10 +42,11 @@ chmod +x ./chicha-isotope-map_darwin_*_desktop
 
 Linux:
 ```bash
-curl -fL https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64_desktop -o chicha-isotope-map-desktop
-chmod +x ./chicha-isotope-map-desktop
-./chicha-isotope-map-desktop
+curl -fL https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64_desktop.AppImage -o chicha-isotope-map-desktop.AppImage
+chmod +x ./chicha-isotope-map-desktop.AppImage
+./chicha-isotope-map-desktop.AppImage
 ```
+Linux desktop release is now a single file (`.AppImage`) with embedded app metadata and icon.
 
 ### Build desktop from source
 
@@ -130,4 +131,3 @@ This project was conceived to grant people a clear and immediate understanding o
 The Chicha Isotope Map finds its roots in the field research of [Dmitry Ignatenko](https://www.youtube.com/@MrDrimogemon) and has been profoundly shaped by the insights of Rob Oudendijk and the [Safecast community](https://safecast.org). We extend our sincere appreciation to [Safecast](https://simplemap.safecast.org), [AtomFast](https://atomfast.net), [Radiacode](https://radiacode.com), [DoseMap](https://dosemap.org), and the many contributors to open dosimetry whose efforts made this possible.
 
 Should this work serve to safeguard even a single living being, its purpose shall be fully justified.
-


### PR DESCRIPTION
### Motivation
- Provide single-file Linux desktop releases (AppImage) to simplify distribution and execution.
- Preserve AppImage metadata by copying the desktop entry to the AppDir root and ensure `AppRun` is executable.
- Keep a portable tar.gz helper flow for alternate distribution and update user-facing documentation to reflect the new artifact type.

### Description
- Extended the GitHub Actions `release.yml` workflow to create an AppDir, copy desktop metadata to the AppDir root, download `appimagetool`, and build a single-file `.AppImage` artifact using `appimagetool.AppImage` and `tar -czf` for intermediate packaging.
- Added a Linux portable desktop launcher step that extracts the previously created tarball and writes a portable `chicha-isotope-map.desktop` that launches `AppRun` via `/bin/sh -c`, and cleans up intermediate files.
- Standardized the `.desktop` file `Categories` value (removed `Utility`) and ensured `AppRun` and desktop files are marked executable where required.
- Updated `README.md` to point Linux download links to the new `.AppImage` artifacts and changed the Linux run instructions to use the `.AppImage` single-file format while noting the release format change.

### Testing
- No automated tests were executed as part of this change; this PR updates CI packaging steps and documentation only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e38cd5f35c8332b6304aaebb6a25f2)