### PR TITLE
Add offline download estimation API and offline roadmap docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,171 @@ Ports 80/443 must be open.
 
 ---
 
+## Offline map download roadmap (desktop + server)
+
+This section describes a practical design for full offline work: user selects an area, app downloads required map layers and track overlays, then renders everything without internet.
+
+### Goals
+- One offline workflow for both modes:
+  - Desktop app (`-desktop`)
+  - Server mode opened in browser
+- Deterministic cache package: selected bounds + selected zoom range + selected layers.
+- Explicit storage limits and predictable eviction.
+
+### 1) Data model for offline region
+
+Persist one `offline_region` manifest per user action:
+- `region_id` (UUID)
+- `created_at`
+- `bbox` (`minLon,minLat,maxLon,maxLat`)
+- `zoom_min`, `zoom_max`
+- `base_layers[]` (e.g., OSM, satellite)
+- `overlay_layers[]` (track heatmap, markers, optional tiles)
+- `tile_count_estimate`, `byte_estimate`
+- `status` (`queued|downloading|ready|failed|canceled`)
+
+Each manifest points to downloaded tile and overlay records. Keep manifests immutable after `ready`; update by creating a new region version.
+
+### 2) Client storage (IndexedDB first)
+
+Use IndexedDB as the primary browser-side storage for both desktop WebView and server-browser sessions:
+
+- DB: `chicha_offline_v1`
+- Stores:
+  - `offline_regions` (manifest metadata)
+  - `tiles` (key: `source|z|x|y|styleVersion`, value: binary blob + metadata)
+  - `overlays` (vector chunks / compressed GeoJSON for tracks)
+  - `jobs` (download progress, retry counters)
+
+Recommended indexes:
+- `tiles.by_source_zxy`
+- `tiles.by_last_access`
+- `tiles.by_region_id`
+- `jobs.by_status`
+
+Why IndexedDB:
+- Works in browser and desktop WebView with one code path.
+- Blob storage is efficient enough for map tiles.
+- Can stream chunks and resume interrupted downloads.
+
+### 3) Server-side cache mirror
+
+For server deployments, add a disk cache so offline packs survive browser storage resets:
+
+- Directory layout:
+  - `data/offline/regions/<region_id>/manifest.json`
+  - `data/offline/tiles/<source>/<z>/<x>/<y>.tile`
+  - `data/offline/overlays/<region_id>/<chunk_id>.bin`
+- Optional metadata table in existing SQL DB:
+  - `offline_regions`
+  - `offline_region_tiles`
+  - `offline_region_overlays`
+
+Client still uses IndexedDB for fast read. Server cache is authoritative backup and supports sharing one prepared region with many users.
+
+### 4) Area selection and tile enumeration
+
+User flow:
+1. Click **Offline mode**
+2. Draw rectangle / polygon
+3. Choose zoom range and layers
+4. See estimate (`N tiles`, `~MB/GB`)
+5. Confirm download
+
+Tile enumeration algorithm:
+- Convert selected geometry to XYZ tile ranges for each zoom level.
+- If polygon mode is used, keep only tiles intersecting polygon.
+- Deduplicate by tile key across layers that share source/version.
+- Emit a deterministic queue (`source,z,x,y`) sorted by:
+  1. lower zoom first (faster coarse preview),
+  2. then distance from map center.
+
+### 5) Download pipeline (channel-oriented)
+
+Use a pipeline model for Go + frontend workers:
+
+`enumerate -> fetch -> verify -> persist -> index -> progress`
+
+Rules:
+- Bounded worker pool per source host (avoid bans).
+- Retry with exponential backoff for transient failures.
+- Verify content type + non-empty body before persist.
+- Persist atomically (temp key/file then commit).
+- Progress events over WebSocket:
+  - `offline_job_started`
+  - `offline_tile_saved`
+  - `offline_overlay_saved`
+  - `offline_job_failed`
+  - `offline_job_completed`
+
+### 6) Read path in offline mode
+
+At render time:
+1. Try IndexedDB tile/overlay.
+2. If miss and server mode enabled: ask server offline cache endpoint.
+3. If still miss and online allowed: fetch network and optionally backfill cache.
+4. If strict offline enabled: return explicit placeholder + log miss counter.
+
+This keeps behavior explicit and debuggable.
+
+### 7) Eviction and quotas
+
+Required controls:
+- Global byte quota for IndexedDB cache.
+- Optional per-region quota.
+- LRU eviction on `tiles.by_last_access`.
+- “Pin region” flag to prevent eviction.
+- Pre-download warning if estimated size exceeds remaining budget.
+
+### 8) Overlay/track offline strategy
+
+Tracks should not rely on live API when region is offline-ready.
+
+Recommended approach:
+- During region download, query track points intersecting selected geometry.
+- Chunk by geohash/S2 cell or tile-aligned vector chunks.
+- Store compressed payload (gzip/brotli) in `overlays`.
+- Build local spatial index (`cell_id -> chunk_ids`).
+
+Render path loads only visible chunks for current viewport.
+
+### 9) Minimal incremental implementation plan
+
+Phase 1:
+- Rectangle selection, base map tiles only, IndexedDB storage, manual delete.
+
+Phase 2:
+- Add overlays/tracks download and local chunk index.
+
+Phase 3:
+- Add server disk mirror and rehydrate endpoint.
+
+Phase 4:
+- Add polygon selection, pinning, quota UI, and integrity checker.
+
+### 10) API contracts to add
+
+- `POST /api/offline/estimate`
+  - input: bbox/polygon + zooms + layers
+  - output: tile count + byte estimate
+- `POST /api/offline/jobs`
+  - start download job
+- `GET /api/offline/jobs/:id`
+  - progress state
+- `DELETE /api/offline/regions/:id`
+  - delete region
+- `GET /api/offline/tiles/:source/:z/:x/:y`
+  - server cache fallback
+
+### 11) Why this architecture fits the current project
+
+- Keeps one UX across desktop and server variants.
+- Uses web-standard client storage (IndexedDB) with no platform-specific branching.
+- Preserves fast startup and predictable behavior during no-network operation.
+- Scales from single-user desktop to multi-user hosted server.
+
+---
+
 ## History and contributors
 
 This project was conceived to grant people a clear and immediate understanding of radiation safety in the very places they inhabit—where they reside, labor, cultivate the land, and draw water.

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -59,6 +59,7 @@ func NewHandler(db *database.Database, dbType string, archive *jsonarchive.Gener
 func (h *Handler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("/api", h.handleOverview)
 	mux.HandleFunc("/api/latest", h.handleLatestNearby)
+	mux.HandleFunc("/api/offline/estimate", h.handleOfflineEstimate)
 	mux.HandleFunc("/api/tracks", h.handleTracksList)
 	mux.HandleFunc("/api/tracks/index/", h.handleTrackDataByIndex)
 	mux.HandleFunc("/api/tracks/years/", h.handleTracksByYear)
@@ -328,6 +329,11 @@ func (h *Handler) handleOverview(w http.ResponseWriter, r *http.Request) {
 				"method":      "GET",
 				"path":        "/api/tracks/months/{year}/{month}",
 				"description": "Lists all tracks for a calendar month without pagination.",
+			},
+			"offlineEstimate": map[string]any{
+				"method":      "POST",
+				"path":        "/api/offline/estimate",
+				"description": "Estimates how many XYZ tiles are needed for a selected bbox and zoom range, plus rough storage size.",
 			},
 		}
 		if h.Archive != nil {

--- a/pkg/api/offline_estimate.go
+++ b/pkg/api/offline_estimate.go
@@ -1,0 +1,227 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"math"
+	"net/http"
+	"strings"
+)
+
+const (
+	maxMercatorLatitude          = 85.05112878
+	defaultOfflineBytesPerTile   = 28 * 1024
+	maxOfflineEstimateRequestRaw = 16 * 1024
+)
+
+type offlineEstimateRequest struct {
+	MinLat        float64  `json:"minLat"`
+	MinLon        float64  `json:"minLon"`
+	MaxLat        float64  `json:"maxLat"`
+	MaxLon        float64  `json:"maxLon"`
+	ZoomMin       int      `json:"zoomMin"`
+	ZoomMax       int      `json:"zoomMax"`
+	BaseLayers    []string `json:"baseLayers"`
+	OverlayLayers []string `json:"overlayLayers"`
+	BytesPerTile  int64    `json:"bytesPerTile"`
+}
+
+type offlineEstimateZoom struct {
+	Zoom      int   `json:"zoom"`
+	TileCount int64 `json:"tileCount"`
+}
+
+type offlineEstimateResponse struct {
+	TileCount      int64                 `json:"tileCount"`
+	LayerCount     int                   `json:"layerCount"`
+	EstimatedBytes int64                 `json:"estimatedBytes"`
+	EstimatedMiB   float64               `json:"estimatedMiB"`
+	Breakdown      []offlineEstimateZoom `json:"breakdown"`
+}
+
+// handleOfflineEstimate returns a deterministic estimate used by the frontend
+// before starting a large offline download job. We keep this endpoint
+// stateless so callers can safely retry without side effects.
+func (h *Handler) handleOfflineEstimate(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	permit, ok := h.acquirePermit(w, r, RequestGeneral)
+	if !ok {
+		return
+	}
+	if permit != nil {
+		defer permit.Release()
+	}
+
+	requestPayload, err := decodeOfflineEstimateRequest(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	responsePayload, err := buildOfflineEstimate(requestPayload)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	h.respondJSON(w, responsePayload)
+}
+
+func decodeOfflineEstimateRequest(r *http.Request) (offlineEstimateRequest, error) {
+	defer r.Body.Close()
+	bodyBytes, err := io.ReadAll(io.LimitReader(r.Body, maxOfflineEstimateRequestRaw))
+	if err != nil {
+		return offlineEstimateRequest{}, errors.New("read body")
+	}
+
+	var requestPayload offlineEstimateRequest
+	if err := json.Unmarshal(bodyBytes, &requestPayload); err != nil {
+		return offlineEstimateRequest{}, errors.New("invalid json")
+	}
+
+	return requestPayload, nil
+}
+
+func buildOfflineEstimate(requestPayload offlineEstimateRequest) (offlineEstimateResponse, error) {
+	validatedRequest, err := normalizeOfflineEstimateRequest(requestPayload)
+	if err != nil {
+		return offlineEstimateResponse{}, err
+	}
+
+	totalTileCount := int64(0)
+	breakdown := make([]offlineEstimateZoom, 0, validatedRequest.ZoomMax-validatedRequest.ZoomMin+1)
+
+	for zoom := validatedRequest.ZoomMin; zoom <= validatedRequest.ZoomMax; zoom++ {
+		tilesForZoom := estimateTileCountForZoom(validatedRequest.MinLat, validatedRequest.MinLon, validatedRequest.MaxLat, validatedRequest.MaxLon, zoom)
+		totalTileCount += tilesForZoom
+		breakdown = append(breakdown, offlineEstimateZoom{
+			Zoom:      zoom,
+			TileCount: tilesForZoom,
+		})
+	}
+
+	layerCount := countUniqueLayerNames(validatedRequest.BaseLayers, validatedRequest.OverlayLayers)
+	estimatedBytes := totalTileCount * int64(layerCount) * validatedRequest.BytesPerTile
+	estimatedMiB := float64(estimatedBytes) / (1024.0 * 1024.0)
+
+	return offlineEstimateResponse{
+		TileCount:      totalTileCount,
+		LayerCount:     layerCount,
+		EstimatedBytes: estimatedBytes,
+		EstimatedMiB:   math.Round(estimatedMiB*100) / 100,
+		Breakdown:      breakdown,
+	}, nil
+}
+
+func normalizeOfflineEstimateRequest(requestPayload offlineEstimateRequest) (offlineEstimateRequest, error) {
+	requestPayload.MinLat = clampFloat(requestPayload.MinLat, -maxMercatorLatitude, maxMercatorLatitude)
+	requestPayload.MaxLat = clampFloat(requestPayload.MaxLat, -maxMercatorLatitude, maxMercatorLatitude)
+
+	if requestPayload.MinLat > requestPayload.MaxLat {
+		requestPayload.MinLat, requestPayload.MaxLat = requestPayload.MaxLat, requestPayload.MinLat
+	}
+
+	if requestPayload.MinLon < -180 || requestPayload.MinLon > 180 || requestPayload.MaxLon < -180 || requestPayload.MaxLon > 180 {
+		return offlineEstimateRequest{}, errors.New("lon out of range")
+	}
+
+	if requestPayload.ZoomMin < 0 || requestPayload.ZoomMin > 22 {
+		return offlineEstimateRequest{}, errors.New("zoomMin out of range")
+	}
+	if requestPayload.ZoomMax < 0 || requestPayload.ZoomMax > 22 {
+		return offlineEstimateRequest{}, errors.New("zoomMax out of range")
+	}
+	if requestPayload.ZoomMin > requestPayload.ZoomMax {
+		return offlineEstimateRequest{}, errors.New("zoomMin must be <= zoomMax")
+	}
+
+	if requestPayload.BytesPerTile <= 0 {
+		requestPayload.BytesPerTile = defaultOfflineBytesPerTile
+	}
+
+	return requestPayload, nil
+}
+
+func countUniqueLayerNames(baseLayers []string, overlayLayers []string) int {
+	uniqueNames := map[string]struct{}{}
+	for _, rawLayerName := range baseLayers {
+		layerName := strings.TrimSpace(rawLayerName)
+		if layerName == "" {
+			continue
+		}
+		uniqueNames[layerName] = struct{}{}
+	}
+	for _, rawLayerName := range overlayLayers {
+		layerName := strings.TrimSpace(rawLayerName)
+		if layerName == "" {
+			continue
+		}
+		uniqueNames[layerName] = struct{}{}
+	}
+
+	if len(uniqueNames) == 0 {
+		return 1
+	}
+	return len(uniqueNames)
+}
+
+func estimateTileCountForZoom(minLat float64, minLon float64, maxLat float64, maxLon float64, zoom int) int64 {
+	scale := int64(1) << uint(zoom)
+	minY := latToTileY(maxLat, zoom)
+	maxY := latToTileY(minLat, zoom)
+
+	verticalTileCount := int64(maxY - minY + 1)
+	if verticalTileCount <= 0 {
+		return 0
+	}
+
+	minX := lonToTileX(minLon, zoom)
+	maxX := lonToTileX(maxLon, zoom)
+	if minLon <= maxLon {
+		horizontalTileCount := int64(maxX - minX + 1)
+		if horizontalTileCount <= 0 {
+			return 0
+		}
+		return horizontalTileCount * verticalTileCount
+	}
+
+	leftSegmentTileCount := scale - int64(minX)
+	rightSegmentTileCount := int64(maxX + 1)
+	return (leftSegmentTileCount + rightSegmentTileCount) * verticalTileCount
+}
+
+func lonToTileX(lon float64, zoom int) int {
+	scale := float64(int64(1) << uint(zoom))
+	normalized := (lon + 180.0) / 360.0
+	tile := int(math.Floor(normalized * scale))
+	if tile < 0 {
+		return 0
+	}
+	maxTile := (1 << zoom) - 1
+	if tile > maxTile {
+		return maxTile
+	}
+	return tile
+}
+
+func latToTileY(lat float64, zoom int) int {
+	clampedLat := clampFloat(lat, -maxMercatorLatitude, maxMercatorLatitude)
+	latRad := clampedLat * math.Pi / 180.0
+	scale := float64(int64(1) << uint(zoom))
+	projected := (1 - math.Log(math.Tan(latRad)+1/math.Cos(latRad))/math.Pi) / 2
+	tile := int(math.Floor(projected * scale))
+	if tile < 0 {
+		return 0
+	}
+	maxTile := (1 << zoom) - 1
+	if tile > maxTile {
+		return maxTile
+	}
+	return tile
+}

--- a/pkg/api/offline_estimate_test.go
+++ b/pkg/api/offline_estimate_test.go
@@ -1,0 +1,62 @@
+package api
+
+import "testing"
+
+func TestEstimateTileCountForZoom_WorldZoom0(t *testing.T) {
+	gotTileCount := estimateTileCountForZoom(-85, -180, 85, 180, 0)
+	if gotTileCount != 1 {
+		t.Fatalf("expected 1 tile at z0, got %d", gotTileCount)
+	}
+}
+
+func TestEstimateTileCountForZoom_WorldZoom1(t *testing.T) {
+	gotTileCount := estimateTileCountForZoom(-85, -180, 85, 180, 1)
+	if gotTileCount != 4 {
+		t.Fatalf("expected 4 tiles at z1, got %d", gotTileCount)
+	}
+}
+
+func TestEstimateTileCountForZoom_CrossesAntimeridian(t *testing.T) {
+	gotTileCount := estimateTileCountForZoom(-10, 170, 10, -170, 3)
+	if gotTileCount <= 0 {
+		t.Fatalf("expected positive tile count, got %d", gotTileCount)
+	}
+}
+
+func TestBuildOfflineEstimate_DefaultLayerAndBytesFallback(t *testing.T) {
+	requestPayload := offlineEstimateRequest{
+		MinLat:  10,
+		MinLon:  10,
+		MaxLat:  12,
+		MaxLon:  12,
+		ZoomMin: 5,
+		ZoomMax: 5,
+	}
+
+	responsePayload, err := buildOfflineEstimate(requestPayload)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if responsePayload.LayerCount != 1 {
+		t.Fatalf("expected default layer count 1, got %d", responsePayload.LayerCount)
+	}
+	if responsePayload.EstimatedBytes <= 0 {
+		t.Fatalf("expected estimated bytes > 0, got %d", responsePayload.EstimatedBytes)
+	}
+}
+
+func TestNormalizeOfflineEstimateRequest_InvalidZoomRange(t *testing.T) {
+	requestPayload := offlineEstimateRequest{
+		MinLat:  0,
+		MinLon:  0,
+		MaxLat:  1,
+		MaxLon:  1,
+		ZoomMin: 10,
+		ZoomMax: 2,
+	}
+
+	_, err := normalizeOfflineEstimateRequest(requestPayload)
+	if err == nil {
+		t.Fatal("expected error for invalid zoom range")
+	}
+}

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -3819,6 +3819,160 @@ document.addEventListener('DOMContentLoaded', function () {
   setInterval(adjustMarkerRadius, 60 * 1000);
 
   /**
+   * Offline selection control keeps region bounds and zoom range explicit
+   * before the user starts any heavy download workflow.
+   */
+  function createOfflineSelectionControl() {
+    if (isTrackView) return;
+
+    const offlineSelectionModel = {
+      minLat: 0,
+      minLon: 0,
+      maxLat: 0,
+      maxLon: 0,
+      zoomMin: 6,
+      zoomMax: 12,
+      isExpanded: false,
+      isBusy: false,
+      statusText: '',
+    };
+
+    const OfflineSelectionControl = L.Control.extend({
+      onAdd() {
+        const controlNode = L.DomUtil.create('div', 'leaflet-control-layers');
+        controlNode.style.padding = '6px 8px';
+        controlNode.style.minWidth = '220px';
+        controlNode.innerHTML = `
+          <button id="offlineToggleButton" type="button" style="width:100%;">Offline area</button>
+          <div id="offlineSelectionPanel" style="display:none; margin-top:8px;">
+            <div style="display:grid; grid-template-columns:1fr 1fr; gap:4px;">
+              <label style="display:flex; flex-direction:column;">Min lat<input id="offlineMinLatInput" type="number" step="0.000001"></label>
+              <label style="display:flex; flex-direction:column;">Min lon<input id="offlineMinLonInput" type="number" step="0.000001"></label>
+              <label style="display:flex; flex-direction:column;">Max lat<input id="offlineMaxLatInput" type="number" step="0.000001"></label>
+              <label style="display:flex; flex-direction:column;">Max lon<input id="offlineMaxLonInput" type="number" step="0.000001"></label>
+              <label style="display:flex; flex-direction:column;">Zoom min<input id="offlineZoomMinInput" type="number" min="0" max="22" step="1"></label>
+              <label style="display:flex; flex-direction:column;">Zoom max<input id="offlineZoomMaxInput" type="number" min="0" max="22" step="1"></label>
+            </div>
+            <div style="display:flex; gap:6px; margin-top:8px;">
+              <button id="offlineUseViewButton" type="button" style="flex:1;">Use current view</button>
+              <button id="offlineEstimateButton" type="button" style="flex:1;">Estimate</button>
+            </div>
+            <div id="offlineEstimateStatus" style="margin-top:6px; font-size:var(--font-size-sm);"></div>
+          </div>
+        `;
+
+        const toggleButtonNode = controlNode.querySelector('#offlineToggleButton');
+        const panelNode = controlNode.querySelector('#offlineSelectionPanel');
+        const minLatInputNode = controlNode.querySelector('#offlineMinLatInput');
+        const minLonInputNode = controlNode.querySelector('#offlineMinLonInput');
+        const maxLatInputNode = controlNode.querySelector('#offlineMaxLatInput');
+        const maxLonInputNode = controlNode.querySelector('#offlineMaxLonInput');
+        const zoomMinInputNode = controlNode.querySelector('#offlineZoomMinInput');
+        const zoomMaxInputNode = controlNode.querySelector('#offlineZoomMaxInput');
+        const useViewButtonNode = controlNode.querySelector('#offlineUseViewButton');
+        const estimateButtonNode = controlNode.querySelector('#offlineEstimateButton');
+        const statusNode = controlNode.querySelector('#offlineEstimateStatus');
+
+        function formatCoordinateText(coordinateNumber) {
+          return Number(coordinateNumber).toFixed(6);
+        }
+
+        function readModelFromInputs() {
+          offlineSelectionModel.minLat = Number(minLatInputNode.value);
+          offlineSelectionModel.minLon = Number(minLonInputNode.value);
+          offlineSelectionModel.maxLat = Number(maxLatInputNode.value);
+          offlineSelectionModel.maxLon = Number(maxLonInputNode.value);
+          offlineSelectionModel.zoomMin = Number(zoomMinInputNode.value);
+          offlineSelectionModel.zoomMax = Number(zoomMaxInputNode.value);
+        }
+
+        function applyCurrentMapViewToModel() {
+          const mapBounds = map.getBounds();
+          const currentZoomLevel = map.getZoom();
+          offlineSelectionModel.minLat = mapBounds.getSouth();
+          offlineSelectionModel.minLon = mapBounds.getWest();
+          offlineSelectionModel.maxLat = mapBounds.getNorth();
+          offlineSelectionModel.maxLon = mapBounds.getEast();
+          offlineSelectionModel.zoomMin = Math.max(0, currentZoomLevel - 2);
+          offlineSelectionModel.zoomMax = Math.min(22, currentZoomLevel + 2);
+        }
+
+        function renderOfflineSelectionControl() {
+          panelNode.style.display = offlineSelectionModel.isExpanded ? 'block' : 'none';
+          minLatInputNode.value = formatCoordinateText(offlineSelectionModel.minLat);
+          minLonInputNode.value = formatCoordinateText(offlineSelectionModel.minLon);
+          maxLatInputNode.value = formatCoordinateText(offlineSelectionModel.maxLat);
+          maxLonInputNode.value = formatCoordinateText(offlineSelectionModel.maxLon);
+          zoomMinInputNode.value = String(offlineSelectionModel.zoomMin);
+          zoomMaxInputNode.value = String(offlineSelectionModel.zoomMax);
+          toggleButtonNode.textContent = offlineSelectionModel.isExpanded ? 'Hide offline area' : 'Offline area';
+          estimateButtonNode.disabled = offlineSelectionModel.isBusy;
+          useViewButtonNode.disabled = offlineSelectionModel.isBusy;
+          statusNode.textContent = offlineSelectionModel.statusText;
+        }
+
+        async function estimateCurrentSelection() {
+          readModelFromInputs();
+          offlineSelectionModel.isBusy = true;
+          offlineSelectionModel.statusText = 'Estimating…';
+          renderOfflineSelectionControl();
+
+          try {
+            const response = await fetch('/api/offline/estimate', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                minLat: offlineSelectionModel.minLat,
+                minLon: offlineSelectionModel.minLon,
+                maxLat: offlineSelectionModel.maxLat,
+                maxLon: offlineSelectionModel.maxLon,
+                zoomMin: offlineSelectionModel.zoomMin,
+                zoomMax: offlineSelectionModel.zoomMax,
+                baseLayers: [getActiveBaseLayerName()],
+              }),
+            });
+            if (!response.ok) {
+              const errorText = await response.text();
+              throw new Error(errorText || ('HTTP ' + response.status));
+            }
+            const estimatePayload = await response.json();
+            offlineSelectionModel.statusText = 'Tiles: ' + estimatePayload.tileCount + ' • Size: ~' + estimatePayload.estimatedMiB + ' MiB';
+          } catch (requestError) {
+            offlineSelectionModel.statusText = 'Estimate failed: ' + (requestError && requestError.message ? requestError.message : 'unknown error');
+          } finally {
+            offlineSelectionModel.isBusy = false;
+            renderOfflineSelectionControl();
+          }
+        }
+
+        toggleButtonNode.addEventListener('click', function () {
+          offlineSelectionModel.isExpanded = !offlineSelectionModel.isExpanded;
+          renderOfflineSelectionControl();
+        });
+        useViewButtonNode.addEventListener('click', function () {
+          applyCurrentMapViewToModel();
+          offlineSelectionModel.statusText = '';
+          renderOfflineSelectionControl();
+        });
+        estimateButtonNode.addEventListener('click', estimateCurrentSelection);
+        minLatInputNode.addEventListener('change', readModelFromInputs);
+        minLonInputNode.addEventListener('change', readModelFromInputs);
+        maxLatInputNode.addEventListener('change', readModelFromInputs);
+        maxLonInputNode.addEventListener('change', readModelFromInputs);
+        zoomMinInputNode.addEventListener('change', readModelFromInputs);
+        zoomMaxInputNode.addEventListener('change', readModelFromInputs);
+
+        L.DomEvent.disableClickPropagation(controlNode);
+        applyCurrentMapViewToModel();
+        renderOfflineSelectionControl();
+        return controlNode;
+      }
+    });
+
+    new OfflineSelectionControl({ position: 'topleft' }).addTo(map);
+  }
+
+  /**
    * Build a Leaflet control with three check-boxes that filter markers
    * by recorded speed. Labels now show speed in km/h instead of m/s.
    * Default state (when realtime exists): Safecast heart on, ✈️ off, 🚗 on, 🚶 on.
@@ -3936,6 +4090,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
 
   // Call it
+  createOfflineSelectionControl();
   createSpeedFilterControls();   
   createDateRangeSlider();
 


### PR DESCRIPTION
### Motivation
- Provide a deterministic, lightweight estimate for offline map downloads so clients can preview tile counts and storage before starting large downloads. 
- Document a practical offline download/cache architecture and workflow in the `README` to guide frontend and server implementation.

### Description
- Add a new POST endpoint `POST /api/offline/estimate` wired in `Register` that validates input and returns a tile and byte estimate for a bbox and zoom range. 
- Implement `pkg/api/offline_estimate.go` with request normalization, tile-count estimation per zoom (`lonToTileX`, `latToTileY`, `estimateTileCountForZoom`), unique layer counting, and default bytes-per-tile fallback. 
- Update API overview to advertise the new `offlineEstimate` endpoint. 
- Add a comprehensive documentation section "Offline map download roadmap" to `README.md` describing data model, client storage (IndexedDB), server-side mirror, pipeline, eviction, overlays, and an incremental implementation plan. 

### Testing
- Added unit tests in `pkg/api/offline_estimate_test.go` covering world-level counts, antimeridian handling, default layer/bytes fallback, and invalid zoom range. 
- Ran `go test ./pkg/api` and the new tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e73dd7c4d48332a8d0a73336de3f3a)