### PR TITLE
Package Linux desktop as single AppImage and zip in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -287,8 +287,6 @@ jobs:
           cp "${APP_DIR}/usr/share/applications/chicha-isotope-map.desktop" "${APP_DIR}/chicha-isotope-map.desktop"
 
           chmod +x "${APP_DIR}/AppRun"
-
-          tar -czf "dist/${BIN}.tar.gz" -C dist "$(basename "${APP_DIR}")"
           TOOL_ARCH="x86_64"
           if [ "${GOARCH}" = "arm64" ]; then
             TOOL_ARCH="aarch64"
@@ -298,7 +296,7 @@ jobs:
           ARCH="${TOOL_ARCH}" ./appimagetool.AppImage "${APP_DIR}" "dist/${BIN}.AppImage"
           rm -rf "${APP_DIR}" "dist/${BIN}"
 
-      - name: Build portable desktop launcher (Linux tar.gz helper)
+      - name: Package Linux desktop artifact (single AppImage)
         if: runner.os == 'Linux'
         shell: bash
         env:
@@ -307,23 +305,18 @@ jobs:
         run: |
           set -euo pipefail
           BIN="chicha-isotope-map_${GOOS}_${GOARCH}_desktop"
-          APP_DIR="dist/chicha-isotope-map_${GOOS}_${GOARCH}_desktop.AppDir"
-          tar -xzf "dist/${BIN}.tar.gz" -C dist
+          APPIMAGE_SOURCE="dist/${BIN}.AppImage"
+          APPIMAGE_TARGET="dist/chicha-isotope-map_${GOARCH}.AppImage"
 
-          cat > "${APP_DIR}/chicha-isotope-map.desktop" <<'DESKTOP_PORTABLE'
-          [Desktop Entry]
-          Type=Application
-          Name=Chicha Isotope Map
-          Comment=Desktop webview launcher for Chicha Isotope Map
-          Exec=/bin/sh -c '"$(dirname "$1")/AppRun"' sh %k
-          Icon=chicha-isotope-map.png
-          Terminal=false
-          Categories=Science;
-          DESKTOP_PORTABLE
+          mv "${APPIMAGE_SOURCE}" "${APPIMAGE_TARGET}"
+          chmod +x "${APPIMAGE_TARGET}"
 
-          chmod +x "${APP_DIR}/chicha-isotope-map.desktop"
-          tar -czf "dist/${BIN}.tar.gz" -C dist "$(basename "${APP_DIR}")"
-          rm -rf "${APP_DIR}" "dist/${BIN}"
+          # Keep release output as a single executable file and a download-friendly archive.
+          # zip stores Unix mode bits; extraction tools that honor them keep the executable bit.
+          (
+            cd dist
+            zip -q -X "chicha-isotope-map_${GOOS}_${GOARCH}_desktop.zip" "chicha-isotope-map_${GOARCH}.AppImage"
+          )
 
       - name: Prepare Windows icon resource
         if: runner.os == 'Windows'


### PR DESCRIPTION
### Motivation
- Replace the previous portable `.tar.gz` AppDir packaging with a single AppImage plus a zip archive to simplify distribution and keep the executable bit across extractors.

### Description
- Rename the workflow step to `Package Linux desktop artifact (single AppImage)` and remove the older `.tar.gz` AppDir creation and desktop-file post-processing logic.
- Move the generated AppImage from `dist/${BIN}.AppImage` to `dist/chicha-isotope-map_${GOARCH}.AppImage`, ensure it is executable, and create a zip named `chicha-isotope-map_${GOOS}_${GOARCH}_desktop.zip` that contains the AppImage.
- Preserve the existing AppImage creation via `appimagetool.AppImage` and adjust cleanup to not repackage an AppDir tarball.

### Testing
- Executed the GitHub Actions release workflow packaging job on Linux which produced the AppImage and zip artifact and completed successfully.
- No unit tests were changed by this packaging-only update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3a48842548332bfd49625a7c0c41e)