### PR TITLE
Set default server binary path to /usr/local/bin/chicha-isotope-map

### DIFF
--- a/chicha-isotope-map.go
+++ b/chicha-isotope-map.go
@@ -7043,9 +7043,7 @@ func main() {
 			ArchivePath:  *jsonArchivePathFlag,
 			ImportTGZURL: *importTGZURLFlag,
 			SupportEmail: *supportEmail,
-		}
-		if exe, err := os.Executable(); err == nil {
-			defaults.BinaryPath = exe
+			BinaryPath:   "/usr/local/bin/chicha-isotope-map",
 		}
 		if wd, err := os.Getwd(); err == nil {
 			defaults.WorkingDir = wd

--- a/pkg/setupwizard/wizard.go
+++ b/pkg/setupwizard/wizard.go
@@ -16,6 +16,8 @@ import (
 	"time"
 )
 
+const defaultServerBinaryPath = "/usr/local/bin/chicha-isotope-map"
+
 // Defaults carries the starting values presented by the wizard so operators
 // can speed through with sensible answers while still being free to tweak them.
 // Keeping the struct small matches the Go proverb about simplicity beating
@@ -338,9 +340,10 @@ func enrichDefaults(defaults Defaults) Defaults {
 		defaults.NeedCert = true
 	}
 	if defaults.BinaryPath == "" {
-		if exe, err := os.Executable(); err == nil {
-			defaults.BinaryPath = exe
-		}
+		// The setup wizard targets server deployments, so we keep a stable
+		// system-wide binary location that matches release instructions and
+		// updater scripts.
+		defaults.BinaryPath = defaultServerBinaryPath
 	}
 	if defaults.WorkingDir == "" {
 		if wd, err := os.Getwd(); err == nil {


### PR DESCRIPTION
### Motivation
- Server installs and the generated systemd unit/updater should target a stable, predictable binary location rather than the current executable path so service files and helpers consistently point to `/usr/local/bin/chicha-isotope-map`.

### Description
- Add `defaultServerBinaryPath` constant in `pkg/setupwizard/wizard.go` and use it as the fallback for `Defaults.BinaryPath` in `enrichDefaults` instead of `os.Executable()`.
- Set `BinaryPath: "/usr/local/bin/chicha-isotope-map"` in the `setupwizard.Defaults` passed from `main` when `-setup` is invoked so the created unit and updater reference the system-wide install location.

### Testing
- Ran `gofmt -w chicha-isotope-map.go pkg/setupwizard/wizard.go` which completed successfully.
- Ran `go test ./pkg/setupwizard` which reported no test files (success for package).
- Ran `go test ./...` and the test suite completed with packages reporting as expected (no failing tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3dea5b99c83328060dbcea43cfd95)