### PR TITLE
Fix desktop native import to focus uploaded track bounds

### DIFF
--- a/chicha-isotope-map.go
+++ b/chicha-isotope-map.go
@@ -5006,6 +5006,13 @@ func uploadLocalFiles(ctx context.Context, filePaths []string) (map[string]inter
 	}
 
 	trackURL := fmt.Sprintf("/trackid/%s", trackID)
+	if hasBounds {
+		trackURL = fmt.Sprintf(
+			"/trackid/%s?minLat=%f&minLon=%f&maxLat=%f&maxLon=%f&zoom=14&layer=%s",
+			trackID, global.MinLat, global.MinLon, global.MaxLat, global.MaxLon,
+			"OpenStreetMap",
+		)
+	}
 	return map[string]interface{}{
 		"status":       "success",
 		"trackID":      trackID,


### PR DESCRIPTION
### Motivation
- Desktop native file imports did not include computed map bounds in the returned `trackURL`, so the UI did not automatically focus/zoom to the newly uploaded track as it did for regular uploads.

### Description
- Update `uploadLocalFiles` to build a bounds-aware URL when `hasBounds` is true and return it as `trackURL` in the success response in `chicha-isotope-map.go`.
- The bounds-aware URL uses the shape `/trackid/{id}?minLat=...&minLon=...&maxLat=...&maxLon=...&zoom=14&layer=OpenStreetMap` so the front-end will call `map.fitBounds(...)` and center/zoom the map to the track area.
- Preserve the fallback `'/trackid/{id}'` URL when no bounds are available and leave background/queued import behavior unchanged.

### Testing
- Ran `go test ./...` and the test suite passed (reported `ok` for packages with tests and no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6898b38e4833299f387b88e65ae97)