### PR TITLE
CI: Adjust macOS desktop build targets and switch universal packaging to DMG

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,7 +170,8 @@ jobs:
           - { goos: linux, goarch: amd64, goversion: "1.23", runner: "ubuntu-24.04", desktop_variant: "gtk41" }
           - { goos: linux, goarch: arm64, goversion: "1.23", runner: "ubuntu-22.04-arm", desktop_variant: "gtk40" }
           - { goos: linux, goarch: arm64, goversion: "1.23", runner: "ubuntu-24.04-arm", desktop_variant: "gtk41" }
-          - { goos: darwin, goarch: amd64, goversion: "1.23", runner: "macos-14", desktop_variant: "default" }
+          # Build amd64 on Intel runner to avoid cgo cross-compilation edge cases.
+          - { goos: darwin, goarch: amd64, goversion: "1.23", runner: "macos-13", desktop_variant: "default" }
           - { goos: darwin, goarch: arm64, goversion: "1.23", runner: "macos-14", desktop_variant: "default" }
           - { goos: windows, goarch: amd64, goversion: "1.23", runner: "windows-latest", desktop_variant: "default" }
           - { goos: windows, goarch: arm64, goversion: "1.23", runner: "windows-latest", desktop_variant: "default" }
@@ -245,6 +246,19 @@ jobs:
           BIN="chicha-isotope-map_${GOOS}_${GOARCH}_desktop"
           if [ "${GOOS}" = "linux" ]; then
             BIN="${BIN}_${DESKTOP_VARIANT}"
+          fi
+          if [ "${GOOS}" = "darwin" ] && [ "${GOARCH}" = "amd64" ]; then
+            # Keep Intel builds launchable on older macOS releases.
+            export MACOSX_DEPLOYMENT_TARGET=10.13
+            export CGO_CFLAGS="-mmacosx-version-min=10.13"
+            export CGO_CXXFLAGS="-mmacosx-version-min=10.13"
+            export CGO_LDFLAGS="-mmacosx-version-min=10.13"
+          elif [ "${GOOS}" = "darwin" ] && [ "${GOARCH}" = "arm64" ]; then
+            # Apple Silicon binaries require macOS 11+.
+            export MACOSX_DEPLOYMENT_TARGET=11.0
+            export CGO_CFLAGS="-mmacosx-version-min=11.0"
+            export CGO_CXXFLAGS="-mmacosx-version-min=11.0"
+            export CGO_LDFLAGS="-mmacosx-version-min=11.0"
           fi
           GOFLAGS="-trimpath -buildvcs=false" \
           go build -tags "desktop" \
@@ -379,15 +393,18 @@ jobs:
           ARM64_BIN="dist/chicha-isotope-map_darwin_arm64_desktop"
           UNIVERSAL_BIN="dist/chicha-isotope-map_darwin_universal_desktop"
           lipo -create "${AMD64_BIN}" "${ARM64_BIN}" -output "${UNIVERSAL_BIN}"
+          lipo -verify_arch x86_64 arm64 "${UNIVERSAL_BIN}"
           chmod +x "${UNIVERSAL_BIN}"
 
-      - name: Package universal desktop app (macOS)
+      - name: Package universal desktop app (macOS DMG)
         shell: bash
         run: |
           set -euo pipefail
           BIN="chicha-isotope-map_darwin_universal_desktop"
           APP_NAME="Chicha Isotope Map"
           APP_DIR="dist/${APP_NAME}.app"
+          DMG_STAGING_DIR="dist/dmg-staging"
+          DMG_PATH="dist/chicha-isotope-map_darwin_universal_desktop.dmg"
           ICONSET_DIR="dist/AppIcon.iconset"
           ICON_SOURCE="public_html/images/apple-touch-icon.png"
 
@@ -429,18 +446,32 @@ jobs:
             <key>CFBundleIconFile</key>
             <string>AppIcon.icns</string>
             <key>LSMinimumSystemVersion</key>
-            <string>10.2</string>
+            <string>10.13</string>
           </dict>
           </plist>
           PLIST
 
-          ditto -c -k --sequesterRsrc --keepParent "${APP_DIR}" "dist/${BIN}.app.zip"
+          # Put the app and /Applications shortcut into DMG so installation is drag-and-drop.
+          rm -rf "${DMG_STAGING_DIR}"
+          mkdir -p "${DMG_STAGING_DIR}"
+          cp -R "${APP_DIR}" "${DMG_STAGING_DIR}/"
+          ln -s /Applications "${DMG_STAGING_DIR}/Applications"
+
+          rm -f "${DMG_PATH}"
+          hdiutil create \
+            -volname "Chicha Isotope Map" \
+            -srcfolder "${DMG_STAGING_DIR}" \
+            -ov \
+            -format UDZO \
+            "${DMG_PATH}"
 
       - name: Upload macOS universal desktop artifact
         uses: actions/upload-artifact@v4
         with:
           name: bin-desktop-darwin-universal
-          path: dist/chicha-isotope-map_darwin_universal_desktop*
+          path: |
+            dist/chicha-isotope-map_darwin_universal_desktop
+            dist/chicha-isotope-map_darwin_universal_desktop.dmg
 
   release:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/stable-release') || contains(join(github.event.commits.*.message, ' || '), 'stable release') || contains(join(github.event.commits.*.message, ' || '), 'Stable Release')


### PR DESCRIPTION
### Motivation
- Avoid cgo cross-compilation edge cases for Intel macOS builds while keeping broader compatibility for Apple Silicon, and ensure universal binaries are verified and launchable on older macOS releases.
- Provide a native macOS installer experience by producing a DMG with an Applications symlink for drag-and-drop installation instead of a zip.
- Align the app bundle `LSMinimumSystemVersion` with the chosen deployment targets for Intel and Apple Silicon builds.

### Description
- Changed the darwin/amd64 runner from `macos-14` to `macos-13` with a note to avoid cgo cross-compilation edge cases.
- Export `MACOSX_DEPLOYMENT_TARGET` and set `CGO_CFLAGS`, `CGO_CXXFLAGS`, and `CGO_LDFLAGS` for darwin/amd64 (10.13) and darwin/arm64 (11.0) before `go build` to control minimum macOS versions.
- Added `lipo -verify_arch x86_64 arm64` to validate the universal binary and updated `Info.plist` `LSMinimumSystemVersion` to `10.13`.
- Replaced the previous zip-based packaging for the universal macOS app with a DMG creation flow that stages the `.app`, adds an `/Applications` symlink, runs `hdiutil create` to produce a UDZO `.dmg`, and uploads the `.dmg` alongside the universal binary artifact.

### Testing
- No automated test suite changes were included; this PR modifies the GitHub Actions release workflow only.
- The workflow uses the existing `go build` steps in the `build_desktop` matrix and the `build_desktop_macos_universal` packaging steps to produce artifacts under `dist/`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5dbc9cb7483328a48657255dc2b0a)