### PR TITLE
release: embed macOS app icon into Windows desktop exe and add .zip download options

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,6 +263,40 @@ jobs:
             zip -q -X "chicha-isotope-map_${GOOS}_${GOARCH}_desktop.zip" "${BIN}"
           )
 
+      - name: Build Windows ICO from desktop app icon
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $pngPath = "public_html/images/apple-touch-icon.png"
+          $icoPath = "dist/windows-desktop-icon.ico"
+          New-Item -Force -ItemType Directory dist | Out-Null
+
+          [byte[]]$pngBytes = [System.IO.File]::ReadAllBytes($pngPath)
+          if ($pngBytes.Length -lt 8 -or $pngBytes[0] -ne 0x89 -or $pngBytes[1] -ne 0x50 -or $pngBytes[2] -ne 0x4E -or $pngBytes[3] -ne 0x47) {
+            throw "Icon source must be a PNG file: $pngPath"
+          }
+
+          # ICO can store PNG payloads directly; this keeps the Windows desktop icon pixel-identical to the macOS icon source.
+          $iconDataOffset = 6 + 16
+          $writer = New-Object System.IO.BinaryWriter([System.IO.File]::Open($icoPath, [System.IO.FileMode]::Create))
+          try {
+            $writer.Write([UInt16]0)                 # reserved
+            $writer.Write([UInt16]1)                 # type = icon
+            $writer.Write([UInt16]1)                 # one image
+            $writer.Write([Byte]0)                   # width = 256
+            $writer.Write([Byte]0)                   # height = 256
+            $writer.Write([Byte]0)                   # color count
+            $writer.Write([Byte]0)                   # reserved
+            $writer.Write([UInt16]1)                 # color planes
+            $writer.Write([UInt16]32)                # bits per pixel
+            $writer.Write([UInt32]$pngBytes.Length)  # image data size
+            $writer.Write([UInt32]$iconDataOffset)   # image data offset
+            $writer.Write($pngBytes)
+          } finally {
+            $writer.Dispose()
+          }
+
       - name: Prepare Windows icon resource
         if: runner.os == 'Windows'
         shell: pwsh
@@ -270,9 +304,8 @@ jobs:
           $ErrorActionPreference = "Stop"
           go install github.com/akavel/rsrc@latest
           $rsrcBin = Join-Path (go env GOPATH) "bin/rsrc.exe"
-          # rsrc requires a real ICO container; app-icon.ico currently stores PNG bytes.
           $resourceArch = if ("${{ matrix.goarch }}" -eq "arm64") { "arm64" } else { "amd64" }
-          & $rsrcBin -ico "public_html/images/favicon.ico" -arch $resourceArch -o "zz_chicha_icon_windows_${{ matrix.goarch }}.syso"
+          & $rsrcBin -ico "dist/windows-desktop-icon.ico" -arch $resourceArch -o "zz_chicha_icon_windows_${{ matrix.goarch }}.syso"
 
       - name: Build desktop (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -276,6 +276,18 @@ jobs:
           if ($pngBytes.Length -lt 8 -or $pngBytes[0] -ne 0x89 -or $pngBytes[1] -ne 0x50 -or $pngBytes[2] -ne 0x4E -or $pngBytes[3] -ne 0x47) {
             throw "Icon source must be a PNG file: $pngPath"
           }
+          if ($pngBytes.Length -lt 24) {
+            throw "Icon source PNG is too short to contain IHDR dimensions: $pngPath"
+          }
+
+          # Read dimensions from PNG IHDR to keep ICO directory metadata aligned with embedded payload.
+          $pngWidth = ([UInt32]$pngBytes[16] -shl 24) -bor ([UInt32]$pngBytes[17] -shl 16) -bor ([UInt32]$pngBytes[18] -shl 8) -bor [UInt32]$pngBytes[19]
+          $pngHeight = ([UInt32]$pngBytes[20] -shl 24) -bor ([UInt32]$pngBytes[21] -shl 16) -bor ([UInt32]$pngBytes[22] -shl 8) -bor [UInt32]$pngBytes[23]
+          if ($pngWidth -eq 0 -or $pngHeight -eq 0 -or $pngWidth -gt 256 -or $pngHeight -gt 256) {
+            throw "Icon dimensions must be in range 1..256, got ${pngWidth}x${pngHeight}"
+          }
+          $icoWidthByte = if ($pngWidth -eq 256) { [Byte]0 } else { [Byte]$pngWidth }
+          $icoHeightByte = if ($pngHeight -eq 256) { [Byte]0 } else { [Byte]$pngHeight }
 
           # ICO can store PNG payloads directly; this keeps the Windows desktop icon pixel-identical to the macOS icon source.
           $iconDataOffset = 6 + 16
@@ -284,8 +296,8 @@ jobs:
             $writer.Write([UInt16]0)                 # reserved
             $writer.Write([UInt16]1)                 # type = icon
             $writer.Write([UInt16]1)                 # one image
-            $writer.Write([Byte]0)                   # width = 256
-            $writer.Write([Byte]0)                   # height = 256
+            $writer.Write($icoWidthByte)             # width (0 means 256)
+            $writer.Write($icoHeightByte)            # height (0 means 256)
             $writer.Write([Byte]0)                   # color count
             $writer.Write([Byte]0)                   # reserved
             $writer.Write([UInt16]1)                 # color planes

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Best for personal local use.
 ### Download
 - [Desktop for Windows (amd64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_windows_amd64_desktop.exe)
 - [Desktop for Windows (arm64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_windows_arm64_desktop.exe)
+- [Desktop for Windows (amd64, zip)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_windows_amd64_desktop.zip)
+- [Desktop for Windows (arm64, zip)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_windows_arm64_desktop.zip)
 - [Desktop for macOS Apple Silicon (arm64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_darwin_arm64_desktop)
 - [Desktop for macOS Intel (amd64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_darwin_amd64_desktop)
 - [Desktop for Linux (amd64, zip)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64_desktop.zip)
@@ -31,7 +33,7 @@ Best for personal local use.
 
 ### Run
 Windows:
-1. Download `.exe`
+1. Download `.exe` directly (or `.zip` if your browser/security policy blocks direct `.exe` downloads)
 2. Double click
 3. If SmartScreen appears: **More info → Run anyway**
 


### PR DESCRIPTION
### Motivation
- Ensure Windows desktop `.exe` has the same visual icon as the macOS desktop build by embedding a proper Windows ICO generated from the macOS PNG source.
- Offer both direct `.exe` and `.zip` Windows downloads so users can choose the delivery method that works with their browser/security policies.

### Description
- Add a Windows PowerShell workflow step `Build Windows ICO from desktop app icon` that converts `public_html/images/apple-touch-icon.png` into a valid `dist/windows-desktop-icon.ico` storing PNG payloads inside the ICO container.
- Update the Windows resource embedding step to call `rsrc` with the generated `dist/windows-desktop-icon.ico` so the icon is embedded into the built desktop `.exe`.
- Update `README.md` to expose `.zip` download links for Windows (amd64/arm64) and clarify the Windows download instructions to mention `.zip` as a fallback.

### Testing
- Ran `go test ./...` and the test suite completed successfully (`ok`/`?` outputs for packages as expected).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3cd7ed6b883328fd0b15647778502)