### PR TITLE
Fix macOS universal desktop lipo architecture verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -398,7 +398,7 @@ jobs:
           ARM64_BIN="dist/chicha-isotope-map_darwin_arm64_desktop"
           UNIVERSAL_BIN="dist/chicha-isotope-map_darwin_universal_desktop"
           lipo -create "${AMD64_BIN}" "${ARM64_BIN}" -output "${UNIVERSAL_BIN}"
-          lipo -verify_arch x86_64 arm64 "${UNIVERSAL_BIN}"
+          lipo "${UNIVERSAL_BIN}" -verify_arch x86_64 arm64
           chmod +x "${UNIVERSAL_BIN}"
 
       - name: Package universal desktop app (macOS DMG)


### PR DESCRIPTION
### Motivation
- The GitHub Actions `build_desktop_macos_universal` step failed because `lipo` was invoked with arguments in the wrong order causing the universal binary path to be interpreted as an architecture flag. 

### Description
- Reordered the `lipo -verify_arch` invocation in `.github/workflows/release.yml` from `lipo -verify_arch x86_64 arm64 "${UNIVERSAL_BIN}"` to `lipo "${UNIVERSAL_BIN}" -verify_arch x86_64 arm64` so it matches the `lipo <input_file> -verify_arch <arch...>` CLI syntax. 

### Testing
- Inspected the workflow with `sed -n '388,406p' .github/workflows/release.yml` and `nl -ba .github/workflows/release.yml | sed -n '394,404p'`, ran `git status --short`, and committed the change with `git add .github/workflows/release.yml && git commit -m "Fix lipo verify_arch invocation for macOS universal build"`, and all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5f6a8e1b48332a7a4f5ae639a7f34)