### PR TITLE
ci: move macOS desktop amd64 build to macos-14 with explicit arch flags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,8 +170,9 @@ jobs:
           - { goos: linux, goarch: amd64, goversion: "1.23", runner: "ubuntu-24.04", desktop_variant: "gtk41" }
           - { goos: linux, goarch: arm64, goversion: "1.23", runner: "ubuntu-22.04-arm", desktop_variant: "gtk40" }
           - { goos: linux, goarch: arm64, goversion: "1.23", runner: "ubuntu-24.04-arm", desktop_variant: "gtk41" }
-          # Build amd64 on Intel runner to avoid cgo cross-compilation edge cases.
-          - { goos: darwin, goarch: amd64, goversion: "1.23", runner: "macos-13", desktop_variant: "default" }
+          # Build both macOS desktop targets on macos-14 to avoid queue stalls on scarce macos-13 runners.
+          # amd64 output is cross-compiled with explicit x86_64 toolchain flags and old deployment target.
+          - { goos: darwin, goarch: amd64, goversion: "1.23", runner: "macos-14", desktop_variant: "default" }
           - { goos: darwin, goarch: arm64, goversion: "1.23", runner: "macos-14", desktop_variant: "default" }
           - { goos: windows, goarch: amd64, goversion: "1.23", runner: "windows-latest", desktop_variant: "default" }
           - { goos: windows, goarch: arm64, goversion: "1.23", runner: "windows-latest", desktop_variant: "default" }
@@ -248,17 +249,21 @@ jobs:
             BIN="${BIN}_${DESKTOP_VARIANT}"
           fi
           if [ "${GOOS}" = "darwin" ] && [ "${GOARCH}" = "amd64" ]; then
-            # Keep Intel builds launchable on older macOS releases.
+            # Keep Intel builds launchable on older macOS releases even when built on Apple Silicon runners.
             export MACOSX_DEPLOYMENT_TARGET=10.13
-            export CGO_CFLAGS="-mmacosx-version-min=10.13"
-            export CGO_CXXFLAGS="-mmacosx-version-min=10.13"
-            export CGO_LDFLAGS="-mmacosx-version-min=10.13"
+            export CC="clang -arch x86_64"
+            export CXX="clang++ -arch x86_64"
+            export CGO_CFLAGS="-arch x86_64 -mmacosx-version-min=10.13"
+            export CGO_CXXFLAGS="-arch x86_64 -mmacosx-version-min=10.13"
+            export CGO_LDFLAGS="-arch x86_64 -mmacosx-version-min=10.13"
           elif [ "${GOOS}" = "darwin" ] && [ "${GOARCH}" = "arm64" ]; then
             # Apple Silicon binaries require macOS 11+.
             export MACOSX_DEPLOYMENT_TARGET=11.0
-            export CGO_CFLAGS="-mmacosx-version-min=11.0"
-            export CGO_CXXFLAGS="-mmacosx-version-min=11.0"
-            export CGO_LDFLAGS="-mmacosx-version-min=11.0"
+            export CC="clang -arch arm64"
+            export CXX="clang++ -arch arm64"
+            export CGO_CFLAGS="-arch arm64 -mmacosx-version-min=11.0"
+            export CGO_CXXFLAGS="-arch arm64 -mmacosx-version-min=11.0"
+            export CGO_LDFLAGS="-arch arm64 -mmacosx-version-min=11.0"
           fi
           GOFLAGS="-trimpath -buildvcs=false" \
           go build -tags "desktop" \


### PR DESCRIPTION
### Motivation
- The desktop `darwin/amd64` job was frequently stuck waiting for scarce `macos-13` runners, causing long pipeline stalls. 
- Building both macOS desktop targets on `macos-14` avoids the runner availability bottleneck while still producing Intel-compatible binaries.

### Description
- Updated `.github/workflows/release.yml` to change the `build_desktop` matrix entry for `darwin/amd64` from `macos-13` to `macos-14` and clarified the intent in comments. 
- Added explicit compiler/linker and CGO flags for `darwin/amd64` to force `x86_64` (`CC`, `CXX`, `CGO_CFLAGS`, `CGO_CXXFLAGS`, `CGO_LDFLAGS` with `-arch x86_64`) and preserved `MACOSX_DEPLOYMENT_TARGET=10.13` for legacy Intel compatibility. 
- Added matching explicit `arm64` flags (`-arch arm64`) and `MACOSX_DEPLOYMENT_TARGET=11.0` for Apple Silicon builds so both architectures can be deterministically built on `macos-14`. 
- Left the universal binary `lipo` packaging step unchanged so the universal DMG creation is still produced from the two architecture builds. 

### Testing
- Ran `git diff --check` to validate there are no whitespace or patch issues and it succeeded. 
- Verified repository status with `git status --short` to confirm only the intended workflow file changed. 
- Performed a local review of the `build_desktop` matrix and the desktop build environment logic in `.github/workflows/release.yml` to confirm the flags and deployment targets are set correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5f39628f483328f0b8df8b5229228)