### PR TITLE
Fix marker outline rendering at all map zoom levels

### DIFF
--- a/public_html/map.html
+++ b/public_html/map.html
@@ -2089,7 +2089,7 @@ function getRadius(doseRate, zoomLevel) {
 }
 
 const MARKER_CONTRAST_RING_COLOR = '#000000';
-const MARKER_CONTRAST_RING_WIDTH = 1;
+const MARKER_CONTRAST_RING_WIDTH = 0.5;
 
 function createDoseMarkerWithContrastOutline(lat, lon, doseRate, speed, zoomLevel) {
   const markerRadius = getRadius(doseRate, zoomLevel);

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -2089,8 +2089,7 @@ function getRadius(doseRate, zoomLevel) {
 }
 
 const MARKER_CONTRAST_RING_COLOR = '#000000';
-const MARKER_CONTRAST_RING_WIDTH = 0.5;
-const MARKER_CONTRAST_MIN_ZOOM = 4;
+const MARKER_CONTRAST_RING_WIDTH = 1;
 
 function createDoseMarkerWithContrastOutline(lat, lon, doseRate, speed, zoomLevel) {
   const markerRadius = getRadius(doseRate, zoomLevel);
@@ -2099,16 +2098,14 @@ function createDoseMarkerWithContrastOutline(lat, lon, doseRate, speed, zoomLeve
   const markerColor = getGradientColor(doseRate);
   const markerLayers = [];
 
-  if (zoomLevel > MARKER_CONTRAST_MIN_ZOOM) {
-    const contrastRing = L.circleMarker([lat, lon], {
-      radius: markerRadius + MARKER_CONTRAST_RING_WIDTH,
-      color: MARKER_CONTRAST_RING_COLOR,
-      weight: MARKER_CONTRAST_RING_WIDTH,
-      opacity: 1,
-      fillOpacity: 0
-    });
-    markerLayers.push(contrastRing);
-  }
+  const contrastRing = L.circleMarker([lat, lon], {
+    radius: markerRadius + MARKER_CONTRAST_RING_WIDTH,
+    color: MARKER_CONTRAST_RING_COLOR,
+    weight: MARKER_CONTRAST_RING_WIDTH,
+    opacity: 1,
+    fillOpacity: 0
+  });
+  markerLayers.push(contrastRing);
 
   const doseMarker = L.circleMarker([lat, lon], {
     radius: markerRadius,


### PR DESCRIPTION
### Motivation
- Marker contrast ring was not visible on some map layers and zooms (notably OSM zoom 17 and some low-detail zoom levels), causing inconsistent marker outlines across maps.
- The goal is to always render a visible black outline for dose markers on all base layers and zoom levels so markers remain legible.

### Description
- Always create the contrast ring for dose markers by removing the previous `MARKER_CONTRAST_MIN_ZOOM` gating so the ring is rendered at every zoom level in `public_html/map.html`.
- Increase the contrast ring stroke width from `0.5` to `1` by changing `MARKER_CONTRAST_RING_WIDTH` to `1` so the outline remains visible at both high and low zooms.
- The change affects the `createDoseMarkerWithContrastOutline` implementation and the constants near `getRadius` in `public_html/map.html`.

### Testing
- Ran `go test ./...` which failed to run in this environment due to a blocked dependency download (`modernc.org/sqlite` from `proxy.golang.org`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e7e7dc90833285d4e5f19e8ac0d3)