### PR TITLE
Desktop admin: DB path/size UI and translations; add macOS ad-hoc codesign in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -456,6 +456,11 @@ jobs:
           </plist>
           PLIST
 
+          # Ad-hoc sign keeps macOS launch services happy on fresh systems where
+          # unsigned bundles can bounce in Dock before the first trust override.
+          codesign --force --deep --sign - "${APP_DIR}"
+          codesign --verify --deep --strict "${APP_DIR}"
+
           # Put the app and /Applications shortcut into DMG so installation is drag-and-drop.
           rm -rf "${DMG_STAGING_DIR}"
           mkdir -p "${DMG_STAGING_DIR}"

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -3359,6 +3359,8 @@ function createDesktopAdminDefaultModel() {
     importSourcesAtomFast: true,
     realtimeUpdatesEnabled: true,
     weeklyArchiveURL: 'https://pelora.org/api/json/weekly.tgz',
+    dbPath: '',
+    dbSizeGB: 0,
     importStatusLine: '',
   };
 }
@@ -3385,8 +3387,17 @@ function saveDesktopAdminModel(adminModel) {
 function renderDesktopAdminPanel(adminModel) {
   const panelNode = document.getElementById('desktopAdminPanel');
   if (!panelNode) return;
+  const databasePathText = (adminModel.dbPath || '').trim();
+  const databaseSizeText = Number.isFinite(Number(adminModel.dbSizeGB))
+    ? `${Number(adminModel.dbSizeGB).toFixed(2)} GB`
+    : '—';
   panelNode.innerHTML = `
     <h3>${translate('desktop_admin_panel_title')}</h3>
+    <div class="desktop-admin-row">
+      <label for="desktopAdminDBPath">${translate('desktop_admin_option_db_path')}</label><br>
+      <input id="desktopAdminDBPath" type="text" style="width:100%; box-sizing:border-box;" value="${escapeHtml(databasePathText)}" placeholder="/path/to/chicha-isotope-map.db">
+    </div>
+    <div class="desktop-admin-row"><strong>${translate('desktop_admin_option_db_size')}:</strong> <span id="desktopDbSizeValue">${databaseSizeText}</span></div>
     <div class="desktop-admin-row"><label><input id="desktopAdminAutoImport" type="checkbox" ${adminModel.autoImportWeeklyArchive ? 'checked' : ''}> ${translate('desktop_admin_option_auto_import')}</label></div>
     <div class="desktop-admin-row"><label><input id="desktopAdminSourceSafecast" type="checkbox" ${adminModel.importSourcesSafecast ? 'checked' : ''}> ${translate('desktop_admin_option_source_safecast')}</label></div>
     <div class="desktop-admin-row"><label><input id="desktopAdminSourceAtomFast" type="checkbox" ${adminModel.importSourcesAtomFast ? 'checked' : ''}> ${translate('desktop_admin_option_source_atomfast')}</label></div>
@@ -3400,6 +3411,7 @@ function renderDesktopAdminPanel(adminModel) {
 
 function collectDesktopAdminModelFromPanel() {
   const currentModel = createDesktopAdminDefaultModel();
+  currentModel.dbPath = (document.getElementById('desktopAdminDBPath')?.value || '').trim();
   currentModel.autoImportWeeklyArchive = !!document.getElementById('desktopAdminAutoImport')?.checked;
   currentModel.importSourcesSafecast = !!document.getElementById('desktopAdminSourceSafecast')?.checked;
   currentModel.importSourcesAtomFast = !!document.getElementById('desktopAdminSourceAtomFast')?.checked;
@@ -3443,6 +3455,7 @@ async function saveDesktopServerSettings(adminModel) {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
+      dbPath: (adminModel.dbPath || '').trim(),
       enableHistoricalImport: adminModel.autoImportWeeklyArchive,
       enableSafecastImport: adminModel.importSourcesSafecast,
       enableAtomFastImport: adminModel.importSourcesAtomFast,
@@ -3469,6 +3482,15 @@ async function refreshDesktopStatusLine() {
     if (!statusResponse.ok) return;
     const statusPayload = await statusResponse.json();
     const line = `${statusPayload.line || ''}`;
+    if (typeof statusPayload.dbSizeGB !== 'undefined') {
+      const cachedModel = loadDesktopAdminModel();
+      cachedModel.dbSizeGB = Number(statusPayload.dbSizeGB) || 0;
+      saveDesktopAdminModel(cachedModel);
+      const sizeNode = document.getElementById('desktopDbSizeValue');
+      if (sizeNode) {
+        sizeNode.textContent = `${cachedModel.dbSizeGB.toFixed(2)} GB`;
+      }
+    }
     renderDesktopStatusLine(line);
   } catch (error) {
     console.warn('desktop status request failed:', error);
@@ -3521,7 +3543,10 @@ function initializeDesktopAdminUI() {
     adminModel.importSourcesSafecast = !!serverSettings.enableSafecastImport;
     adminModel.importSourcesAtomFast = !!serverSettings.enableAtomFastImport;
     adminModel.realtimeUpdatesEnabled = !!serverSettings.enableRealtimeUpdates;
+    adminModel.dbPath = (serverSettings.dbPath || '').trim();
+    adminModel.dbSizeGB = Number(serverSettings.dbSizeGB) || 0;
     adminModel.importStatusLine = (serverSettings.importStatus || '').trim();
+    saveDesktopAdminModel(adminModel);
     renderDesktopAdminPanel(adminModel);
     bindPanelApplyButton();
   }).catch(function (error) {

--- a/public_html/translations.json
+++ b/public_html/translations.json
@@ -137,9 +137,9 @@
     "waiting_for_server": "بانتظار الخادم...",
     "your_location": "موقعك",
     "desktop_admin_panel_title": "Desktop mode configuration",
-    "desktop_admin_option_auto_import": "Auto-import historical weekly TGZ",
-    "desktop_admin_option_source_safecast": "Enable Safecast importer",
-    "desktop_admin_option_source_atomfast": "Enable AtomFast importer",
+    "desktop_admin_option_auto_import": "البيانات التاريخية (منذ 2012 ~300 غيغابايت)",
+    "desktop_admin_option_source_safecast": "تحديثات Safecast",
+    "desktop_admin_option_source_atomfast": "تحديثات AtomFast",
     "desktop_admin_option_realtime_enable": "Enable Safecast realtime plugin",
     "desktop_admin_option_realtime_visible": "Show realtime markers by default",
     "desktop_admin_option_archive_url": "Weekly TGZ URL",
@@ -153,7 +153,7 @@
     "desktop_admin_option_mapbox_token": "Mapbox API token",
     "desktop_admin_option_default_layer": "Default map layer",
     "desktop_admin_option_mapbox_enable": "Enable Mapbox layer",
-    "desktop_admin_option_realtime_updates": "Receive realtime updates"
+    "desktop_admin_option_realtime_updates": "بيانات realtime"
   },
   "cs": {
     "api_example_archive_desc": "Stáhne archiv tgz se všemi zveřejněnými soubory .json, pokud je JSON archiv zapnutý.",
@@ -293,9 +293,9 @@
     "waiting_for_server": "Čekání na server...",
     "your_location": "Vaše poloha",
     "desktop_admin_panel_title": "Desktop mode configuration",
-    "desktop_admin_option_auto_import": "Auto-import historical weekly TGZ",
-    "desktop_admin_option_source_safecast": "Enable Safecast importer",
-    "desktop_admin_option_source_atomfast": "Enable AtomFast importer",
+    "desktop_admin_option_auto_import": "Historická data (od roku 2012 ~300 GB)",
+    "desktop_admin_option_source_safecast": "Aktualizace Safecast",
+    "desktop_admin_option_source_atomfast": "Aktualizace AtomFast",
     "desktop_admin_option_realtime_enable": "Enable Safecast realtime plugin",
     "desktop_admin_option_realtime_visible": "Show realtime markers by default",
     "desktop_admin_option_archive_url": "Weekly TGZ URL",
@@ -309,7 +309,7 @@
     "desktop_admin_option_mapbox_token": "Mapbox API token",
     "desktop_admin_option_default_layer": "Default map layer",
     "desktop_admin_option_mapbox_enable": "Enable Mapbox layer",
-    "desktop_admin_option_realtime_updates": "Receive realtime updates"
+    "desktop_admin_option_realtime_updates": "Realtime data"
   },
   "da": {
     "api_example_archive_desc": "Downloader en tgz-pakke med alle offentliggjorte .json-filer når JSON-arkivet er aktiveret.",
@@ -449,9 +449,9 @@
     "waiting_for_server": "Venter på serveren...",
     "your_location": "Din placering",
     "desktop_admin_panel_title": "Desktop mode configuration",
-    "desktop_admin_option_auto_import": "Auto-import historical weekly TGZ",
-    "desktop_admin_option_source_safecast": "Enable Safecast importer",
-    "desktop_admin_option_source_atomfast": "Enable AtomFast importer",
+    "desktop_admin_option_auto_import": "Historiske data (siden 2012 ~300 GB)",
+    "desktop_admin_option_source_safecast": "Safecast-opdateringer",
+    "desktop_admin_option_source_atomfast": "AtomFast-opdateringer",
     "desktop_admin_option_realtime_enable": "Enable Safecast realtime plugin",
     "desktop_admin_option_realtime_visible": "Show realtime markers by default",
     "desktop_admin_option_archive_url": "Weekly TGZ URL",
@@ -465,7 +465,7 @@
     "desktop_admin_option_mapbox_token": "Mapbox API token",
     "desktop_admin_option_default_layer": "Default map layer",
     "desktop_admin_option_mapbox_enable": "Enable Mapbox layer",
-    "desktop_admin_option_realtime_updates": "Receive realtime updates"
+    "desktop_admin_option_realtime_updates": "Realtime-data"
   },
   "de": {
     "api_example_archive_desc": "Lädt ein tgz-Paket mit allen veröffentlichten .json-Dateien, sofern das JSON-Archiv aktiv ist.",
@@ -605,9 +605,9 @@
     "waiting_for_server": "Warten auf den Server...",
     "your_location": "Ihr Standort",
     "desktop_admin_panel_title": "Desktop mode configuration",
-    "desktop_admin_option_auto_import": "Auto-import historical weekly TGZ",
-    "desktop_admin_option_source_safecast": "Enable Safecast importer",
-    "desktop_admin_option_source_atomfast": "Enable AtomFast importer",
+    "desktop_admin_option_auto_import": "Historische Daten (seit 2012 ~300 GB)",
+    "desktop_admin_option_source_safecast": "Safecast-Updates",
+    "desktop_admin_option_source_atomfast": "AtomFast-Updates",
     "desktop_admin_option_realtime_enable": "Enable Safecast realtime plugin",
     "desktop_admin_option_realtime_visible": "Show realtime markers by default",
     "desktop_admin_option_archive_url": "Weekly TGZ URL",
@@ -621,7 +621,7 @@
     "desktop_admin_option_mapbox_token": "Mapbox API token",
     "desktop_admin_option_default_layer": "Default map layer",
     "desktop_admin_option_mapbox_enable": "Enable Mapbox layer",
-    "desktop_admin_option_realtime_updates": "Receive realtime updates"
+    "desktop_admin_option_realtime_updates": "Realtime-Daten"
   },
   "el": {
     "api_example_archive_desc": "Κατεβάζει ένα αρχείο tgz με όλα τα δημοσιευμένα αρχεία .json όταν είναι ενεργό το JSON αρχείο.",
@@ -761,9 +761,9 @@
     "waiting_for_server": "Αναμονή για τον διακομιστή...",
     "your_location": "Η τοποθεσία σας",
     "desktop_admin_panel_title": "Desktop mode configuration",
-    "desktop_admin_option_auto_import": "Auto-import historical weekly TGZ",
-    "desktop_admin_option_source_safecast": "Enable Safecast importer",
-    "desktop_admin_option_source_atomfast": "Enable AtomFast importer",
+    "desktop_admin_option_auto_import": "Ιστορικά δεδομένα (από το 2012 ~300 GB)",
+    "desktop_admin_option_source_safecast": "Ενημερώσεις Safecast",
+    "desktop_admin_option_source_atomfast": "Ενημερώσεις AtomFast",
     "desktop_admin_option_realtime_enable": "Enable Safecast realtime plugin",
     "desktop_admin_option_realtime_visible": "Show realtime markers by default",
     "desktop_admin_option_archive_url": "Weekly TGZ URL",
@@ -777,7 +777,7 @@
     "desktop_admin_option_mapbox_token": "Mapbox API token",
     "desktop_admin_option_default_layer": "Default map layer",
     "desktop_admin_option_mapbox_enable": "Enable Mapbox layer",
-    "desktop_admin_option_realtime_updates": "Receive realtime updates"
+    "desktop_admin_option_realtime_updates": "Δεδομένα realtime"
   },
   "en": {
     "api_example_archive_desc": "Downloads a tgz bundle with every published .json file when the server enables the JSON archive.",
@@ -920,9 +920,9 @@
     "waiting_for_server": "Waiting for server...",
     "your_location": "Your location",
     "desktop_admin_panel_title": "Desktop mode configuration",
-    "desktop_admin_option_auto_import": "Auto-import historical weekly TGZ",
-    "desktop_admin_option_source_safecast": "Enable Safecast importer",
-    "desktop_admin_option_source_atomfast": "Enable AtomFast importer",
+    "desktop_admin_option_auto_import": "Historical data (since 2012 ~300 GB)",
+    "desktop_admin_option_source_safecast": "Safecast updates",
+    "desktop_admin_option_source_atomfast": "AtomFast updates",
     "desktop_admin_option_realtime_enable": "Enable Safecast realtime plugin",
     "desktop_admin_option_realtime_visible": "Show realtime markers by default",
     "desktop_admin_option_archive_url": "Weekly TGZ URL",
@@ -936,7 +936,7 @@
     "desktop_admin_option_mapbox_token": "Mapbox API token",
     "desktop_admin_option_default_layer": "Default map layer",
     "desktop_admin_option_mapbox_enable": "Enable Mapbox layer",
-    "desktop_admin_option_realtime_updates": "Receive realtime updates"
+    "desktop_admin_option_realtime_updates": "Realtime data"
   },
   "es": {
     "api_example_archive_desc": "Descarga un paquete tgz con todos los archivos .json publicados cuando el archivo JSON está activado.",
@@ -1076,9 +1076,9 @@
     "waiting_for_server": "Esperando al servidor...",
     "your_location": "Tu ubicación",
     "desktop_admin_panel_title": "Desktop mode configuration",
-    "desktop_admin_option_auto_import": "Auto-import historical weekly TGZ",
-    "desktop_admin_option_source_safecast": "Enable Safecast importer",
-    "desktop_admin_option_source_atomfast": "Enable AtomFast importer",
+    "desktop_admin_option_auto_import": "Datos históricos (desde 2012 ~300 GB)",
+    "desktop_admin_option_source_safecast": "Actualizaciones de Safecast",
+    "desktop_admin_option_source_atomfast": "Actualizaciones de AtomFast",
     "desktop_admin_option_realtime_enable": "Enable Safecast realtime plugin",
     "desktop_admin_option_realtime_visible": "Show realtime markers by default",
     "desktop_admin_option_archive_url": "Weekly TGZ URL",
@@ -1092,7 +1092,7 @@
     "desktop_admin_option_mapbox_token": "Mapbox API token",
     "desktop_admin_option_default_layer": "Default map layer",
     "desktop_admin_option_mapbox_enable": "Enable Mapbox layer",
-    "desktop_admin_option_realtime_updates": "Receive realtime updates"
+    "desktop_admin_option_realtime_updates": "Datos realtime"
   },
   "fa": {
     "api_example_archive_desc": "وقتی آرشیو JSON فعال باشد یک بسته tgz شامل تمام فایل‌های .json منتشرشده را دانلود می‌کند.",
@@ -1232,9 +1232,9 @@
     "waiting_for_server": "در انتظار سرور...",
     "your_location": "موقعیت شما",
     "desktop_admin_panel_title": "Desktop mode configuration",
-    "desktop_admin_option_auto_import": "Auto-import historical weekly TGZ",
-    "desktop_admin_option_source_safecast": "Enable Safecast importer",
-    "desktop_admin_option_source_atomfast": "Enable AtomFast importer",
+    "desktop_admin_option_auto_import": "داده‌های تاریخی (از ۲۰۱۲ ~۳۰۰ گیگابایت)",
+    "desktop_admin_option_source_safecast": "به‌روزرسانی‌های Safecast",
+    "desktop_admin_option_source_atomfast": "به‌روزرسانی‌های AtomFast",
     "desktop_admin_option_realtime_enable": "Enable Safecast realtime plugin",
     "desktop_admin_option_realtime_visible": "Show realtime markers by default",
     "desktop_admin_option_archive_url": "Weekly TGZ URL",
@@ -1248,7 +1248,7 @@
     "desktop_admin_option_mapbox_token": "Mapbox API token",
     "desktop_admin_option_default_layer": "Default map layer",
     "desktop_admin_option_mapbox_enable": "Enable Mapbox layer",
-    "desktop_admin_option_realtime_updates": "Receive realtime updates"
+    "desktop_admin_option_realtime_updates": "داده‌های realtime"
   },
   "fi": {
     "api_example_archive_desc": "Lataa tgz-paketin, jossa on kaikki julkaistut .json-tiedostot, kun JSON-arkisto on käytössä.",
@@ -1388,9 +1388,9 @@
     "waiting_for_server": "Odotetaan palvelinta...",
     "your_location": "Sijaintisi",
     "desktop_admin_panel_title": "Desktop mode configuration",
-    "desktop_admin_option_auto_import": "Auto-import historical weekly TGZ",
-    "desktop_admin_option_source_safecast": "Enable Safecast importer",
-    "desktop_admin_option_source_atomfast": "Enable AtomFast importer",
+    "desktop_admin_option_auto_import": "Historiatiedot (vuodesta 2012 ~300 Gt)",
+    "desktop_admin_option_source_safecast": "Safecast-päivitykset",
+    "desktop_admin_option_source_atomfast": "AtomFast-päivitykset",
     "desktop_admin_option_realtime_enable": "Enable Safecast realtime plugin",
     "desktop_admin_option_realtime_visible": "Show realtime markers by default",
     "desktop_admin_option_archive_url": "Weekly TGZ URL",
@@ -1404,7 +1404,7 @@
     "desktop_admin_option_mapbox_token": "Mapbox API token",
     "desktop_admin_option_default_layer": "Default map layer",
     "desktop_admin_option_mapbox_enable": "Enable Mapbox layer",
-    "desktop_admin_option_realtime_updates": "Receive realtime updates"
+    "desktop_admin_option_realtime_updates": "Realtime-data"
   },
   "fr": {
     "api_example_archive_desc": "Télécharge une archive tgz avec tous les fichiers .json publiés lorsque l’archive JSON est activée.",
@@ -1544,9 +1544,9 @@
     "waiting_for_server": "En attente du serveur...",
     "your_location": "Votre position",
     "desktop_admin_panel_title": "Desktop mode configuration",
-    "desktop_admin_option_auto_import": "Auto-import historical weekly TGZ",
-    "desktop_admin_option_source_safecast": "Enable Safecast importer",
-    "desktop_admin_option_source_atomfast": "Enable AtomFast importer",
+    "desktop_admin_option_auto_import": "Données historiques (depuis 2012 ~300 Go)",
+    "desktop_admin_option_source_safecast": "Mises à jour Safecast",
+    "desktop_admin_option_source_atomfast": "Mises à jour AtomFast",
     "desktop_admin_option_realtime_enable": "Enable Safecast realtime plugin",
     "desktop_admin_option_realtime_visible": "Show realtime markers by default",
     "desktop_admin_option_archive_url": "Weekly TGZ URL",
@@ -1560,7 +1560,7 @@
     "desktop_admin_option_mapbox_token": "Mapbox API token",
     "desktop_admin_option_default_layer": "Default map layer",
     "desktop_admin_option_mapbox_enable": "Enable Mapbox layer",
-    "desktop_admin_option_realtime_updates": "Receive realtime updates"
+    "desktop_admin_option_realtime_updates": "Données realtime"
   },
   "he": {
     "api_example_archive_desc": "מורידה חבילת tgz עם כל קבצי .json שפורסמו כאשר ארכיון ה-JSON מופעל.",
@@ -1700,9 +1700,9 @@
     "waiting_for_server": "ממתין לשרת...",
     "your_location": "המיקום שלך",
     "desktop_admin_panel_title": "Desktop mode configuration",
-    "desktop_admin_option_auto_import": "Auto-import historical weekly TGZ",
-    "desktop_admin_option_source_safecast": "Enable Safecast importer",
-    "desktop_admin_option_source_atomfast": "Enable AtomFast importer",
+    "desktop_admin_option_auto_import": "נתונים היסטוריים (מאז 2012 ~300 ג״ב)",
+    "desktop_admin_option_source_safecast": "עדכוני Safecast",
+    "desktop_admin_option_source_atomfast": "עדכוני AtomFast",
     "desktop_admin_option_realtime_enable": "Enable Safecast realtime plugin",
     "desktop_admin_option_realtime_visible": "Show realtime markers by default",
     "desktop_admin_option_archive_url": "Weekly TGZ URL",
@@ -1716,7 +1716,7 @@
     "desktop_admin_option_mapbox_token": "Mapbox API token",
     "desktop_admin_option_default_layer": "Default map layer",
     "desktop_admin_option_mapbox_enable": "Enable Mapbox layer",
-    "desktop_admin_option_realtime_updates": "Receive realtime updates"
+    "desktop_admin_option_realtime_updates": "נתוני realtime"
   },
   "hi": {
     "api_example_archive_desc": "JSON संग्रह सक्षम होने पर सभी प्रकाशित .json फ़ाइलों वाला tgz पैकेज डाउनलोड करता है।",
@@ -1856,9 +1856,9 @@
     "waiting_for_server": "सर्वर की प्रतीक्षा कर रहे हैं...",
     "your_location": "आपका स्थान",
     "desktop_admin_panel_title": "Desktop mode configuration",
-    "desktop_admin_option_auto_import": "Auto-import historical weekly TGZ",
-    "desktop_admin_option_source_safecast": "Enable Safecast importer",
-    "desktop_admin_option_source_atomfast": "Enable AtomFast importer",
+    "desktop_admin_option_auto_import": "ऐतिहासिक डेटा (2012 से ~300 GB)",
+    "desktop_admin_option_source_safecast": "Safecast अपडेट",
+    "desktop_admin_option_source_atomfast": "AtomFast अपडेट",
     "desktop_admin_option_realtime_enable": "Enable Safecast realtime plugin",
     "desktop_admin_option_realtime_visible": "Show realtime markers by default",
     "desktop_admin_option_archive_url": "Weekly TGZ URL",
@@ -1872,7 +1872,7 @@
     "desktop_admin_option_mapbox_token": "Mapbox API token",
     "desktop_admin_option_default_layer": "Default map layer",
     "desktop_admin_option_mapbox_enable": "Enable Mapbox layer",
-    "desktop_admin_option_realtime_updates": "Receive realtime updates"
+    "desktop_admin_option_realtime_updates": "realtime डेटा"
   },
   "hu": {
     "api_example_archive_desc": "Letölt egy tgz csomagot az összes közzétett .json fájllal, ha a JSON archívum engedélyezett.",
@@ -2012,9 +2012,9 @@
     "waiting_for_server": "Várakozás a szerverre...",
     "your_location": "A te helyzeted",
     "desktop_admin_panel_title": "Desktop mode configuration",
-    "desktop_admin_option_auto_import": "Auto-import historical weekly TGZ",
-    "desktop_admin_option_source_safecast": "Enable Safecast importer",
-    "desktop_admin_option_source_atomfast": "Enable AtomFast importer",
+    "desktop_admin_option_auto_import": "Történelmi adatok (2012 óta ~300 GB)",
+    "desktop_admin_option_source_safecast": "Safecast frissítések",
+    "desktop_admin_option_source_atomfast": "AtomFast frissítések",
     "desktop_admin_option_realtime_enable": "Enable Safecast realtime plugin",
     "desktop_admin_option_realtime_visible": "Show realtime markers by default",
     "desktop_admin_option_archive_url": "Weekly TGZ URL",
@@ -2028,7 +2028,7 @@
     "desktop_admin_option_mapbox_token": "Mapbox API token",
     "desktop_admin_option_default_layer": "Default map layer",
     "desktop_admin_option_mapbox_enable": "Enable Mapbox layer",
-    "desktop_admin_option_realtime_updates": "Receive realtime updates"
+    "desktop_admin_option_realtime_updates": "Realtime adatok"
   },
   "id": {
     "api_example_archive_desc": "Mengunduh paket tgz dengan semua berkas .json yang dipublikasikan saat arsip JSON diaktifkan.",
@@ -2168,9 +2168,9 @@
     "waiting_for_server": "Menunggu server...",
     "your_location": "Lokasimu",
     "desktop_admin_panel_title": "Desktop mode configuration",
-    "desktop_admin_option_auto_import": "Auto-import historical weekly TGZ",
-    "desktop_admin_option_source_safecast": "Enable Safecast importer",
-    "desktop_admin_option_source_atomfast": "Enable AtomFast importer",
+    "desktop_admin_option_auto_import": "Data historis (sejak 2012 ~300 GB)",
+    "desktop_admin_option_source_safecast": "Pembaruan Safecast",
+    "desktop_admin_option_source_atomfast": "Pembaruan AtomFast",
     "desktop_admin_option_realtime_enable": "Enable Safecast realtime plugin",
     "desktop_admin_option_realtime_visible": "Show realtime markers by default",
     "desktop_admin_option_archive_url": "Weekly TGZ URL",
@@ -2184,7 +2184,7 @@
     "desktop_admin_option_mapbox_token": "Mapbox API token",
     "desktop_admin_option_default_layer": "Default map layer",
     "desktop_admin_option_mapbox_enable": "Enable Mapbox layer",
-    "desktop_admin_option_realtime_updates": "Receive realtime updates"
+    "desktop_admin_option_realtime_updates": "Data realtime"
   },
   "it": {
     "api_example_archive_desc": "Scarica un archivio tgz con tutti i file .json pubblicati quando l’archivio JSON è attivo.",
@@ -2324,9 +2324,9 @@
     "waiting_for_server": "In attesa del server...",
     "your_location": "La tua posizione",
     "desktop_admin_panel_title": "Desktop mode configuration",
-    "desktop_admin_option_auto_import": "Auto-import historical weekly TGZ",
-    "desktop_admin_option_source_safecast": "Enable Safecast importer",
-    "desktop_admin_option_source_atomfast": "Enable AtomFast importer",
+    "desktop_admin_option_auto_import": "Dati storici (dal 2012 ~300 GB)",
+    "desktop_admin_option_source_safecast": "Aggiornamenti Safecast",
+    "desktop_admin_option_source_atomfast": "Aggiornamenti AtomFast",
     "desktop_admin_option_realtime_enable": "Enable Safecast realtime plugin",
     "desktop_admin_option_realtime_visible": "Show realtime markers by default",
     "desktop_admin_option_archive_url": "Weekly TGZ URL",
@@ -2340,7 +2340,7 @@
     "desktop_admin_option_mapbox_token": "Mapbox API token",
     "desktop_admin_option_default_layer": "Default map layer",
     "desktop_admin_option_mapbox_enable": "Enable Mapbox layer",
-    "desktop_admin_option_realtime_updates": "Receive realtime updates"
+    "desktop_admin_option_realtime_updates": "Dati realtime"
   },
   "ja": {
     "api_example_archive_desc": "JSON アーカイブが有効な場合、公開済みの .json ファイルをすべて含む tgz バンドルをダウンロードします。",
@@ -2480,9 +2480,9 @@
     "waiting_for_server": "サーバーを待機中...",
     "your_location": "あなたの位置",
     "desktop_admin_panel_title": "Desktop mode configuration",
-    "desktop_admin_option_auto_import": "Auto-import historical weekly TGZ",
-    "desktop_admin_option_source_safecast": "Enable Safecast importer",
-    "desktop_admin_option_source_atomfast": "Enable AtomFast importer",
+    "desktop_admin_option_auto_import": "履歴データ（2012年以降 ~300GB）",
+    "desktop_admin_option_source_safecast": "Safecast 更新",
+    "desktop_admin_option_source_atomfast": "AtomFast 更新",
     "desktop_admin_option_realtime_enable": "Enable Safecast realtime plugin",
     "desktop_admin_option_realtime_visible": "Show realtime markers by default",
     "desktop_admin_option_archive_url": "Weekly TGZ URL",
@@ -2496,7 +2496,7 @@
     "desktop_admin_option_mapbox_token": "Mapbox API token",
     "desktop_admin_option_default_layer": "Default map layer",
     "desktop_admin_option_mapbox_enable": "Enable Mapbox layer",
-    "desktop_admin_option_realtime_updates": "Receive realtime updates"
+    "desktop_admin_option_realtime_updates": "realtime データ"
   },
   "ko": {
     "api_example_archive_desc": "JSON 아카이브가 활성화된 경우 게시된 모든 .json 파일이 포함된 tgz 번들을 다운로드합니다.",
@@ -2636,9 +2636,9 @@
     "waiting_for_server": "서버 대기 중...",
     "your_location": "내 위치",
     "desktop_admin_panel_title": "Desktop mode configuration",
-    "desktop_admin_option_auto_import": "Auto-import historical weekly TGZ",
-    "desktop_admin_option_source_safecast": "Enable Safecast importer",
-    "desktop_admin_option_source_atomfast": "Enable AtomFast importer",
+    "desktop_admin_option_auto_import": "히스토리 데이터(2012년부터 ~300GB)",
+    "desktop_admin_option_source_safecast": "Safecast 업데이트",
+    "desktop_admin_option_source_atomfast": "AtomFast 업데이트",
     "desktop_admin_option_realtime_enable": "Enable Safecast realtime plugin",
     "desktop_admin_option_realtime_visible": "Show realtime markers by default",
     "desktop_admin_option_archive_url": "Weekly TGZ URL",
@@ -2652,7 +2652,7 @@
     "desktop_admin_option_mapbox_token": "Mapbox API token",
     "desktop_admin_option_default_layer": "Default map layer",
     "desktop_admin_option_mapbox_enable": "Enable Mapbox layer",
-    "desktop_admin_option_realtime_updates": "Receive realtime updates"
+    "desktop_admin_option_realtime_updates": "realtime 데이터"
   },
   "ms": {
     "api_example_archive_desc": "Memuat turun pakej tgz dengan semua fail .json yang diterbitkan apabila arkib JSON diaktifkan.",
@@ -2792,9 +2792,9 @@
     "waiting_for_server": "Menunggu pelayan...",
     "your_location": "Lokasi anda",
     "desktop_admin_panel_title": "Desktop mode configuration",
-    "desktop_admin_option_auto_import": "Auto-import historical weekly TGZ",
-    "desktop_admin_option_source_safecast": "Enable Safecast importer",
-    "desktop_admin_option_source_atomfast": "Enable AtomFast importer",
+    "desktop_admin_option_auto_import": "Data sejarah (sejak 2012 ~300 GB)",
+    "desktop_admin_option_source_safecast": "Kemas kini Safecast",
+    "desktop_admin_option_source_atomfast": "Kemas kini AtomFast",
     "desktop_admin_option_realtime_enable": "Enable Safecast realtime plugin",
     "desktop_admin_option_realtime_visible": "Show realtime markers by default",
     "desktop_admin_option_archive_url": "Weekly TGZ URL",
@@ -2808,7 +2808,7 @@
     "desktop_admin_option_mapbox_token": "Mapbox API token",
     "desktop_admin_option_default_layer": "Default map layer",
     "desktop_admin_option_mapbox_enable": "Enable Mapbox layer",
-    "desktop_admin_option_realtime_updates": "Receive realtime updates"
+    "desktop_admin_option_realtime_updates": "Data realtime"
   },
   "nl": {
     "api_example_archive_desc": "Downloadt een tgz-pakket met alle gepubliceerde .json-bestanden wanneer het JSON-archief is ingeschakeld.",
@@ -2948,9 +2948,9 @@
     "waiting_for_server": "Wachten op server...",
     "your_location": "Uw locatie",
     "desktop_admin_panel_title": "Desktop mode configuration",
-    "desktop_admin_option_auto_import": "Auto-import historical weekly TGZ",
-    "desktop_admin_option_source_safecast": "Enable Safecast importer",
-    "desktop_admin_option_source_atomfast": "Enable AtomFast importer",
+    "desktop_admin_option_auto_import": "Historische gegevens (sinds 2012 ~300 GB)",
+    "desktop_admin_option_source_safecast": "Safecast-updates",
+    "desktop_admin_option_source_atomfast": "AtomFast-updates",
     "desktop_admin_option_realtime_enable": "Enable Safecast realtime plugin",
     "desktop_admin_option_realtime_visible": "Show realtime markers by default",
     "desktop_admin_option_archive_url": "Weekly TGZ URL",
@@ -2964,7 +2964,7 @@
     "desktop_admin_option_mapbox_token": "Mapbox API token",
     "desktop_admin_option_default_layer": "Default map layer",
     "desktop_admin_option_mapbox_enable": "Enable Mapbox layer",
-    "desktop_admin_option_realtime_updates": "Receive realtime updates"
+    "desktop_admin_option_realtime_updates": "Realtime-gegevens"
   },
   "no": {
     "api_example_archive_desc": "Laster ned en tgz-pakke med alle publiserte .json-filer når JSON-arkivet er aktivert.",
@@ -3104,9 +3104,9 @@
     "waiting_for_server": "Venter på serveren...",
     "your_location": "Din posisjon",
     "desktop_admin_panel_title": "Desktop mode configuration",
-    "desktop_admin_option_auto_import": "Auto-import historical weekly TGZ",
-    "desktop_admin_option_source_safecast": "Enable Safecast importer",
-    "desktop_admin_option_source_atomfast": "Enable AtomFast importer",
+    "desktop_admin_option_auto_import": "Historiske data (siden 2012 ~300 GB)",
+    "desktop_admin_option_source_safecast": "Safecast-oppdateringer",
+    "desktop_admin_option_source_atomfast": "AtomFast-oppdateringer",
     "desktop_admin_option_realtime_enable": "Enable Safecast realtime plugin",
     "desktop_admin_option_realtime_visible": "Show realtime markers by default",
     "desktop_admin_option_archive_url": "Weekly TGZ URL",
@@ -3120,7 +3120,7 @@
     "desktop_admin_option_mapbox_token": "Mapbox API token",
     "desktop_admin_option_default_layer": "Default map layer",
     "desktop_admin_option_mapbox_enable": "Enable Mapbox layer",
-    "desktop_admin_option_realtime_updates": "Receive realtime updates"
+    "desktop_admin_option_realtime_updates": "Realtime-data"
   },
   "pl": {
     "api_example_archive_desc": "Pobiera paczkę tgz ze wszystkimi opublikowanymi plikami .json, gdy archiwum JSON jest włączone.",
@@ -3260,9 +3260,9 @@
     "waiting_for_server": "Oczekiwanie na serwer...",
     "your_location": "Twoja lokalizacja",
     "desktop_admin_panel_title": "Desktop mode configuration",
-    "desktop_admin_option_auto_import": "Auto-import historical weekly TGZ",
-    "desktop_admin_option_source_safecast": "Enable Safecast importer",
-    "desktop_admin_option_source_atomfast": "Enable AtomFast importer",
+    "desktop_admin_option_auto_import": "Dane historyczne (od 2012 ~300 GB)",
+    "desktop_admin_option_source_safecast": "Aktualizacje Safecast",
+    "desktop_admin_option_source_atomfast": "Aktualizacje AtomFast",
     "desktop_admin_option_realtime_enable": "Enable Safecast realtime plugin",
     "desktop_admin_option_realtime_visible": "Show realtime markers by default",
     "desktop_admin_option_archive_url": "Weekly TGZ URL",
@@ -3276,7 +3276,7 @@
     "desktop_admin_option_mapbox_token": "Mapbox API token",
     "desktop_admin_option_default_layer": "Default map layer",
     "desktop_admin_option_mapbox_enable": "Enable Mapbox layer",
-    "desktop_admin_option_realtime_updates": "Receive realtime updates"
+    "desktop_admin_option_realtime_updates": "Dane realtime"
   },
   "pt": {
     "api_example_archive_desc": "Baixa um pacote tgz com todos os arquivos .json publicados quando o arquivo JSON está ativado.",
@@ -3416,9 +3416,9 @@
     "waiting_for_server": "Aguardando o servidor...",
     "your_location": "Sua localização",
     "desktop_admin_panel_title": "Desktop mode configuration",
-    "desktop_admin_option_auto_import": "Auto-import historical weekly TGZ",
-    "desktop_admin_option_source_safecast": "Enable Safecast importer",
-    "desktop_admin_option_source_atomfast": "Enable AtomFast importer",
+    "desktop_admin_option_auto_import": "Dados históricos (desde 2012 ~300 GB)",
+    "desktop_admin_option_source_safecast": "Atualizações do Safecast",
+    "desktop_admin_option_source_atomfast": "Atualizações do AtomFast",
     "desktop_admin_option_realtime_enable": "Enable Safecast realtime plugin",
     "desktop_admin_option_realtime_visible": "Show realtime markers by default",
     "desktop_admin_option_archive_url": "Weekly TGZ URL",
@@ -3432,7 +3432,7 @@
     "desktop_admin_option_mapbox_token": "Mapbox API token",
     "desktop_admin_option_default_layer": "Default map layer",
     "desktop_admin_option_mapbox_enable": "Enable Mapbox layer",
-    "desktop_admin_option_realtime_updates": "Receive realtime updates"
+    "desktop_admin_option_realtime_updates": "Dados realtime"
   },
   "ru": {
     "api_example_archive_desc": "Скачивает архив tgz со всеми опубликованными файлами .json, если включён JSON‑архив.",
@@ -3572,9 +3572,9 @@
     "waiting_for_server": "Ожидание сервера...",
     "your_location": "Ваше местоположение",
     "desktop_admin_panel_title": "Настройки Desktop режима",
-    "desktop_admin_option_auto_import": "Автоимпорт исторического weekly TGZ",
-    "desktop_admin_option_source_safecast": "Включить импорт Safecast",
-    "desktop_admin_option_source_atomfast": "Включить импорт AtomFast",
+    "desktop_admin_option_auto_import": "исторические данные (с 2012 года ~300гб.)",
+    "desktop_admin_option_source_safecast": "обновления Safecast",
+    "desktop_admin_option_source_atomfast": "обновления AtomFast",
     "desktop_admin_option_realtime_enable": "Включить плагин Safecast realtime",
     "desktop_admin_option_realtime_visible": "Показывать realtime-маркеры по умолчанию",
     "desktop_admin_option_archive_url": "URL weekly TGZ",
@@ -3588,7 +3588,7 @@
     "desktop_admin_option_mapbox_token": "Mapbox API токен",
     "desktop_admin_option_default_layer": "Слой карты по умолчанию",
     "desktop_admin_option_mapbox_enable": "Включить слой Mapbox",
-    "desktop_admin_option_realtime_updates": "Получать real-time данные"
+    "desktop_admin_option_realtime_updates": "realtime данные"
   },
   "sv": {
     "api_example_archive_desc": "Hämtar ett tgz-paket med alla publicerade .json-filer när JSON-arkivet är aktiverat.",
@@ -3728,9 +3728,9 @@
     "waiting_for_server": "Väntar på servern...",
     "your_location": "Din plats",
     "desktop_admin_panel_title": "Desktop mode configuration",
-    "desktop_admin_option_auto_import": "Auto-import historical weekly TGZ",
-    "desktop_admin_option_source_safecast": "Enable Safecast importer",
-    "desktop_admin_option_source_atomfast": "Enable AtomFast importer",
+    "desktop_admin_option_auto_import": "Historiska data (sedan 2012 ~300 GB)",
+    "desktop_admin_option_source_safecast": "Safecast-uppdateringar",
+    "desktop_admin_option_source_atomfast": "AtomFast-uppdateringar",
     "desktop_admin_option_realtime_enable": "Enable Safecast realtime plugin",
     "desktop_admin_option_realtime_visible": "Show realtime markers by default",
     "desktop_admin_option_archive_url": "Weekly TGZ URL",
@@ -3744,7 +3744,7 @@
     "desktop_admin_option_mapbox_token": "Mapbox API token",
     "desktop_admin_option_default_layer": "Default map layer",
     "desktop_admin_option_mapbox_enable": "Enable Mapbox layer",
-    "desktop_admin_option_realtime_updates": "Receive realtime updates"
+    "desktop_admin_option_realtime_updates": "Realtime-data"
   },
   "th": {
     "api_example_archive_desc": "ดาวน์โหลดแพ็กเกจ tgz ที่มีไฟล์ .json ทั้งหมดเมื่อเปิดใช้งานคลัง JSON",
@@ -3884,9 +3884,9 @@
     "waiting_for_server": "กำลังรอเซิร์ฟเวอร์...",
     "your_location": "ตำแหน่งของคุณ",
     "desktop_admin_panel_title": "Desktop mode configuration",
-    "desktop_admin_option_auto_import": "Auto-import historical weekly TGZ",
-    "desktop_admin_option_source_safecast": "Enable Safecast importer",
-    "desktop_admin_option_source_atomfast": "Enable AtomFast importer",
+    "desktop_admin_option_auto_import": "ข้อมูลย้อนหลัง (ตั้งแต่ปี 2012 ~300 GB)",
+    "desktop_admin_option_source_safecast": "อัปเดต Safecast",
+    "desktop_admin_option_source_atomfast": "อัปเดต AtomFast",
     "desktop_admin_option_realtime_enable": "Enable Safecast realtime plugin",
     "desktop_admin_option_realtime_visible": "Show realtime markers by default",
     "desktop_admin_option_archive_url": "Weekly TGZ URL",
@@ -3900,7 +3900,7 @@
     "desktop_admin_option_mapbox_token": "Mapbox API token",
     "desktop_admin_option_default_layer": "Default map layer",
     "desktop_admin_option_mapbox_enable": "Enable Mapbox layer",
-    "desktop_admin_option_realtime_updates": "Receive realtime updates"
+    "desktop_admin_option_realtime_updates": "ข้อมูล realtime"
   },
   "tr": {
     "api_example_archive_desc": "JSON arşivi etkinse yayımlanmış tüm .json dosyalarıyla bir tgz paketi indirir.",
@@ -4040,9 +4040,9 @@
     "waiting_for_server": "Sunucu bekleniyor...",
     "your_location": "Konumunuz",
     "desktop_admin_panel_title": "Desktop mode configuration",
-    "desktop_admin_option_auto_import": "Auto-import historical weekly TGZ",
-    "desktop_admin_option_source_safecast": "Enable Safecast importer",
-    "desktop_admin_option_source_atomfast": "Enable AtomFast importer",
+    "desktop_admin_option_auto_import": "Geçmiş veriler (2012'den beri ~300 GB)",
+    "desktop_admin_option_source_safecast": "Safecast güncellemeleri",
+    "desktop_admin_option_source_atomfast": "AtomFast güncellemeleri",
     "desktop_admin_option_realtime_enable": "Enable Safecast realtime plugin",
     "desktop_admin_option_realtime_visible": "Show realtime markers by default",
     "desktop_admin_option_archive_url": "Weekly TGZ URL",
@@ -4056,7 +4056,7 @@
     "desktop_admin_option_mapbox_token": "Mapbox API token",
     "desktop_admin_option_default_layer": "Default map layer",
     "desktop_admin_option_mapbox_enable": "Enable Mapbox layer",
-    "desktop_admin_option_realtime_updates": "Receive realtime updates"
+    "desktop_admin_option_realtime_updates": "Realtime veriler"
   },
   "uk": {
     "api_example_archive_desc": "Завантажує tgz-пакет з усіма опублікованими файлами .json, коли JSON-архів увімкнено.",
@@ -4196,9 +4196,9 @@
     "waiting_for_server": "Очікування сервера...",
     "your_location": "Ваше розташування",
     "desktop_admin_panel_title": "Desktop mode configuration",
-    "desktop_admin_option_auto_import": "Auto-import historical weekly TGZ",
-    "desktop_admin_option_source_safecast": "Enable Safecast importer",
-    "desktop_admin_option_source_atomfast": "Enable AtomFast importer",
+    "desktop_admin_option_auto_import": "Історичні дані (з 2012 року ~300 ГБ)",
+    "desktop_admin_option_source_safecast": "Оновлення Safecast",
+    "desktop_admin_option_source_atomfast": "Оновлення AtomFast",
     "desktop_admin_option_realtime_enable": "Enable Safecast realtime plugin",
     "desktop_admin_option_realtime_visible": "Show realtime markers by default",
     "desktop_admin_option_archive_url": "Weekly TGZ URL",
@@ -4212,7 +4212,7 @@
     "desktop_admin_option_mapbox_token": "Mapbox API token",
     "desktop_admin_option_default_layer": "Default map layer",
     "desktop_admin_option_mapbox_enable": "Enable Mapbox layer",
-    "desktop_admin_option_realtime_updates": "Receive realtime updates"
+    "desktop_admin_option_realtime_updates": "Realtime дані"
   },
   "vi": {
     "api_example_archive_desc": "Tải gói tgz chứa mọi tệp .json đã công bố khi bật lưu trữ JSON.",
@@ -4352,9 +4352,9 @@
     "waiting_for_server": "Đang chờ máy chủ...",
     "your_location": "Vị trí của bạn",
     "desktop_admin_panel_title": "Desktop mode configuration",
-    "desktop_admin_option_auto_import": "Auto-import historical weekly TGZ",
-    "desktop_admin_option_source_safecast": "Enable Safecast importer",
-    "desktop_admin_option_source_atomfast": "Enable AtomFast importer",
+    "desktop_admin_option_auto_import": "Dữ liệu lịch sử (từ 2012 ~300 GB)",
+    "desktop_admin_option_source_safecast": "Cập nhật Safecast",
+    "desktop_admin_option_source_atomfast": "Cập nhật AtomFast",
     "desktop_admin_option_realtime_enable": "Enable Safecast realtime plugin",
     "desktop_admin_option_realtime_visible": "Show realtime markers by default",
     "desktop_admin_option_archive_url": "Weekly TGZ URL",
@@ -4368,7 +4368,7 @@
     "desktop_admin_option_mapbox_token": "Mapbox API token",
     "desktop_admin_option_default_layer": "Default map layer",
     "desktop_admin_option_mapbox_enable": "Enable Mapbox layer",
-    "desktop_admin_option_realtime_updates": "Receive realtime updates"
+    "desktop_admin_option_realtime_updates": "Dữ liệu realtime"
   },
   "zh": {
     "api_example_archive_desc": "在启用 JSON 归档时，下载包含所有已发布 .json 文件的 tgz 包。",
@@ -4508,9 +4508,9 @@
     "waiting_for_server": "正在等待服务器...",
     "your_location": "您的位置",
     "desktop_admin_panel_title": "Desktop mode configuration",
-    "desktop_admin_option_auto_import": "Auto-import historical weekly TGZ",
-    "desktop_admin_option_source_safecast": "Enable Safecast importer",
-    "desktop_admin_option_source_atomfast": "Enable AtomFast importer",
+    "desktop_admin_option_auto_import": "历史数据（自2012年起 ~300GB）",
+    "desktop_admin_option_source_safecast": "Safecast 更新",
+    "desktop_admin_option_source_atomfast": "AtomFast 更新",
     "desktop_admin_option_realtime_enable": "Enable Safecast realtime plugin",
     "desktop_admin_option_realtime_visible": "Show realtime markers by default",
     "desktop_admin_option_archive_url": "Weekly TGZ URL",
@@ -4524,6 +4524,6 @@
     "desktop_admin_option_mapbox_token": "Mapbox API token",
     "desktop_admin_option_default_layer": "Default map layer",
     "desktop_admin_option_mapbox_enable": "Enable Mapbox layer",
-    "desktop_admin_option_realtime_updates": "Receive realtime updates"
+    "desktop_admin_option_realtime_updates": "realtime 数据"
   }
 }


### PR DESCRIPTION
### Motivation
- Expose and persist a configurable database path and visible database size in the Desktop admin panel so desktop users can choose where the DB lives and see its on-disk size.
- Improve macOS packaging so freshly-built unsigned apps don't misbehave in the Dock by ad-hoc signing and verifying before DMG creation.
- Localize and clarify desktop admin option labels across many languages to better communicate historical data size and realtime behaviour.

### Description
- Updated `public_html/map.html` to add `dbPath` and `dbSizeGB` to the desktop admin model, persist them via `localStorage`, render an editable `Default database path` input, display `Database size`, collect `dbPath` on apply, and include `dbPath` in the `saveDesktopServerSettings` POST payload.
- Added status polling in `refreshDesktopStatusLine` to accept `dbSizeGB` from `/desktop/admin/status`, persist it to the cached admin model, and update the panel `desktopDbSizeValue` live (polling every 5s).
- Updated `public_html/translations.json` with revised/localized strings for desktop admin options (notably `desktop_admin_option_auto_import`, `desktop_admin_option_source_safecast`, `desktop_admin_option_source_atomfast`, and `desktop_admin_option_realtime_updates`) across many locales to reflect the historical-data size and clearer labels.
- Modified `.github/workflows/release.yml` to run `codesign --force --deep --sign - "${APP_DIR}"` and `codesign --verify --deep --strict "${APP_DIR}"` before creating the DMG to ad-hoc sign and verify the app bundle.

### Testing
- No automated tests were added or modified for this change and no automated test suite was run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e66f9a1fa88332a2731e8f0ccda783)