### PR TITLE
Remove Linux AppImage packaging; ship zipped desktop binaries for amd64/arm64

### DIFF
--- a/.github/release/stable-release.md
+++ b/.github/release/stable-release.md
@@ -35,12 +35,14 @@ chmod +x ./chicha-isotope-map_darwin_*_desktop
 If Gatekeeper blocks launch, open **System Settings → Privacy & Security** and allow the app.
 
 ### Linux
-[⬇️ Download Desktop for Linux (amd64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64_desktop)
+- [⬇️ Download Desktop for Linux (amd64, zip)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64_desktop.zip)
+- [⬇️ Download Desktop for Linux (arm64, zip)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_arm64_desktop.zip)
 
 ```bash
-curl -fL https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64_desktop -o chicha-isotope-map-desktop
-chmod +x ./chicha-isotope-map-desktop
-./chicha-isotope-map-desktop
+curl -fL https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64_desktop.zip -o chicha-isotope-map-desktop.zip
+unzip chicha-isotope-map-desktop.zip
+chmod +x ./chicha-isotope-map_linux_amd64_desktop
+./chicha-isotope-map_linux_amd64_desktop
 ```
 
 ---

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,7 +245,7 @@ jobs:
                    -ldflags "-s -w -X main.CompileVersion=$VERSION" \
                    -o "dist/${BIN}"
 
-      - name: Package desktop launcher (Linux)
+      - name: Package Linux desktop artifact (zip with executable binary)
         if: runner.os == 'Linux'
         shell: bash
         env:
@@ -254,79 +254,13 @@ jobs:
         run: |
           set -euo pipefail
           BIN="chicha-isotope-map_${GOOS}_${GOARCH}_desktop"
-          APP_DIR="dist/chicha-isotope-map_${GOOS}_${GOARCH}_desktop.AppDir"
-          mkdir -p "${APP_DIR}/usr/bin" \
-                   "${APP_DIR}/usr/share/applications" \
-                   "${APP_DIR}/usr/share/icons/hicolor/256x256/apps"
+          chmod +x "dist/${BIN}"
 
-          cp "dist/${BIN}" "${APP_DIR}/usr/bin/chicha-isotope-map"
-          chmod +x "${APP_DIR}/usr/bin/chicha-isotope-map"
-          cp "public_html/images/apple-touch-icon.png" "${APP_DIR}/usr/share/icons/hicolor/256x256/apps/chicha-isotope-map.png"
-          cp "public_html/images/apple-touch-icon.png" "${APP_DIR}/chicha-isotope-map.png"
-          ln -sf "chicha-isotope-map.png" "${APP_DIR}/.DirIcon"
-
-          APPIMAGE_ARCH="x86_64"
-          if [ "${GOARCH}" = "arm64" ]; then
-            APPIMAGE_ARCH="aarch64"
-          fi
-
-          cat > "${APP_DIR}/AppRun" <<'APP_RUN'
-          #!/usr/bin/env bash
-          set -euo pipefail
-          APP_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
-          exec "${APP_DIR}/usr/bin/chicha-isotope-map" "$@"
-          APP_RUN
-
-          cat > "${APP_DIR}/usr/share/applications/chicha-isotope-map.desktop" <<'DESKTOP'
-          [Desktop Entry]
-          Type=Application
-          Name=Chicha Isotope Map
-          Comment=Desktop webview launcher for Chicha Isotope Map
-          Exec=AppRun
-          Icon=chicha-isotope-map
-          StartupWMClass=chicha-isotope-map
-          Terminal=false
-          Categories=Science;
-          X-AppImage-Name=Chicha Isotope Map
-          X-AppImage-Arch=__APPIMAGE_ARCH__
-          DESKTOP
-
-          sed -i "s/__APPIMAGE_ARCH__/${APPIMAGE_ARCH}/" "${APP_DIR}/usr/share/applications/chicha-isotope-map.desktop"
-
-          # AppImage tooling validates the desktop entry from APP_DIR root.
-          # Keep it spec-compliant and equivalent to the installed launcher file.
-          cp "${APP_DIR}/usr/share/applications/chicha-isotope-map.desktop" "${APP_DIR}/chicha-isotope-map.desktop"
-
-          chmod +x "${APP_DIR}/AppRun"
-          TOOL_ARCH="x86_64"
-          if [ "${GOARCH}" = "arm64" ]; then
-            TOOL_ARCH="aarch64"
-          fi
-          curl -fL "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${TOOL_ARCH}.AppImage" -o appimagetool.AppImage
-          chmod +x appimagetool.AppImage
-          ARCH="${TOOL_ARCH}" ./appimagetool.AppImage "${APP_DIR}" "dist/${BIN}.AppImage"
-          rm -rf "${APP_DIR}" "dist/${BIN}"
-
-      - name: Package Linux desktop artifact (single AppImage)
-        if: runner.os == 'Linux'
-        shell: bash
-        env:
-          GOOS: ${{ matrix.goos }}
-          GOARCH: ${{ matrix.goarch }}
-        run: |
-          set -euo pipefail
-          BIN="chicha-isotope-map_${GOOS}_${GOARCH}_desktop"
-          APPIMAGE_SOURCE="dist/${BIN}.AppImage"
-          APPIMAGE_TARGET="dist/chicha-isotope-map_${GOARCH}.AppImage"
-
-          mv "${APPIMAGE_SOURCE}" "${APPIMAGE_TARGET}"
-          chmod +x "${APPIMAGE_TARGET}"
-
-          # Keep release output as a single executable file and a download-friendly archive.
-          # zip stores Unix mode bits; extraction tools that honor them keep the executable bit.
+          # Keep a direct binary and a download-friendly archive for Linux desktop releases.
+          # zip stores Unix mode bits, so extraction tools that honor them keep the executable bit.
           (
             cd dist
-            zip -q -X "chicha-isotope-map_${GOOS}_${GOARCH}_desktop.zip" "chicha-isotope-map_${GOARCH}.AppImage"
+            zip -q -X "chicha-isotope-map_${GOOS}_${GOARCH}_desktop.zip" "${BIN}"
           )
 
       - name: Prepare Windows icon resource

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Best for personal local use.
 - [Desktop for Windows (arm64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_windows_arm64_desktop.exe)
 - [Desktop for macOS Apple Silicon (arm64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_darwin_arm64_desktop)
 - [Desktop for macOS Intel (amd64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_darwin_amd64_desktop)
-- [Desktop for Linux (amd64, single-file AppImage)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64_desktop.AppImage)
-- [Desktop for Linux (arm64, single-file AppImage)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_arm64_desktop.AppImage)
+- [Desktop for Linux (amd64, zip)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64_desktop.zip)
+- [Desktop for Linux (arm64, zip)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_arm64_desktop.zip)
 
 ### Run
 Windows:
@@ -43,11 +43,12 @@ chmod +x ./chicha-isotope-map_darwin_*_desktop
 
 Linux:
 ```bash
-curl -fL https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64_desktop.AppImage -o chicha-isotope-map-desktop.AppImage
-chmod +x ./chicha-isotope-map-desktop.AppImage
-./chicha-isotope-map-desktop.AppImage
+curl -fL https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64_desktop.zip -o chicha-isotope-map-desktop.zip
+unzip chicha-isotope-map-desktop.zip
+chmod +x ./chicha-isotope-map_linux_amd64_desktop
+./chicha-isotope-map_linux_amd64_desktop
 ```
-Linux desktop release is now a single file (`.AppImage`) with embedded app metadata and icon.
+Linux desktop release now ships as a regular executable binary in a `.zip` archive.
 
 ### Build desktop from source
 


### PR DESCRIPTION
### Motivation
- Replace fragile AppImage packaging with a simpler, icon-less Linux desktop distribution that provides a plain executable binary zipped for easy download and double-click run. 
- Support both `amd64` and `arm64` desktop artifacts and ensure the binary has the executable bit set before archiving. 

### Description
- Updated CI packaging in `.github/workflows/release.yml` to remove AppImage/AppDir creation and `appimagetool` steps and instead `chmod +x` the built `chicha-isotope-map_${GOOS}_${GOARCH}_desktop` binary and zip that file into `chicha-isotope-map_${GOOS}_${GOARCH}_desktop.zip`. 
- Updated user-facing docs in `README.md` to point Linux desktop download links to `.zip` artifacts and to use `unzip`, `chmod +x`, then run the plain binary. 
- Updated release template `.github/release/stable-release.md` to match the new `.zip` links and Linux run snippet. 
- Removed copying of icons, `.DirIcon`, `.desktop` AppDir files and all AppImage-specific metadata from the workflow. 

### Testing
- Ran an automated search with `rg` for `AppImage|appimage|.AppImage` across modified files to verify AppImage references were removed, which succeeded. 
- Ran `git diff --check` to validate there are no whitespace or diff errors, which succeeded. 
- Started `go test ./...` in the workspace but the run did not complete within the environment and therefore its final status could not be confirmed here; CI should validate full test suite on merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3c6d24758833283541f6dde1aceb9)