### PR TITLE
Add device-agnostic spectrum pipeline, Radiacode XML driver and isotope catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ The project now has a device-agnostic spectrum pipeline in `pkg/spectrum/`:
 - Common `Driver` interface for instrument parsers (`CanParse` + `Parse`).
 - Built-in Radiacode XML driver as the first implementation.
 - Shared `SpectrumMeasurement` model so AtomSpectra and other devices can be plugged in without rewriting isotope analysis.
-- Shared analyzer that detects peaks and maps energies to nuclides from one common catalog.
+- Shared analyzer that detects peaks and maps alpha/beta/gamma energies to nuclides from one common catalog.
+- Composite-spectrum estimator that ranks two- and three-nuclide mixtures when peaks overlap in scintillation detectors.
 
 Catalog scope in the built-in dataset:
 - Cosmogenic and primordial isotopes (`H-3`, `C-14`, `K-40`, etc.).

--- a/README.md
+++ b/README.md
@@ -129,6 +129,29 @@ Ports 80/443 must be open.
 ./chicha-isotope-map -import-tgz-url https://pelora.org/api/json/weekly.tgz
 ```
 
+
+
+## Universal isotope catalog and spectrum drivers
+
+The project now has a device-agnostic spectrum pipeline in `pkg/spectrum/`:
+
+- Common `Driver` interface for instrument parsers (`CanParse` + `Parse`).
+- Built-in Radiacode XML driver as the first implementation.
+- Shared `SpectrumMeasurement` model so AtomSpectra and other devices can be plugged in without rewriting isotope analysis.
+- Shared analyzer that detects peaks and maps energies to nuclides from one common catalog.
+
+Catalog scope in the built-in dataset:
+- Cosmogenic and primordial isotopes (`H-3`, `C-14`, `K-40`, etc.).
+- Full natural decay families used in field dosimetry:
+  - Thorium-232 chain,
+  - Uranium-238 chain,
+  - Uranium-235 (actinium) chain,
+  - Neptunium-237 family.
+- Common environmental/industrial/medical/fallout isotopes (`Cs-137`, `Co-60`, `I-131`, `Am-241`, `Eu-152`, ...).
+- Heavy transuranics up to `Og-294` for completeness of identifier parsing.
+
+This gives one universal parser entrypoint and one extensible isotope catalog, while keeping drivers isolated by format.
+
 ---
 
 ## History and contributors

--- a/chicha-isotope-map.go
+++ b/chicha-isotope-map.go
@@ -61,6 +61,7 @@ import (
 	safecastrealtime "chicha-isotope-map/pkg/safecast-realtime"
 	"chicha-isotope-map/pkg/safecastimport"
 	"chicha-isotope-map/pkg/setupwizard"
+	"chicha-isotope-map/pkg/spectrum"
 )
 
 // content bundles the UI and the license texts so single-file binaries still
@@ -4875,6 +4876,174 @@ type desktopUploadProgressEvent struct {
 	StatusCode int    `json:"statusCode,omitempty"`
 }
 
+// spectrumTrackCandidate keeps linking decisions explicit so XML uploads can
+// attach to the best matching track without hidden global state.
+type spectrumTrackCandidate struct {
+	TrackID         string
+	Bounds          database.Bounds
+	MatchedMarkers  int
+	DeviceNameMatch bool
+}
+
+// uploaderIdentityKey derives a lightweight user key for correlation between
+// uploads. We avoid database-specific auth coupling and keep the heuristic
+// stable across desktop/web by preferring explicit headers, then remote IP.
+func uploaderIdentityKey(r *http.Request) string {
+	if r == nil {
+		return "desktop-native"
+	}
+	for _, headerName := range []string{"X-Upload-User", "X-Forwarded-For", "CF-Connecting-IP"} {
+		value := strings.TrimSpace(r.Header.Get(headerName))
+		if value != "" {
+			return strings.ToLower(value)
+		}
+	}
+	host, _, err := net.SplitHostPort(strings.TrimSpace(r.RemoteAddr))
+	if err == nil && strings.TrimSpace(host) != "" {
+		return strings.ToLower(strings.TrimSpace(host))
+	}
+	return strings.ToLower(strings.TrimSpace(r.RemoteAddr))
+}
+
+func deriveBoundsFromTrack(
+	ctx context.Context,
+	db *database.Database,
+	dbType string,
+	trackID string,
+) (database.Bounds, int, error) {
+	summary, err := db.GetTrackSummary(ctx, trackID, dbType)
+	if err != nil {
+		return database.Bounds{}, 0, err
+	}
+	if summary.MarkerCount == 0 {
+		return database.Bounds{}, 0, nil
+	}
+
+	markersCh, errCh := db.StreamMarkersByTrackRange(ctx, trackID, summary.FirstID, summary.LastID, 0, dbType)
+	bounds := database.Bounds{MinLat: 90, MinLon: 180, MaxLat: -90, MaxLon: -180}
+	matchedCount := 0
+	for marker := range markersCh {
+		matchedCount++
+		if marker.Lat < bounds.MinLat {
+			bounds.MinLat = marker.Lat
+		}
+		if marker.Lat > bounds.MaxLat {
+			bounds.MaxLat = marker.Lat
+		}
+		if marker.Lon < bounds.MinLon {
+			bounds.MinLon = marker.Lon
+		}
+		if marker.Lon > bounds.MaxLon {
+			bounds.MaxLon = marker.Lon
+		}
+	}
+	if streamErr := <-errCh; streamErr != nil {
+		return database.Bounds{}, 0, streamErr
+	}
+	if matchedCount == 0 {
+		return database.Bounds{}, 0, nil
+	}
+	return bounds, matchedCount, nil
+}
+
+func linkSpectrumToTrackByTime(
+	ctx context.Context,
+	db *database.Database,
+	dbType string,
+	analysis spectrum.Analysis,
+) (spectrumTrackCandidate, bool) {
+	if db == nil {
+		return spectrumTrackCandidate{}, false
+	}
+	startUnix := analysis.Measurement.StartTime.Unix() - 900
+	endUnix := analysis.Measurement.EndTime.Unix() + 900
+	tracksCh, errCh := db.StreamTrackSummariesByDateRange(ctx, "", 40, startUnix, endUnix, dbType)
+	bestCandidate := spectrumTrackCandidate{}
+	bestScore := -1
+	deviceNeedle := strings.ToLower(strings.TrimSpace(analysis.Measurement.DeviceName))
+	serialNeedle := strings.ToLower(strings.TrimSpace(analysis.Measurement.DeviceSerial))
+
+	for summary := range tracksCh {
+		trackBounds, markerCount, boundsErr := deriveBoundsFromTrack(ctx, db, dbType, summary.TrackID)
+		if boundsErr != nil || markerCount == 0 {
+			continue
+		}
+
+		trackDeviceName, _ := db.GetTrackDeviceName(ctx, summary.TrackID, dbType)
+		normalizedTrackDevice := strings.ToLower(strings.TrimSpace(trackDeviceName))
+		deviceMatch := false
+		if normalizedTrackDevice != "" && (normalizedTrackDevice == deviceNeedle || strings.Contains(normalizedTrackDevice, serialNeedle) || strings.Contains(serialNeedle, normalizedTrackDevice)) {
+			deviceMatch = true
+		}
+		score := markerCount
+		if deviceMatch {
+			score += 5000
+		}
+
+		if score > bestScore {
+			bestScore = score
+			bestCandidate = spectrumTrackCandidate{
+				TrackID:         summary.TrackID,
+				Bounds:          trackBounds,
+				MatchedMarkers:  markerCount,
+				DeviceNameMatch: deviceMatch,
+			}
+		}
+	}
+	if streamErr := <-errCh; streamErr != nil {
+		log.Printf("spectrum link track scan failed: %v", streamErr)
+		return spectrumTrackCandidate{}, false
+	}
+	if bestScore < 0 {
+		return spectrumTrackCandidate{}, false
+	}
+	return bestCandidate, true
+}
+
+func processSpectrumXMLUpload(
+	ctx context.Context,
+	reader io.Reader,
+	db *database.Database,
+	dbType string,
+	currentTrackID string,
+	currentBounds database.Bounds,
+	currentHasBounds bool,
+) (database.Bounds, string, bool, map[string]any, error) {
+	raw, err := io.ReadAll(reader)
+	if err != nil {
+		return database.Bounds{}, currentTrackID, currentHasBounds, nil, fmt.Errorf("read spectrum xml: %w", err)
+	}
+	analysis, err := spectrum.AnalyzeWithKnownDrivers(raw)
+	if err != nil {
+		return database.Bounds{}, currentTrackID, currentHasBounds, nil, fmt.Errorf("parse spectrum xml: %w", err)
+	}
+
+	detail := map[string]any{
+		"spectrum_format": analysis.Measurement.Format,
+		"device_name":     analysis.Measurement.DeviceName,
+		"device_serial":   analysis.Measurement.DeviceSerial,
+		"isotope_hits":    len(analysis.Isotopes),
+		"composites":      len(analysis.CompositeModels),
+	}
+
+	if currentTrackID != "" && currentHasBounds {
+		detail["linked_track_id"] = currentTrackID
+		detail["link_reason"] = "same-upload-batch"
+		return currentBounds, currentTrackID, true, detail, nil
+	}
+
+	candidate, ok := linkSpectrumToTrackByTime(ctx, db, dbType, analysis)
+	if !ok {
+		detail["link_reason"] = "no-track-candidate"
+		return currentBounds, currentTrackID, currentHasBounds, detail, nil
+	}
+	detail["linked_track_id"] = candidate.TrackID
+	detail["matched_markers"] = candidate.MatchedMarkers
+	detail["device_match"] = candidate.DeviceNameMatch
+	detail["link_reason"] = "time-and-device-heuristic"
+	return candidate.Bounds, candidate.TrackID, true, detail, nil
+}
+
 // uploadLocalFiles processes files selected by a desktop-native picker.
 // It mirrors uploadHandler logic so macOS desktop builds can import files even
 // when the embedded WebView blocks <input type="file">.
@@ -4939,6 +5108,13 @@ func uploadLocalFiles(ctx context.Context, filePaths []string, emitProgress func
 			bbox, trackID, err = processAtomSwiftCSVFile(openedFile, trackID, db, *dbType)
 		case ".rctrk":
 			bbox, trackID, err = processRCTRKFile(openedFile, trackID, db, *dbType)
+		case ".xml":
+			var linked bool
+			linkedDetails := map[string]any{}
+			bbox, trackID, linked, linkedDetails, err = processSpectrumXMLUpload(ctx, openedFile, db, *dbType, trackID, global, hasBounds)
+			if err == nil {
+				logT(trackID, "Upload", "desktop spectrum linked=%t details=%v", linked, linkedDetails)
+			}
 		case ".cim":
 			var imported bool
 			bbox, trackID, imported, err = processTrackExportFile(ctx, openedFile, trackID, db, *dbType)
@@ -5443,6 +5619,14 @@ func uploadHandler(w http.ResponseWriter, r *http.Request) {
 			bbox, trackID, err = processAtomSwiftCSVFile(f, trackID, db, *dbType)
 		case ".rctrk":
 			bbox, trackID, err = processRCTRKFile(f, trackID, db, *dbType)
+		case ".xml":
+			var linked bool
+			linkedDetails := map[string]any{}
+			bbox, trackID, linked, linkedDetails, err = processSpectrumXMLUpload(r.Context(), f, db, *dbType, trackID, global, hasBounds)
+			if err == nil {
+				linkedDetails["uploader_key"] = uploaderIdentityKey(r)
+				logT(trackID, "Upload", "spectrum linked=%t details=%v", linked, linkedDetails)
+			}
 		case ".cim":
 			var imported bool
 			bbox, trackID, imported, err = processTrackExportFile(r.Context(), f, trackID, db, *dbType)

--- a/chicha-isotope-map.go
+++ b/chicha-isotope-map.go
@@ -5184,6 +5184,8 @@ func processSpectrumXMLUpload(
 		"qualitative":     spectrumQualitativeSummary(analysis),
 		"components":      analysis.Components,
 		"component_text":  spectrumComponentSummary(analysis),
+		"group_checks":    analysis.GroupChecks,
+		"explanation":     analysis.Explanation,
 	}
 
 	if currentTrackID != "" && currentHasBounds {

--- a/chicha-isotope-map.go
+++ b/chicha-isotope-map.go
@@ -4938,6 +4938,24 @@ func spectrumQualitativeSummary(analysis spectrum.Analysis) string {
 	return "qualitative composition: " + strings.Join(parts, ", ")
 }
 
+func spectrumComponentSummary(analysis spectrum.Analysis) string {
+	if len(analysis.Components) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(analysis.Components))
+	for _, component := range analysis.Components {
+		percent := int(math.Round(component.Contribution * 100))
+		if percent <= 0 {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s (%d%%)", component.DisplayName, percent))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, ", ")
+}
+
 // uploaderIdentityKey derives a lightweight user key for correlation between
 // uploads. We avoid database-specific auth coupling and keep the heuristic
 // stable across desktop/web by preferring explicit headers, then remote IP.
@@ -5164,6 +5182,8 @@ func processSpectrumXMLUpload(
 		"isotope_hits":    len(analysis.Isotopes),
 		"composites":      len(analysis.CompositeModels),
 		"qualitative":     spectrumQualitativeSummary(analysis),
+		"components":      analysis.Components,
+		"component_text":  spectrumComponentSummary(analysis),
 	}
 
 	if currentTrackID != "" && currentHasBounds {

--- a/chicha-isotope-map.go
+++ b/chicha-isotope-map.go
@@ -5060,14 +5060,24 @@ func processSpectrumXMLUpload(
 	candidate, ok := linkSpectrumToTrackByTime(ctx, db, dbType, analysis)
 	if !ok {
 		detail["link_reason"] = "no-track-candidate"
+		detail["start_unix"] = analysis.Measurement.StartTime.Unix()
+		detail["end_unix"] = analysis.Measurement.EndTime.Unix()
 		return currentBounds, currentTrackID, currentHasBounds, detail, nil
 	}
 	detail["linked_track_id"] = candidate.TrackID
 	detail["matched_markers"] = candidate.MatchedMarkers
 	detail["device_match"] = candidate.DeviceNameMatch
-	detail["link_reason"] = "time-and-device-heuristic"
-	_ = db.AnnotateTrackRadiationWindow(ctx, candidate.TrackID, analysis.Measurement.StartTime.Unix()-60, analysis.Measurement.EndTime.Unix()+60, spectrumQualitativeSummary(analysis), dbType)
-	return candidate.Bounds, candidate.TrackID, true, detail, nil
+	detail["link_reason"] = "candidate-required-confirmation"
+	detail["start_unix"] = analysis.Measurement.StartTime.Unix()
+	detail["end_unix"] = analysis.Measurement.EndTime.Unix()
+	detail["candidate_tracks"] = []map[string]any{
+		{
+			"trackID":       candidate.TrackID,
+			"matchedPoints": candidate.MatchedMarkers,
+			"deviceMatch":   candidate.DeviceNameMatch,
+		},
+	}
+	return currentBounds, currentTrackID, currentHasBounds, detail, nil
 }
 
 // uploadLocalFiles processes files selected by a desktop-native picker.
@@ -5090,6 +5100,7 @@ func uploadLocalFiles(ctx context.Context, filePaths []string, emitProgress func
 	fileTypes := map[string]int{}
 	spectrumNeedsManualPoint := false
 	spectrumManualSummary := ""
+	spectrumContext := map[string]any{}
 
 	for fileIndex, currentPath := range filePaths {
 		filename := filepath.Base(currentPath)
@@ -5144,6 +5155,7 @@ func uploadLocalFiles(ctx context.Context, filePaths []string, emitProgress func
 				logT(trackID, "Upload", "desktop spectrum linked=%t details=%v", linked, linkedDetails)
 				if !linked {
 					spectrumNeedsManualPoint = true
+					spectrumContext = linkedDetails
 					if text, ok := linkedDetails["qualitative"].(string); ok {
 						spectrumManualSummary = text
 					}
@@ -5291,6 +5303,7 @@ func uploadLocalFiles(ctx context.Context, filePaths []string, emitProgress func
 		"hasMapBounds":             hasBounds,
 		"spectrumNeedsManualPoint": spectrumNeedsManualPoint,
 		"spectrumQualitative":      spectrumManualSummary,
+		"spectrumContext":          spectrumContext,
 	}, http.StatusOK, nil
 }
 
@@ -5627,6 +5640,7 @@ func uploadHandler(w http.ResponseWriter, r *http.Request) {
 	fileTypes := map[string]int{}
 	spectrumNeedsManualPoint := false
 	spectrumManualSummary := ""
+	spectrumContext := map[string]any{}
 
 	for _, fh := range files {
 		logT(trackID, "Upload", "file received: %s", fh.Filename)
@@ -5666,6 +5680,7 @@ func uploadHandler(w http.ResponseWriter, r *http.Request) {
 				logT(trackID, "Upload", "spectrum linked=%t details=%v", linked, linkedDetails)
 				if !linked {
 					spectrumNeedsManualPoint = true
+					spectrumContext = linkedDetails
 					if text, ok := linkedDetails["qualitative"].(string); ok {
 						spectrumManualSummary = text
 					}
@@ -5798,6 +5813,7 @@ func uploadHandler(w http.ResponseWriter, r *http.Request) {
 		"background_import": backgroundImport,
 		"status":            status,
 		"spectrum_manual":   spectrumNeedsManualPoint,
+		"spectrum_context":  spectrumContext,
 	}
 	if deviceSummary.Detector != "" {
 		detail["detector"] = deviceSummary.Detector
@@ -5824,6 +5840,7 @@ func uploadHandler(w http.ResponseWriter, r *http.Request) {
 		"trackURL":                 trackURL,
 		"spectrumNeedsManualPoint": spectrumNeedsManualPoint,
 		"spectrumQualitative":      spectrumManualSummary,
+		"spectrumContext":          spectrumContext,
 	}); err != nil {
 		if isClientDisconnect(err) {
 			log.Printf("client disconnected while writing upload response")
@@ -5874,6 +5891,67 @@ func manualSpectrumPointHandler(w http.ResponseWriter, r *http.Request) {
 	trackURL := fmt.Sprintf("/trackid/%s?minLat=%f&minLon=%f&maxLat=%f&maxLon=%f&zoom=14&layer=%s", finalTrackID, bbox.MinLat, bbox.MinLon, bbox.MaxLat, bbox.MaxLon, "OpenStreetMap")
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{"status": "success", "trackURL": trackURL})
+}
+
+func attachSpectrumToTrackHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var payload struct {
+		TrackID     string `json:"trackID"`
+		Qualitative string `json:"qualitative"`
+		StartUnix   int64  `json:"startUnix"`
+		EndUnix     int64  `json:"endUnix"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+	if strings.TrimSpace(payload.TrackID) == "" {
+		http.Error(w, "track id required", http.StatusBadRequest)
+		return
+	}
+	if err := db.AnnotateTrackRadiationWindow(r.Context(), payload.TrackID, payload.StartUnix-60, payload.EndUnix+60, payload.Qualitative, *dbType); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	bounds, _, err := deriveBoundsFromTrack(r.Context(), db, *dbType, payload.TrackID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	trackURL := fmt.Sprintf("/trackid/%s?minLat=%f&minLon=%f&maxLat=%f&maxLon=%f&zoom=14&layer=%s", payload.TrackID, bounds.MinLat, bounds.MinLon, bounds.MaxLat, bounds.MaxLon, "OpenStreetMap")
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"status": "success", "trackURL": trackURL})
+}
+
+func attachSpectrumToAreaHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var payload struct {
+		MinLat      float64 `json:"minLat"`
+		MinLon      float64 `json:"minLon"`
+		MaxLat      float64 `json:"maxLat"`
+		MaxLon      float64 `json:"maxLon"`
+		Qualitative string  `json:"qualitative"`
+		StartUnix   int64   `json:"startUnix"`
+		EndUnix     int64   `json:"endUnix"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+	if err := db.AnnotateAreaRadiationWindow(r.Context(), payload.StartUnix-60, payload.EndUnix+60, payload.MinLat, payload.MinLon, payload.MaxLat, payload.MaxLon, payload.Qualitative, *dbType); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"status": "success"})
 }
 
 // =====================
@@ -8016,6 +8094,8 @@ func main() {
 	http.HandleFunc("/upload", uploadHandler)
 	http.HandleFunc("/desktop/upload-native", desktopNativeUploadHandler)
 	http.HandleFunc("/api/spectrum/manual-point", manualSpectrumPointHandler)
+	http.HandleFunc("/api/spectrum/attach-track", attachSpectrumToTrackHandler)
+	http.HandleFunc("/api/spectrum/attach-area", attachSpectrumToAreaHandler)
 	http.HandleFunc("/desktop/download-track/", desktopTrackDownloadHandler)
 	http.HandleFunc("/desktop/admin/bootstrap-import", desktopAdminBootstrapImportHandler)
 	http.HandleFunc("/desktop/admin/settings", desktopAdminSettingsHandler)

--- a/chicha-isotope-map.go
+++ b/chicha-isotope-map.go
@@ -4885,6 +4885,29 @@ type spectrumTrackCandidate struct {
 	DeviceNameMatch bool
 }
 
+func spectrumQualitativeSummary(analysis spectrum.Analysis) string {
+	seen := make(map[string]struct{})
+	names := make([]string, 0, 6)
+	for _, hit := range analysis.Isotopes {
+		name := strings.TrimSpace(hit.NuclideID)
+		if name == "" {
+			continue
+		}
+		if _, exists := seen[name]; exists {
+			continue
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+		if len(names) >= 6 {
+			break
+		}
+	}
+	if len(names) == 0 {
+		return "qualitative composition: isotopes detected"
+	}
+	return "qualitative composition: " + strings.Join(names, ", ")
+}
+
 // uploaderIdentityKey derives a lightweight user key for correlation between
 // uploads. We avoid database-specific auth coupling and keep the heuristic
 // stable across desktop/web by preferring explicit headers, then remote IP.
@@ -5024,9 +5047,11 @@ func processSpectrumXMLUpload(
 		"device_serial":   analysis.Measurement.DeviceSerial,
 		"isotope_hits":    len(analysis.Isotopes),
 		"composites":      len(analysis.CompositeModels),
+		"qualitative":     spectrumQualitativeSummary(analysis),
 	}
 
 	if currentTrackID != "" && currentHasBounds {
+		_ = db.AnnotateTrackRadiationWindow(ctx, currentTrackID, analysis.Measurement.StartTime.Unix()-60, analysis.Measurement.EndTime.Unix()+60, spectrumQualitativeSummary(analysis), dbType)
 		detail["linked_track_id"] = currentTrackID
 		detail["link_reason"] = "same-upload-batch"
 		return currentBounds, currentTrackID, true, detail, nil
@@ -5041,6 +5066,7 @@ func processSpectrumXMLUpload(
 	detail["matched_markers"] = candidate.MatchedMarkers
 	detail["device_match"] = candidate.DeviceNameMatch
 	detail["link_reason"] = "time-and-device-heuristic"
+	_ = db.AnnotateTrackRadiationWindow(ctx, candidate.TrackID, analysis.Measurement.StartTime.Unix()-60, analysis.Measurement.EndTime.Unix()+60, spectrumQualitativeSummary(analysis), dbType)
 	return candidate.Bounds, candidate.TrackID, true, detail, nil
 }
 
@@ -5062,6 +5088,8 @@ func uploadLocalFiles(ctx context.Context, filePaths []string, emitProgress func
 	hasBounds := false
 	backgroundImport := false
 	fileTypes := map[string]int{}
+	spectrumNeedsManualPoint := false
+	spectrumManualSummary := ""
 
 	for fileIndex, currentPath := range filePaths {
 		filename := filepath.Base(currentPath)
@@ -5114,6 +5142,12 @@ func uploadLocalFiles(ctx context.Context, filePaths []string, emitProgress func
 			bbox, trackID, linked, linkedDetails, err = processSpectrumXMLUpload(ctx, openedFile, db, *dbType, trackID, global, hasBounds)
 			if err == nil {
 				logT(trackID, "Upload", "desktop spectrum linked=%t details=%v", linked, linkedDetails)
+				if !linked {
+					spectrumNeedsManualPoint = true
+					if text, ok := linkedDetails["qualitative"].(string); ok {
+						spectrumManualSummary = text
+					}
+				}
 			}
 		case ".cim":
 			var imported bool
@@ -5250,11 +5284,13 @@ func uploadLocalFiles(ctx context.Context, filePaths []string, emitProgress func
 		)
 	}
 	return map[string]interface{}{
-		"status":       "success",
-		"trackID":      trackID,
-		"trackURL":     trackURL,
-		"mapBounds":    global,
-		"hasMapBounds": hasBounds,
+		"status":                   "success",
+		"trackID":                  trackID,
+		"trackURL":                 trackURL,
+		"mapBounds":                global,
+		"hasMapBounds":             hasBounds,
+		"spectrumNeedsManualPoint": spectrumNeedsManualPoint,
+		"spectrumQualitative":      spectrumManualSummary,
 	}, http.StatusOK, nil
 }
 
@@ -5589,6 +5625,8 @@ func uploadHandler(w http.ResponseWriter, r *http.Request) {
 	hasBounds := false
 	backgroundImport := false
 	fileTypes := map[string]int{}
+	spectrumNeedsManualPoint := false
+	spectrumManualSummary := ""
 
 	for _, fh := range files {
 		logT(trackID, "Upload", "file received: %s", fh.Filename)
@@ -5626,6 +5664,12 @@ func uploadHandler(w http.ResponseWriter, r *http.Request) {
 			if err == nil {
 				linkedDetails["uploader_key"] = uploaderIdentityKey(r)
 				logT(trackID, "Upload", "spectrum linked=%t details=%v", linked, linkedDetails)
+				if !linked {
+					spectrumNeedsManualPoint = true
+					if text, ok := linkedDetails["qualitative"].(string); ok {
+						spectrumManualSummary = text
+					}
+				}
 			}
 		case ".cim":
 			var imported bool
@@ -5753,6 +5797,7 @@ func uploadHandler(w http.ResponseWriter, r *http.Request) {
 		"file_types":        fileTypes,
 		"background_import": backgroundImport,
 		"status":            status,
+		"spectrum_manual":   spectrumNeedsManualPoint,
 	}
 	if deviceSummary.Detector != "" {
 		detail["detector"] = deviceSummary.Detector
@@ -5775,8 +5820,10 @@ func uploadHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(map[string]any{
-		"status":   status,
-		"trackURL": trackURL,
+		"status":                   status,
+		"trackURL":                 trackURL,
+		"spectrumNeedsManualPoint": spectrumNeedsManualPoint,
+		"spectrumQualitative":      spectrumManualSummary,
 	}); err != nil {
 		if isClientDisconnect(err) {
 			log.Printf("client disconnected while writing upload response")
@@ -5784,6 +5831,49 @@ func uploadHandler(w http.ResponseWriter, r *http.Request) {
 			log.Printf("upload response write error: %v", err)
 		}
 	}
+}
+
+func manualSpectrumPointHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var payload struct {
+		Lat         float64 `json:"lat"`
+		Lon         float64 `json:"lon"`
+		Qualitative string  `json:"qualitative"`
+		DeviceName  string  `json:"deviceName"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+	if math.IsNaN(payload.Lat) || math.IsNaN(payload.Lon) || payload.Lat < -90 || payload.Lat > 90 || payload.Lon < -180 || payload.Lon > 180 {
+		http.Error(w, "invalid coordinates", http.StatusBadRequest)
+		return
+	}
+	trackID := "spectrum-manual-" + GenerateSerialNumber()
+	markers := []database.Marker{
+		{
+			Date:      time.Now().Unix(),
+			Lat:       payload.Lat,
+			Lon:       payload.Lon,
+			DoseRate:  0.01,
+			CountRate: 0.01,
+			TrackID:   trackID,
+			Detector:  strings.TrimSpace(payload.DeviceName),
+			Radiation: strings.TrimSpace(payload.Qualitative),
+		},
+	}
+	bbox, finalTrackID, err := processAndStoreMarkers(markers, trackID, db, *dbType)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	trackURL := fmt.Sprintf("/trackid/%s?minLat=%f&minLon=%f&maxLat=%f&maxLon=%f&zoom=14&layer=%s", finalTrackID, bbox.MinLat, bbox.MinLon, bbox.MaxLat, bbox.MaxLon, "OpenStreetMap")
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"status": "success", "trackURL": trackURL})
 }
 
 // =====================
@@ -7925,6 +8015,7 @@ func main() {
 	http.HandleFunc("/licenses/", licenseHandler)
 	http.HandleFunc("/upload", uploadHandler)
 	http.HandleFunc("/desktop/upload-native", desktopNativeUploadHandler)
+	http.HandleFunc("/api/spectrum/manual-point", manualSpectrumPointHandler)
 	http.HandleFunc("/desktop/download-track/", desktopTrackDownloadHandler)
 	http.HandleFunc("/desktop/admin/bootstrap-import", desktopAdminBootstrapImportHandler)
 	http.HandleFunc("/desktop/admin/settings", desktopAdminSettingsHandler)

--- a/chicha-isotope-map.go
+++ b/chicha-isotope-map.go
@@ -5287,7 +5287,7 @@ func uploadLocalFiles(ctx context.Context, filePaths []string, emitProgress func
 		}, http.StatusOK, nil
 	}
 
-	trackURL := fmt.Sprintf("/trackid/%s", trackID)
+	trackURL := "/"
 	if hasBounds {
 		trackURL = fmt.Sprintf(
 			"/trackid/%s?minLat=%f&minLon=%f&maxLat=%f&maxLon=%f&zoom=14&layer=%s",

--- a/chicha-isotope-map.go
+++ b/chicha-isotope-map.go
@@ -4865,15 +4865,18 @@ func formatFileTypeSummary(fileTypes map[string]int) string {
 }
 
 type desktopUploadProgressEvent struct {
-	Type       string `json:"type"`
-	FileName   string `json:"fileName,omitempty"`
-	Index      int    `json:"index,omitempty"`
-	Total      int    `json:"total,omitempty"`
-	Percent    int    `json:"percent,omitempty"`
-	Status     string `json:"status,omitempty"`
-	Message    string `json:"message,omitempty"`
-	TrackURL   string `json:"trackURL,omitempty"`
-	StatusCode int    `json:"statusCode,omitempty"`
+	Type                     string         `json:"type"`
+	FileName                 string         `json:"fileName,omitempty"`
+	Index                    int            `json:"index,omitempty"`
+	Total                    int            `json:"total,omitempty"`
+	Percent                  int            `json:"percent,omitempty"`
+	Status                   string         `json:"status,omitempty"`
+	Message                  string         `json:"message,omitempty"`
+	TrackURL                 string         `json:"trackURL,omitempty"`
+	StatusCode               int            `json:"statusCode,omitempty"`
+	SpectrumNeedsManualPoint bool           `json:"spectrumNeedsManualPoint,omitempty"`
+	SpectrumQualitative      string         `json:"spectrumQualitative,omitempty"`
+	SpectrumContext          map[string]any `json:"spectrumContext,omitempty"`
 }
 
 // spectrumTrackCandidate keeps linking decisions explicit so XML uploads can
@@ -5295,6 +5298,10 @@ func uploadLocalFiles(ctx context.Context, filePaths []string, emitProgress func
 			"OpenStreetMap",
 		)
 	}
+	if spectrumNeedsManualPoint {
+		// Force modal-first UX for spectrum uploads that require an explicit user decision.
+		trackURL = "/"
+	}
 	return map[string]interface{}{
 		"status":                   "success",
 		"trackID":                  trackID,
@@ -5354,12 +5361,19 @@ func desktopNativeUploadHandler(w http.ResponseWriter, r *http.Request) {
 
 	payloadStatus, _ := response["status"].(string)
 	trackURL, _ := response["trackURL"].(string)
+	spectrumNeedsManualPoint, _ := response["spectrumNeedsManualPoint"].(bool)
+	spectrumQualitative, _ := response["spectrumQualitative"].(string)
+	spectrumContext, _ := response["spectrumContext"].(map[string]any)
 	writeEvent(desktopUploadProgressEvent{
-		Type:     "result",
-		Status:   payloadStatus,
-		TrackURL: trackURL,
-		Message:  "desktop upload completed",
-		Percent:  100,
+		Type:                     "result",
+		Status:                   payloadStatus,
+		TrackURL:                 trackURL,
+		Message:                  "desktop upload completed",
+		Percent:                  100,
+		StatusCode:               status,
+		SpectrumNeedsManualPoint: spectrumNeedsManualPoint,
+		SpectrumQualitative:      spectrumQualitative,
+		SpectrumContext:          spectrumContext,
 	})
 }
 
@@ -5787,6 +5801,10 @@ func uploadHandler(w http.ResponseWriter, r *http.Request) {
 			"/trackid/%s?minLat=%f&minLon=%f&maxLat=%f&maxLon=%f&zoom=14&layer=%s",
 			trackID, global.MinLat, global.MinLon, global.MaxLat, global.MaxLon,
 			"OpenStreetMap")
+	}
+	if spectrumNeedsManualPoint {
+		// Force modal-first UX for spectrum uploads that require an explicit user decision.
+		trackURL = "/"
 	}
 
 	status := "success"

--- a/chicha-isotope-map.go
+++ b/chicha-isotope-map.go
@@ -4886,29 +4886,56 @@ type spectrumTrackCandidate struct {
 	Bounds          database.Bounds
 	MatchedMarkers  int
 	DeviceNameMatch bool
+	TrackStartUnix  int64
+	TrackEndUnix    int64
+	OverlapSec      int64
+	CenterDeltaSec  int64
+	Score           int64
 }
 
 func spectrumQualitativeSummary(analysis spectrum.Analysis) string {
-	seen := make(map[string]struct{})
-	names := make([]string, 0, 6)
+	scoreByNuclide := make(map[string]float64)
 	for _, hit := range analysis.Isotopes {
-		name := strings.TrimSpace(hit.NuclideID)
-		if name == "" {
+		nuclideID := strings.TrimSpace(hit.NuclideID)
+		if nuclideID == "" {
 			continue
 		}
-		if _, exists := seen[name]; exists {
-			continue
-		}
-		seen[name] = struct{}{}
-		names = append(names, name)
-		if len(names) >= 6 {
-			break
-		}
+		scoreByNuclide[nuclideID] += hit.Confidence
 	}
-	if len(names) == 0 {
+	if len(scoreByNuclide) == 0 {
 		return "qualitative composition: isotopes detected"
 	}
-	return "qualitative composition: " + strings.Join(names, ", ")
+
+	type nuclideShare struct {
+		NuclideID string
+		Score     float64
+	}
+	shares := make([]nuclideShare, 0, len(scoreByNuclide))
+	totalScore := 0.0
+	for nuclideID, score := range scoreByNuclide {
+		totalScore += score
+		shares = append(shares, nuclideShare{NuclideID: nuclideID, Score: score})
+	}
+	sort.Slice(shares, func(i, j int) bool {
+		if shares[i].Score == shares[j].Score {
+			return shares[i].NuclideID < shares[j].NuclideID
+		}
+		return shares[i].Score > shares[j].Score
+	})
+
+	if totalScore <= 0 {
+		return "qualitative composition: isotopes detected"
+	}
+
+	parts := make([]string, 0, 6)
+	for index, share := range shares {
+		if index >= 6 {
+			break
+		}
+		percent := int(math.Round((share.Score / totalScore) * 100))
+		parts = append(parts, fmt.Sprintf("%s (%d%%)", share.NuclideID, percent))
+	}
+	return "qualitative composition: " + strings.Join(parts, ", ")
 }
 
 // uploaderIdentityKey derives a lightweight user key for correlation between
@@ -4972,25 +4999,77 @@ func deriveBoundsFromTrack(
 	return bounds, matchedCount, nil
 }
 
+func deriveTrackMatchDetails(
+	ctx context.Context,
+	db *database.Database,
+	dbType string,
+	trackID string,
+) (database.Bounds, int, int64, int64, error) {
+	summary, err := db.GetTrackSummary(ctx, trackID, dbType)
+	if err != nil {
+		return database.Bounds{}, 0, 0, 0, err
+	}
+	if summary.MarkerCount == 0 {
+		return database.Bounds{}, 0, 0, 0, nil
+	}
+
+	markersCh, errCh := db.StreamMarkersByTrackRange(ctx, trackID, summary.FirstID, summary.LastID, 0, dbType)
+	bounds := database.Bounds{MinLat: 90, MinLon: 180, MaxLat: -90, MaxLon: -180}
+	matchedCount := 0
+	trackStartUnix := int64(0)
+	trackEndUnix := int64(0)
+
+	for marker := range markersCh {
+		matchedCount++
+		if marker.Lat < bounds.MinLat {
+			bounds.MinLat = marker.Lat
+		}
+		if marker.Lat > bounds.MaxLat {
+			bounds.MaxLat = marker.Lat
+		}
+		if marker.Lon < bounds.MinLon {
+			bounds.MinLon = marker.Lon
+		}
+		if marker.Lon > bounds.MaxLon {
+			bounds.MaxLon = marker.Lon
+		}
+		if trackStartUnix == 0 || marker.Date < trackStartUnix {
+			trackStartUnix = marker.Date
+		}
+		if trackEndUnix == 0 || marker.Date > trackEndUnix {
+			trackEndUnix = marker.Date
+		}
+	}
+	if streamErr := <-errCh; streamErr != nil {
+		return database.Bounds{}, 0, 0, 0, streamErr
+	}
+	if matchedCount == 0 {
+		return database.Bounds{}, 0, 0, 0, nil
+	}
+	return bounds, matchedCount, trackStartUnix, trackEndUnix, nil
+}
+
 func linkSpectrumToTrackByTime(
 	ctx context.Context,
 	db *database.Database,
 	dbType string,
 	analysis spectrum.Analysis,
-) (spectrumTrackCandidate, bool) {
+) ([]spectrumTrackCandidate, bool) {
 	if db == nil {
-		return spectrumTrackCandidate{}, false
+		return nil, false
 	}
-	startUnix := analysis.Measurement.StartTime.Unix() - 900
-	endUnix := analysis.Measurement.EndTime.Unix() + 900
+	measurementStartUnix := analysis.Measurement.StartTime.Unix()
+	measurementEndUnix := analysis.Measurement.EndTime.Unix()
+	startUnix := measurementStartUnix - 7200
+	endUnix := measurementEndUnix + 7200
 	tracksCh, errCh := db.StreamTrackSummariesByDateRange(ctx, "", 40, startUnix, endUnix, dbType)
-	bestCandidate := spectrumTrackCandidate{}
-	bestScore := -1
+	candidates := make([]spectrumTrackCandidate, 0, 5)
 	deviceNeedle := strings.ToLower(strings.TrimSpace(analysis.Measurement.DeviceName))
 	serialNeedle := strings.ToLower(strings.TrimSpace(analysis.Measurement.DeviceSerial))
+	measurementCenterUnix := measurementStartUnix + (measurementEndUnix-measurementStartUnix)/2
 
 	for summary := range tracksCh {
-		trackBounds, markerCount, boundsErr := deriveBoundsFromTrack(ctx, db, dbType, summary.TrackID)
+		trackBounds, markerCount, trackStartUnix, trackEndUnix, boundsErr := deriveTrackMatchDetails(ctx, db, dbType, summary.TrackID)
 		if boundsErr != nil || markerCount == 0 {
 			continue
 		}
@@ -5001,29 +5080,63 @@ func linkSpectrumToTrackByTime(
 		if normalizedTrackDevice != "" && (normalizedTrackDevice == deviceNeedle || strings.Contains(normalizedTrackDevice, serialNeedle) || strings.Contains(serialNeedle, normalizedTrackDevice)) {
 			deviceMatch = true
 		}
-		score := markerCount
-		if deviceMatch {
-			score += 5000
+
+		overlapStart := measurementStartUnix
+		if trackStartUnix > overlapStart {
+			overlapStart = trackStartUnix
+		}
+		overlapEnd := measurementEndUnix
+		if trackEndUnix < overlapEnd {
+			overlapEnd = trackEndUnix
+		}
+		overlapSec := overlapEnd - overlapStart
+		if overlapSec < 0 {
+			overlapSec = 0
 		}
 
-		if score > bestScore {
-			bestScore = score
-			bestCandidate = spectrumTrackCandidate{
-				TrackID:         summary.TrackID,
-				Bounds:          trackBounds,
-				MatchedMarkers:  markerCount,
-				DeviceNameMatch: deviceMatch,
-			}
+		trackCenterUnix := trackStartUnix + (trackEndUnix-trackStartUnix)/2
+		centerDeltaSec := trackCenterUnix - measurementCenterUnix
+		if centerDeltaSec < 0 {
+			centerDeltaSec = -centerDeltaSec
 		}
+
+		score := overlapSec*20 + int64(markerCount)
+		if deviceMatch {
+			score += 120000
+		}
+		score -= centerDeltaSec / 3
+
+		candidate := spectrumTrackCandidate{
+			TrackID:         summary.TrackID,
+			Bounds:          trackBounds,
+			MatchedMarkers:  markerCount,
+			DeviceNameMatch: deviceMatch,
+			TrackStartUnix:  trackStartUnix,
+			TrackEndUnix:    trackEndUnix,
+			OverlapSec:      overlapSec,
+			CenterDeltaSec:  centerDeltaSec,
+			Score:           score,
+		}
+		candidates = append(candidates, candidate)
 	}
+
 	if streamErr := <-errCh; streamErr != nil {
 		log.Printf("spectrum link track scan failed: %v", streamErr)
-		return spectrumTrackCandidate{}, false
+		return nil, false
 	}
-	if bestScore < 0 {
-		return spectrumTrackCandidate{}, false
+	if len(candidates) == 0 {
+		return nil, false
 	}
-	return bestCandidate, true
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].Score == candidates[j].Score {
+			return candidates[i].TrackID < candidates[j].TrackID
+		}
+		return candidates[i].Score > candidates[j].Score
+	})
+	if len(candidates) > 5 {
+		candidates = candidates[:5]
+	}
+	return candidates, true
 }
 
 func processSpectrumXMLUpload(
@@ -5060,26 +5173,51 @@ func processSpectrumXMLUpload(
 		return currentBounds, currentTrackID, true, detail, nil
 	}
 
-	candidate, ok := linkSpectrumToTrackByTime(ctx, db, dbType, analysis)
+	candidates, ok := linkSpectrumToTrackByTime(ctx, db, dbType, analysis)
 	if !ok {
 		detail["link_reason"] = "no-track-candidate"
 		detail["start_unix"] = analysis.Measurement.StartTime.Unix()
 		detail["end_unix"] = analysis.Measurement.EndTime.Unix()
 		return currentBounds, currentTrackID, currentHasBounds, detail, nil
 	}
-	detail["linked_track_id"] = candidate.TrackID
-	detail["matched_markers"] = candidate.MatchedMarkers
-	detail["device_match"] = candidate.DeviceNameMatch
+	bestCandidate := candidates[0]
+	detail["linked_track_id"] = bestCandidate.TrackID
+	detail["matched_markers"] = bestCandidate.MatchedMarkers
+	detail["device_match"] = bestCandidate.DeviceNameMatch
+	detail["track_start_unix"] = bestCandidate.TrackStartUnix
+	detail["track_end_unix"] = bestCandidate.TrackEndUnix
+	detail["overlap_sec"] = bestCandidate.OverlapSec
+	detail["center_delta_sec"] = bestCandidate.CenterDeltaSec
 	detail["link_reason"] = "candidate-required-confirmation"
 	detail["start_unix"] = analysis.Measurement.StartTime.Unix()
 	detail["end_unix"] = analysis.Measurement.EndTime.Unix()
-	detail["candidate_tracks"] = []map[string]any{
-		{
-			"trackID":       candidate.TrackID,
-			"matchedPoints": candidate.MatchedMarkers,
-			"deviceMatch":   candidate.DeviceNameMatch,
-		},
+	candidateTracks := make([]map[string]any, 0, len(candidates))
+	for _, candidate := range candidates {
+		candidateTracks = append(candidateTracks, map[string]any{
+			"trackID":        candidate.TrackID,
+			"matchedPoints":  candidate.MatchedMarkers,
+			"deviceMatch":    candidate.DeviceNameMatch,
+			"trackStartUnix": candidate.TrackStartUnix,
+			"trackEndUnix":   candidate.TrackEndUnix,
+			"overlapSec":     candidate.OverlapSec,
+			"centerDeltaSec": candidate.CenterDeltaSec,
+			"score":          candidate.Score,
+			"minLat":         candidate.Bounds.MinLat,
+			"minLon":         candidate.Bounds.MinLon,
+			"maxLat":         candidate.Bounds.MaxLat,
+			"maxLon":         candidate.Bounds.MaxLon,
+			"trackURL": fmt.Sprintf(
+				"/trackid/%s?minLat=%f&minLon=%f&maxLat=%f&maxLon=%f&zoom=14&layer=%s",
+				candidate.TrackID,
+				candidate.Bounds.MinLat,
+				candidate.Bounds.MinLon,
+				candidate.Bounds.MaxLat,
+				candidate.Bounds.MaxLon,
+				"OpenStreetMap",
+			),
+		})
 	}
+	detail["candidate_tracks"] = candidateTracks
 	return currentBounds, currentTrackID, currentHasBounds, detail, nil
 }
 
@@ -5929,6 +6067,15 @@ func attachSpectrumToTrackHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	if strings.TrimSpace(payload.TrackID) == "" {
 		http.Error(w, "track id required", http.StatusBadRequest)
+		return
+	}
+	trackSummary, err := db.GetTrackSummary(r.Context(), payload.TrackID, *dbType)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if trackSummary.MarkerCount == 0 {
+		http.Error(w, "track id not found", http.StatusBadRequest)
 		return
 	}
 	if err := db.AnnotateTrackRadiationWindow(r.Context(), payload.TrackID, payload.StartUnix-60, payload.EndUnix+60, payload.Qualitative, *dbType); err != nil {

--- a/pkg/database/tracks.go
+++ b/pkg/database/tracks.go
@@ -474,6 +474,43 @@ WHERE trackID = %s AND (device_name IS NULL OR device_name = '');`, ph, ph2)
 	return nil
 }
 
+// AnnotateTrackRadiationWindow writes qualitative isotope composition into the
+// radiation field for markers captured in a time window.
+func (db *Database) AnnotateTrackRadiationWindow(ctx context.Context, trackID string, fromUnix, toUnix int64, radiationText, dbType string) error {
+	if db == nil || db.DB == nil {
+		return fmt.Errorf("database unavailable")
+	}
+	trackID = strings.TrimSpace(trackID)
+	radiationText = strings.TrimSpace(radiationText)
+	if trackID == "" || radiationText == "" {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if fromUnix > toUnix {
+		fromUnix, toUnix = toUnix, fromUnix
+	}
+
+	ph1 := placeholder(dbType, 1)
+	ph2 := placeholder(dbType, 2)
+	ph3 := placeholder(dbType, 3)
+	ph4 := placeholder(dbType, 4)
+	stmt := fmt.Sprintf(`UPDATE markers
+SET radiation = %s
+WHERE trackID = %s AND date >= %s AND date <= %s;`, ph1, ph2, ph3, ph4)
+
+	ctx, cancel := queueFriendlyContext(ctx, serializedWaitFloor)
+	defer cancel()
+
+	return db.withSerializedConnectionFor(ctx, WorkloadUserUpload, func(runCtx context.Context, conn *sql.DB) error {
+		if _, err := conn.ExecContext(runCtx, stmt, radiationText, trackID, fromUnix, toUnix); err != nil {
+			return fmt.Errorf("annotate track radiation window: %w", err)
+		}
+		return nil
+	})
+}
+
 // TrackHasDeviceName checks whether any marker in the track already carries a device label.
 // We use it to avoid downloading full track payloads when only the device name is missing.
 func (db *Database) TrackHasDeviceName(ctx context.Context, trackID, dbType string) (bool, error) {

--- a/pkg/database/tracks.go
+++ b/pkg/database/tracks.go
@@ -511,6 +511,53 @@ WHERE trackID = %s AND date >= %s AND date <= %s;`, ph1, ph2, ph3, ph4)
 	})
 }
 
+// AnnotateAreaRadiationWindow writes qualitative isotope composition into
+// markers inside a bounding box and time window.
+func (db *Database) AnnotateAreaRadiationWindow(ctx context.Context, fromUnix, toUnix int64, minLat, minLon, maxLat, maxLon float64, radiationText, dbType string) error {
+	if db == nil || db.DB == nil {
+		return fmt.Errorf("database unavailable")
+	}
+	radiationText = strings.TrimSpace(radiationText)
+	if radiationText == "" {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if fromUnix > toUnix {
+		fromUnix, toUnix = toUnix, fromUnix
+	}
+	if minLat > maxLat {
+		minLat, maxLat = maxLat, minLat
+	}
+	if minLon > maxLon {
+		minLon, maxLon = maxLon, minLon
+	}
+
+	ph1 := placeholder(dbType, 1)
+	ph2 := placeholder(dbType, 2)
+	ph3 := placeholder(dbType, 3)
+	ph4 := placeholder(dbType, 4)
+	ph5 := placeholder(dbType, 5)
+	ph6 := placeholder(dbType, 6)
+	ph7 := placeholder(dbType, 7)
+	stmt := fmt.Sprintf(`UPDATE markers
+SET radiation = %s
+WHERE date >= %s AND date <= %s
+  AND lat >= %s AND lat <= %s
+  AND lon >= %s AND lon <= %s;`, ph1, ph2, ph3, ph4, ph5, ph6, ph7)
+
+	ctx, cancel := queueFriendlyContext(ctx, serializedWaitFloor)
+	defer cancel()
+
+	return db.withSerializedConnectionFor(ctx, WorkloadUserUpload, func(runCtx context.Context, conn *sql.DB) error {
+		if _, err := conn.ExecContext(runCtx, stmt, radiationText, fromUnix, toUnix, minLat, maxLat, minLon, maxLon); err != nil {
+			return fmt.Errorf("annotate area radiation window: %w", err)
+		}
+		return nil
+	})
+}
+
 // TrackHasDeviceName checks whether any marker in the track already carries a device label.
 // We use it to avoid downloading full track payloads when only the device name is missing.
 func (db *Database) TrackHasDeviceName(ctx context.Context, trackID, dbType string) (bool, error) {

--- a/pkg/spectrum/analysis.go
+++ b/pkg/spectrum/analysis.go
@@ -3,6 +3,7 @@ package spectrum
 import (
 	"math"
 	"sort"
+	"strings"
 )
 
 // AnalyzeMeasurement runs generic peak detection and isotope matching.
@@ -11,12 +12,16 @@ func AnalyzeMeasurement(measurement SpectrumMeasurement) Analysis {
 	isotopes := matchIsotopes(peaks, DefaultCatalog())
 	composites := buildCompositeModels(peaks, isotopes, 3)
 	components := estimateSpectrumComponents(peaks)
+	groupChecks := evaluatePracticalGroups(peaks)
+	explanation := buildPlainLanguageExplanation(components, groupChecks)
 	return Analysis{
 		Measurement:     measurement,
 		DetectedPeaks:   peaks,
 		Isotopes:        isotopes,
 		CompositeModels: composites,
 		Components:      components,
+		GroupChecks:     groupChecks,
+		Explanation:     explanation,
 	}
 }
 
@@ -368,4 +373,127 @@ func estimateSpectrumComponents(peaks []Peak) []SpectrumComponent {
 		return components[i].Contribution > components[j].Contribution
 	})
 	return components
+}
+
+type practicalGroupRule struct {
+	GroupID       string
+	DisplayName   string
+	RequiredLines []float64
+	MinMatches    int
+}
+
+func evaluatePracticalGroups(peaks []Peak) []GroupCheck {
+	rules := []practicalGroupRule{
+		{GroupID: "k40", DisplayName: "K-40", RequiredLines: []float64{1460.8}, MinMatches: 1},
+		{GroupID: "cs137", DisplayName: "Cs-137", RequiredLines: []float64{661.7}, MinMatches: 1},
+		{GroupID: "co60", DisplayName: "Co-60", RequiredLines: []float64{1173.2, 1332.5}, MinMatches: 2},
+		{GroupID: "u_ra", DisplayName: "U/Ra series", RequiredLines: []float64{186.2, 295.2, 351.9, 609.3}, MinMatches: 2},
+		{GroupID: "th232", DisplayName: "Th-232 series", RequiredLines: []float64{238.6, 583.2, 911.2, 2614.5}, MinMatches: 2},
+		{GroupID: "am241", DisplayName: "Am-241", RequiredLines: []float64{59.5}, MinMatches: 1},
+	}
+
+	checks := make([]GroupCheck, 0, len(rules))
+	for _, rule := range rules {
+		matched := make([]float64, 0, len(rule.RequiredLines))
+		missing := make([]float64, 0, len(rule.RequiredLines))
+		for _, lineEnergy := range rule.RequiredLines {
+			peak, ok := closestPeakForEnergy(peaks, lineEnergy)
+			if !ok {
+				missing = append(missing, lineEnergy)
+				continue
+			}
+			tolerance := 35.0
+			if lineEnergy < 120 {
+				tolerance = 25.0
+			}
+			if math.Abs(peak.Energy-lineEnergy) <= tolerance {
+				matched = append(matched, lineEnergy)
+			} else {
+				missing = append(missing, lineEnergy)
+			}
+		}
+		confidence := float64(len(matched)) / float64(len(rule.RequiredLines))
+		isConfirmed := len(matched) >= rule.MinMatches
+		comment := "not confirmed by group lines"
+		if isConfirmed {
+			comment = "confirmed by group line pattern"
+		}
+		checks = append(checks, GroupCheck{
+			GroupID:      rule.GroupID,
+			DisplayName:  rule.DisplayName,
+			MatchedLines: matched,
+			MissingLines: missing,
+			Confidence:   confidence,
+			IsConfirmed:  isConfirmed,
+			Comment:      comment,
+		})
+	}
+	sort.Slice(checks, func(i, j int) bool {
+		if checks[i].Confidence == checks[j].Confidence {
+			return checks[i].DisplayName < checks[j].DisplayName
+		}
+		return checks[i].Confidence > checks[j].Confidence
+	})
+	return checks
+}
+
+func buildPlainLanguageExplanation(components []SpectrumComponent, groupChecks []GroupCheck) string {
+	if len(components) == 0 {
+		return "Spectrum does not contain enough stable evidence for component interpretation."
+	}
+
+	leading := make([]string, 0, 2)
+	for _, component := range components {
+		if component.ComponentID == "unknown" {
+			continue
+		}
+		percent := int(math.Round(component.Contribution * 100))
+		if percent < 8 {
+			continue
+		}
+		leading = append(leading, component.DisplayName)
+		if len(leading) == 2 {
+			break
+		}
+	}
+
+	confirmed := make([]string, 0, 3)
+	rejected := make([]string, 0, 3)
+	for _, check := range groupChecks {
+		if check.IsConfirmed {
+			confirmed = append(confirmed, check.DisplayName)
+			continue
+		}
+		if check.Confidence < 0.35 {
+			rejected = append(rejected, check.DisplayName)
+		}
+	}
+
+	sentenceParts := make([]string, 0, 3)
+	if len(leading) > 0 {
+		sentenceParts = append(sentenceParts, "Rise is best explained by "+joinHumanList(leading)+".")
+	}
+	if len(confirmed) > 0 {
+		sentenceParts = append(sentenceParts, "Confirmed groups: "+joinHumanList(confirmed)+".")
+	}
+	if len(rejected) > 0 {
+		sentenceParts = append(sentenceParts, "Not confirmed by key lines: "+joinHumanList(rejected)+".")
+	}
+	if len(sentenceParts) == 0 {
+		return "Spectrum fit remains uncertain; key group lines are incomplete."
+	}
+	return strings.Join(sentenceParts, " ")
+}
+
+func joinHumanList(items []string) string {
+	if len(items) == 0 {
+		return ""
+	}
+	if len(items) == 1 {
+		return items[0]
+	}
+	if len(items) == 2 {
+		return items[0] + " and " + items[1]
+	}
+	return items[0] + ", " + items[1] + ", and " + items[2]
 }

--- a/pkg/spectrum/analysis.go
+++ b/pkg/spectrum/analysis.go
@@ -9,7 +9,8 @@ import (
 func AnalyzeMeasurement(measurement SpectrumMeasurement) Analysis {
 	peaks := findPeaks(measurement.Channels, measurement.Coefficients)
 	isotopes := matchIsotopes(peaks, DefaultCatalog())
-	return Analysis{Measurement: measurement, DetectedPeaks: peaks, Isotopes: isotopes}
+	composites := buildCompositeModels(peaks, isotopes, 3)
+	return Analysis{Measurement: measurement, DetectedPeaks: peaks, Isotopes: isotopes, CompositeModels: composites}
 }
 
 // AnalyzeWithKnownDrivers parses with known drivers and analyzes the result.
@@ -92,33 +93,38 @@ func findPeaks(channels []float64, coeffs []float64) []Peak {
 }
 
 func matchIsotopes(peaks []Peak, nuclides []Nuclide) []IsotopeHit {
-	hits := make([]IsotopeHit, 0, 32)
+	hits := make([]IsotopeHit, 0, 64)
 	if len(peaks) == 0 || len(nuclides) == 0 {
 		return hits
 	}
 
 	for _, nuclide := range nuclides {
-		for _, gammaLine := range nuclide.GammaLinesKeV {
-			peak, ok := closestPeakForEnergy(peaks, gammaLine)
+		for _, line := range nuclide.RadiationLines() {
+			peak, ok := closestPeakForEnergy(peaks, line.EnergyKeV)
 			if !ok {
 				continue
 			}
-			delta := math.Abs(peak.Energy - gammaLine)
-			if delta > 25 {
+			delta := math.Abs(peak.Energy - line.EnergyKeV)
+			tolerance := 25.0
+			if line.RadiationType == "alpha" {
+				tolerance = 60.0
+			}
+			if delta > tolerance {
 				continue
 			}
-			confidence := 1.0 - delta/25.0
+			confidence := 1.0 - delta/tolerance
 			if confidence < 0 {
 				confidence = 0
 			}
 			hits = append(hits, IsotopeHit{
-				Name:       nuclide.DisplayName,
-				NuclideID:  nuclide.NuclideID,
-				EnergyKeV:  gammaLine,
-				PeakEnergy: peak.Energy,
-				DeltaKeV:   delta,
-				Confidence: confidence,
-				Series:     nuclide.DecaySeries,
+				Name:          nuclide.DisplayName,
+				NuclideID:     nuclide.NuclideID,
+				RadiationType: line.RadiationType,
+				EnergyKeV:     line.EnergyKeV,
+				PeakEnergy:    peak.Energy,
+				DeltaKeV:      delta,
+				Confidence:    confidence,
+				Series:        nuclide.DecaySeries,
 			})
 		}
 	}
@@ -130,10 +136,134 @@ func matchIsotopes(peaks []Peak, nuclides []Nuclide) []IsotopeHit {
 		return hits[i].Confidence > hits[j].Confidence
 	})
 
-	if len(hits) > 50 {
-		return hits[:50]
+	if len(hits) > 80 {
+		return hits[:80]
 	}
 	return hits
+}
+
+func buildCompositeModels(peaks []Peak, hits []IsotopeHit, maxComponents int) []CompositeHit {
+	if len(peaks) == 0 || len(hits) == 0 || maxComponents < 2 {
+		return nil
+	}
+
+	candidates := topNuclideCandidates(hits, 12)
+	if len(candidates) < 2 {
+		return nil
+	}
+
+	combos := enumerateNuclideCombos(candidates, maxComponents)
+	if len(combos) == 0 {
+		return nil
+	}
+
+	resultsChannel := make(chan CompositeHit, len(combos))
+	for _, combo := range combos {
+		comboCopy := append([]string(nil), combo...)
+		go func() {
+			resultsChannel <- evaluateCombo(peaks, hits, comboCopy)
+		}()
+	}
+
+	models := make([]CompositeHit, 0, len(combos))
+	for range combos {
+		model := <-resultsChannel
+		if model.MatchedPeaks == 0 {
+			continue
+		}
+		models = append(models, model)
+	}
+
+	sort.Slice(models, func(i, j int) bool {
+		if models[i].TotalScore == models[j].TotalScore {
+			return models[i].ResidualKeV < models[j].ResidualKeV
+		}
+		return models[i].TotalScore > models[j].TotalScore
+	})
+	if len(models) > 20 {
+		return models[:20]
+	}
+	return models
+}
+
+func topNuclideCandidates(hits []IsotopeHit, limit int) []string {
+	scoreByNuclide := make(map[string]float64)
+	for _, hit := range hits {
+		scoreByNuclide[hit.NuclideID] += hit.Confidence
+	}
+	type scored struct {
+		nuclide string
+		score   float64
+	}
+	rows := make([]scored, 0, len(scoreByNuclide))
+	for nuclide, score := range scoreByNuclide {
+		rows = append(rows, scored{nuclide: nuclide, score: score})
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].score > rows[j].score })
+	if len(rows) > limit {
+		rows = rows[:limit]
+	}
+	out := make([]string, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, row.nuclide)
+	}
+	return out
+}
+
+func enumerateNuclideCombos(nuclides []string, maxComponents int) [][]string {
+	combos := make([][]string, 0, 64)
+	for size := 2; size <= maxComponents; size++ {
+		collectCombos(nuclides, size, 0, nil, &combos)
+	}
+	return combos
+}
+
+func collectCombos(nuclides []string, size, start int, prefix []string, combos *[][]string) {
+	if len(prefix) == size {
+		item := append([]string(nil), prefix...)
+		*combos = append(*combos, item)
+		return
+	}
+	for index := start; index < len(nuclides); index++ {
+		prefix = append(prefix, nuclides[index])
+		collectCombos(nuclides, size, index+1, prefix, combos)
+		prefix = prefix[:len(prefix)-1]
+	}
+}
+
+func evaluateCombo(peaks []Peak, hits []IsotopeHit, combo []string) CompositeHit {
+	inCombo := make(map[string]struct{}, len(combo))
+	for _, nuclide := range combo {
+		inCombo[nuclide] = struct{}{}
+	}
+	bestByPeak := make(map[int]IsotopeHit)
+	for _, hit := range hits {
+		if _, ok := inCombo[hit.NuclideID]; !ok {
+			continue
+		}
+		peakKey := int(math.Round(hit.PeakEnergy * 10))
+		current, exists := bestByPeak[peakKey]
+		if !exists || hit.Confidence > current.Confidence {
+			bestByPeak[peakKey] = hit
+		}
+	}
+	if len(bestByPeak) == 0 {
+		return CompositeHit{NuclideIDs: combo}
+	}
+	var residual float64
+	var score float64
+	for _, hit := range bestByPeak {
+		residual += hit.DeltaKeV
+		score += hit.Confidence
+	}
+	coverage := float64(len(bestByPeak)) / float64(len(peaks))
+	return CompositeHit{
+		NuclideIDs:   combo,
+		Coverage:     coverage,
+		ResidualKeV:  residual / float64(len(bestByPeak)),
+		TotalScore:   score + coverage,
+		MatchedPeaks: len(bestByPeak),
+	}
 }
 
 func closestPeakForEnergy(peaks []Peak, targetEnergy float64) (Peak, bool) {

--- a/pkg/spectrum/analysis.go
+++ b/pkg/spectrum/analysis.go
@@ -1,0 +1,153 @@
+package spectrum
+
+import (
+	"math"
+	"sort"
+)
+
+// AnalyzeMeasurement runs generic peak detection and isotope matching.
+func AnalyzeMeasurement(measurement SpectrumMeasurement) Analysis {
+	peaks := findPeaks(measurement.Channels, measurement.Coefficients)
+	isotopes := matchIsotopes(peaks, DefaultCatalog())
+	return Analysis{Measurement: measurement, DetectedPeaks: peaks, Isotopes: isotopes}
+}
+
+// AnalyzeWithKnownDrivers parses with known drivers and analyzes the result.
+func AnalyzeWithKnownDrivers(raw []byte) (Analysis, error) {
+	measurement, err := ParseWithKnownDrivers(raw)
+	if err != nil {
+		return Analysis{}, err
+	}
+	return AnalyzeMeasurement(measurement), nil
+}
+
+// AnalyzeRadiacodeXML keeps backward compatibility with the previous API.
+func AnalyzeRadiacodeXML(raw []byte) (Analysis, error) {
+	driver := RadiacodeXMLDriver{}
+	measurement, err := driver.Parse(raw)
+	if err != nil {
+		return Analysis{}, err
+	}
+	return AnalyzeMeasurement(measurement), nil
+}
+
+// FindClosestMarkerByTime chooses the nearest marker to the spectrum window center.
+func FindClosestMarkerByTime(markers []MarkerTimePoint, windowStart, windowEnd, marginSec int64) (MarkerMatch, bool) {
+	if len(markers) == 0 {
+		return MarkerMatch{}, false
+	}
+	if windowEnd < windowStart {
+		windowStart, windowEnd = windowEnd, windowStart
+	}
+	windowCenter := windowStart + (windowEnd-windowStart)/2
+	best := MarkerMatch{}
+	bestSet := false
+
+	for _, marker := range markers {
+		delta := marker.Date - windowCenter
+		if delta < 0 {
+			delta = -delta
+		}
+		candidate := MarkerMatch{
+			Marker:             marker,
+			AbsoluteDeltaSec:   delta,
+			WithinWindow:       marker.Date >= windowStart && marker.Date <= windowEnd,
+			WithinWindowMargin: marker.Date >= windowStart-marginSec && marker.Date <= windowEnd+marginSec,
+		}
+		if !bestSet || candidate.AbsoluteDeltaSec < best.AbsoluteDeltaSec {
+			best = candidate
+			bestSet = true
+		}
+	}
+	return best, bestSet
+}
+
+func findPeaks(channels []float64, coeffs []float64) []Peak {
+	if len(channels) < 3 || len(coeffs) < 2 {
+		return nil
+	}
+	peaks := make([]Peak, 0, 24)
+	for channelIndex := 1; channelIndex < len(channels)-1; channelIndex++ {
+		left := channels[channelIndex-1]
+		middle := channels[channelIndex]
+		right := channels[channelIndex+1]
+		if middle < 4 {
+			continue
+		}
+		if middle > left && middle >= right {
+			energy := coeffs[0] + coeffs[1]*float64(channelIndex)
+			if len(coeffs) > 2 {
+				energy += coeffs[2] * float64(channelIndex*channelIndex)
+			}
+			peaks = append(peaks, Peak{Channel: channelIndex, Energy: energy, Counts: middle})
+		}
+	}
+	sort.Slice(peaks, func(i, j int) bool {
+		return peaks[i].Counts > peaks[j].Counts
+	})
+	if len(peaks) > 24 {
+		return peaks[:24]
+	}
+	return peaks
+}
+
+func matchIsotopes(peaks []Peak, nuclides []Nuclide) []IsotopeHit {
+	hits := make([]IsotopeHit, 0, 32)
+	if len(peaks) == 0 || len(nuclides) == 0 {
+		return hits
+	}
+
+	for _, nuclide := range nuclides {
+		for _, gammaLine := range nuclide.GammaLinesKeV {
+			peak, ok := closestPeakForEnergy(peaks, gammaLine)
+			if !ok {
+				continue
+			}
+			delta := math.Abs(peak.Energy - gammaLine)
+			if delta > 25 {
+				continue
+			}
+			confidence := 1.0 - delta/25.0
+			if confidence < 0 {
+				confidence = 0
+			}
+			hits = append(hits, IsotopeHit{
+				Name:       nuclide.DisplayName,
+				NuclideID:  nuclide.NuclideID,
+				EnergyKeV:  gammaLine,
+				PeakEnergy: peak.Energy,
+				DeltaKeV:   delta,
+				Confidence: confidence,
+				Series:     nuclide.DecaySeries,
+			})
+		}
+	}
+
+	sort.Slice(hits, func(i, j int) bool {
+		if hits[i].Confidence == hits[j].Confidence {
+			return hits[i].DeltaKeV < hits[j].DeltaKeV
+		}
+		return hits[i].Confidence > hits[j].Confidence
+	})
+
+	if len(hits) > 50 {
+		return hits[:50]
+	}
+	return hits
+}
+
+func closestPeakForEnergy(peaks []Peak, targetEnergy float64) (Peak, bool) {
+	if len(peaks) == 0 {
+		return Peak{}, false
+	}
+	best := peaks[0]
+	bestDelta := math.Abs(best.Energy - targetEnergy)
+	for _, peak := range peaks[1:] {
+		delta := math.Abs(peak.Energy - targetEnergy)
+		if delta < bestDelta {
+			best = peak
+			bestDelta = delta
+		}
+	}
+	return best, true
+}

--- a/pkg/spectrum/analysis.go
+++ b/pkg/spectrum/analysis.go
@@ -10,7 +10,14 @@ func AnalyzeMeasurement(measurement SpectrumMeasurement) Analysis {
 	peaks := findPeaks(measurement.Channels, measurement.Coefficients)
 	isotopes := matchIsotopes(peaks, DefaultCatalog())
 	composites := buildCompositeModels(peaks, isotopes, 3)
-	return Analysis{Measurement: measurement, DetectedPeaks: peaks, Isotopes: isotopes, CompositeModels: composites}
+	components := estimateSpectrumComponents(peaks)
+	return Analysis{
+		Measurement:     measurement,
+		DetectedPeaks:   peaks,
+		Isotopes:        isotopes,
+		CompositeModels: composites,
+		Components:      components,
+	}
 }
 
 // AnalyzeWithKnownDrivers parses with known drivers and analyzes the result.
@@ -280,4 +287,85 @@ func closestPeakForEnergy(peaks []Peak, targetEnergy float64) (Peak, bool) {
 		}
 	}
 	return best, true
+}
+
+type componentTemplate struct {
+	ComponentID  string
+	DisplayName  string
+	LineEnergies []float64
+}
+
+func estimateSpectrumComponents(peaks []Peak) []SpectrumComponent {
+	if len(peaks) == 0 {
+		return []SpectrumComponent{{ComponentID: "unknown", DisplayName: "Unknown / background", Contribution: 1}}
+	}
+
+	templates := []componentTemplate{
+		{ComponentID: "k40", DisplayName: "K-40", LineEnergies: []float64{1460.8}},
+		{ComponentID: "u_ra_series", DisplayName: "U/Ra series", LineEnergies: []float64{186.2, 295.2, 351.9, 609.3, 1120.3, 1764.5}},
+		{ComponentID: "th_series", DisplayName: "Th series", LineEnergies: []float64{238.6, 338.3, 583.2, 911.2, 969.0, 2614.5}},
+		{ComponentID: "cs137", DisplayName: "Cs-137", LineEnergies: []float64{661.7}},
+		{ComponentID: "co60", DisplayName: "Co-60", LineEnergies: []float64{1173.2, 1332.5}},
+		{ComponentID: "am241", DisplayName: "Am-241", LineEnergies: []float64{59.5}},
+		{ComponentID: "i123", DisplayName: "I-123", LineEnergies: []float64{159.0}},
+		{ComponentID: "tc99m", DisplayName: "Tc-99m", LineEnergies: []float64{140.5}},
+	}
+
+	components := make([]SpectrumComponent, 0, len(templates)+1)
+	totalScore := 0.0
+	for _, template := range templates {
+		score := 0.0
+		matchedLines := 0
+		totalError := 0.0
+		for _, lineEnergy := range template.LineEnergies {
+			peak, ok := closestPeakForEnergy(peaks, lineEnergy)
+			if !ok {
+				continue
+			}
+			delta := math.Abs(peak.Energy - lineEnergy)
+			tolerance := 40.0
+			if lineEnergy < 200 {
+				tolerance = 30.0
+			}
+			if delta > tolerance {
+				continue
+			}
+			lineScore := (1.0 - delta/tolerance) * math.Sqrt(math.Max(peak.Counts, 1))
+			score += lineScore
+			matchedLines++
+			totalError += delta
+		}
+		if matchedLines == 0 || score <= 0 {
+			continue
+		}
+		component := SpectrumComponent{
+			ComponentID:  template.ComponentID,
+			DisplayName:  template.DisplayName,
+			Contribution: score,
+			MatchedLines: matchedLines,
+		}
+		component.AverageLineError = totalError / float64(matchedLines)
+		components = append(components, component)
+		totalScore += score
+	}
+
+	if totalScore <= 0 {
+		return []SpectrumComponent{{ComponentID: "unknown", DisplayName: "Unknown / background", Contribution: 1}}
+	}
+
+	const unknownFloor = 0.08
+	scale := 1.0 - unknownFloor
+	for index := range components {
+		components[index].Contribution = (components[index].Contribution / totalScore) * scale
+	}
+	components = append(components, SpectrumComponent{
+		ComponentID:  "unknown",
+		DisplayName:  "Unknown / background",
+		Contribution: unknownFloor,
+	})
+
+	sort.Slice(components, func(i, j int) bool {
+		return components[i].Contribution > components[j].Contribution
+	})
+	return components
 }

--- a/pkg/spectrum/catalog.go
+++ b/pkg/spectrum/catalog.go
@@ -17,7 +17,29 @@ type Nuclide struct {
 	DecaySeries   string
 	Category      string
 	TypicalSource string
+	AlphaLinesKeV []float64
+	BetaMaxKeV    []float64
 	GammaLinesKeV []float64
+}
+
+// RadiationLine describes one emission line that can participate in spectral matching.
+type RadiationLine struct {
+	RadiationType string
+	EnergyKeV     float64
+}
+
+func (nuclide Nuclide) RadiationLines() []RadiationLine {
+	lines := make([]RadiationLine, 0, len(nuclide.AlphaLinesKeV)+len(nuclide.BetaMaxKeV)+len(nuclide.GammaLinesKeV))
+	for _, energy := range nuclide.AlphaLinesKeV {
+		lines = append(lines, RadiationLine{RadiationType: "alpha", EnergyKeV: energy})
+	}
+	for _, energy := range nuclide.BetaMaxKeV {
+		lines = append(lines, RadiationLine{RadiationType: "beta", EnergyKeV: energy})
+	}
+	for _, energy := range nuclide.GammaLinesKeV {
+		lines = append(lines, RadiationLine{RadiationType: "gamma", EnergyKeV: energy})
+	}
+	return lines
 }
 
 // DefaultCatalog returns a broad catalog with natural chains, NORM and key artificial isotopes.
@@ -107,8 +129,8 @@ func normalizeNuclideToken(input string) (string, bool) {
 }
 
 var defaultNuclides = []Nuclide{
-	{NuclideID: "H-3", DisplayName: "Tritium", Element: "H", MassNumber: 3, HalfLife: "12.32 y", Category: "cosmogenic", TypicalSource: "water, tritium signs"},
-	{NuclideID: "C-14", DisplayName: "Carbon-14", Element: "C", MassNumber: 14, HalfLife: "5730 y", Category: "cosmogenic"},
+	{NuclideID: "H-3", DisplayName: "Tritium", Element: "H", MassNumber: 3, HalfLife: "12.32 y", Category: "cosmogenic", TypicalSource: "water, tritium signs", BetaMaxKeV: []float64{18.6}},
+	{NuclideID: "C-14", DisplayName: "Carbon-14", Element: "C", MassNumber: 14, HalfLife: "5730 y", Category: "cosmogenic", BetaMaxKeV: []float64{156.5}},
 	{NuclideID: "K-40", DisplayName: "Potassium-40", Element: "K", MassNumber: 40, HalfLife: "1.248e9 y", Category: "NORM", TypicalSource: "fertilizers, food, concrete", GammaLinesKeV: []float64{1460.8}},
 	{NuclideID: "Rb-87", DisplayName: "Rubidium-87", Element: "Rb", MassNumber: 87, HalfLife: "4.88e10 y", Category: "NORM"},
 	{NuclideID: "La-138", DisplayName: "Lanthanum-138", Element: "La", MassNumber: 138, HalfLife: "1.02e11 y", Category: "NORM", GammaLinesKeV: []float64{1435.8}},
@@ -140,7 +162,7 @@ var defaultNuclides = []Nuclide{
 	{NuclideID: "Pa-234m", DisplayName: "Protactinium-234m", Element: "Pa", MassNumber: 234, HalfLife: "1.17 min", DecaySeries: "U-238", Category: "NORM"},
 	{NuclideID: "U-234", DisplayName: "Uranium-234", Element: "U", MassNumber: 234, HalfLife: "2.455e5 y", DecaySeries: "U-238", Category: "NORM"},
 	{NuclideID: "Th-230", DisplayName: "Thorium-230", Element: "Th", MassNumber: 230, HalfLife: "75380 y", DecaySeries: "U-238", Category: "NORM"},
-	{NuclideID: "Ra-226", DisplayName: "Radium-226", Element: "Ra", MassNumber: 226, HalfLife: "1600 y", DecaySeries: "U-238", Category: "NORM", GammaLinesKeV: []float64{186.2}},
+	{NuclideID: "Ra-226", DisplayName: "Radium-226", Element: "Ra", MassNumber: 226, HalfLife: "1600 y", DecaySeries: "U-238", Category: "NORM", AlphaLinesKeV: []float64{4784.3}, GammaLinesKeV: []float64{186.2}},
 	{NuclideID: "Rn-222", DisplayName: "Radon-222", Element: "Rn", MassNumber: 222, HalfLife: "3.82 d", DecaySeries: "U-238", Category: "NORM", TypicalSource: "indoor air"},
 	{NuclideID: "Po-218", DisplayName: "Polonium-218", Element: "Po", MassNumber: 218, HalfLife: "3.1 min", DecaySeries: "U-238", Category: "NORM"},
 	{NuclideID: "Pb-214", DisplayName: "Lead-214", Element: "Pb", MassNumber: 214, HalfLife: "26.8 min", DecaySeries: "U-238", Category: "NORM", GammaLinesKeV: []float64{295.2, 351.9}},
@@ -148,7 +170,7 @@ var defaultNuclides = []Nuclide{
 	{NuclideID: "Po-214", DisplayName: "Polonium-214", Element: "Po", MassNumber: 214, HalfLife: "164 us", DecaySeries: "U-238", Category: "NORM"},
 	{NuclideID: "Pb-210", DisplayName: "Lead-210", Element: "Pb", MassNumber: 210, HalfLife: "22.3 y", DecaySeries: "U-238", Category: "NORM", GammaLinesKeV: []float64{46.5}},
 	{NuclideID: "Bi-210", DisplayName: "Bismuth-210", Element: "Bi", MassNumber: 210, HalfLife: "5.01 d", DecaySeries: "U-238", Category: "NORM"},
-	{NuclideID: "Po-210", DisplayName: "Polonium-210", Element: "Po", MassNumber: 210, HalfLife: "138.4 d", DecaySeries: "U-238", Category: "NORM"},
+	{NuclideID: "Po-210", DisplayName: "Polonium-210", Element: "Po", MassNumber: 210, HalfLife: "138.4 d", DecaySeries: "U-238", Category: "NORM", AlphaLinesKeV: []float64{5304.5}},
 	{NuclideID: "Pb-206", DisplayName: "Lead-206", Element: "Pb", MassNumber: 206, HalfLife: "stable", DecaySeries: "U-238", Category: "stable-end"},
 
 	// Uranium-235 / actinium series (4n+3)
@@ -191,8 +213,8 @@ var defaultNuclides = []Nuclide{
 	{NuclideID: "Se-75", DisplayName: "Selenium-75", Element: "Se", MassNumber: 75, HalfLife: "119.8 d", Category: "industrial", GammaLinesKeV: []float64{136.0, 264.7}},
 	{NuclideID: "Kr-85", DisplayName: "Krypton-85", Element: "Kr", MassNumber: 85, HalfLife: "10.7 y", Category: "reprocessing"},
 	{NuclideID: "Sr-89", DisplayName: "Strontium-89", Element: "Sr", MassNumber: 89, HalfLife: "50.5 d", Category: "medical"},
-	{NuclideID: "Sr-90", DisplayName: "Strontium-90", Element: "Sr", MassNumber: 90, HalfLife: "28.8 y", Category: "fallout"},
-	{NuclideID: "Y-90", DisplayName: "Yttrium-90", Element: "Y", MassNumber: 90, HalfLife: "64 h", Category: "medical"},
+	{NuclideID: "Sr-90", DisplayName: "Strontium-90", Element: "Sr", MassNumber: 90, HalfLife: "28.8 y", Category: "fallout", BetaMaxKeV: []float64{546.0}},
+	{NuclideID: "Y-90", DisplayName: "Yttrium-90", Element: "Y", MassNumber: 90, HalfLife: "64 h", Category: "medical", BetaMaxKeV: []float64{2280.1}},
 	{NuclideID: "Zr-95", DisplayName: "Zirconium-95", Element: "Zr", MassNumber: 95, HalfLife: "64 d", Category: "fission", GammaLinesKeV: []float64{724.2, 756.7}},
 	{NuclideID: "Nb-95", DisplayName: "Niobium-95", Element: "Nb", MassNumber: 95, HalfLife: "35 d", Category: "fission", GammaLinesKeV: []float64{765.8}},
 	{NuclideID: "Mo-99", DisplayName: "Molybdenum-99", Element: "Mo", MassNumber: 99, HalfLife: "66 h", Category: "medical", GammaLinesKeV: []float64{739.5}},
@@ -209,7 +231,7 @@ var defaultNuclides = []Nuclide{
 	{NuclideID: "I-131", DisplayName: "Iodine-131", Element: "I", MassNumber: 131, HalfLife: "8.02 d", Category: "fission", GammaLinesKeV: []float64{364.5, 637.0}},
 	{NuclideID: "Cs-134", DisplayName: "Cesium-134", Element: "Cs", MassNumber: 134, HalfLife: "2.06 y", Category: "reactor", GammaLinesKeV: []float64{569.3, 604.7, 795.8, 801.9}},
 	{NuclideID: "Cs-136", DisplayName: "Cesium-136", Element: "Cs", MassNumber: 136, HalfLife: "13.2 d", Category: "reactor", GammaLinesKeV: []float64{818.5, 1048.1}},
-	{NuclideID: "Cs-137", DisplayName: "Cesium-137", Element: "Cs", MassNumber: 137, HalfLife: "30.1 y", Category: "fallout", GammaLinesKeV: []float64{661.7}},
+	{NuclideID: "Cs-137", DisplayName: "Cesium-137", Element: "Cs", MassNumber: 137, HalfLife: "30.1 y", Category: "fallout", BetaMaxKeV: []float64{1176.0, 514.0}, GammaLinesKeV: []float64{661.7}},
 	{NuclideID: "Ba-133", DisplayName: "Barium-133", Element: "Ba", MassNumber: 133, HalfLife: "10.5 y", Category: "calibration", GammaLinesKeV: []float64{81.0, 356.0, 383.8}},
 	{NuclideID: "Ba-140", DisplayName: "Barium-140", Element: "Ba", MassNumber: 140, HalfLife: "12.8 d", Category: "fission", GammaLinesKeV: []float64{537.3}},
 	{NuclideID: "La-140", DisplayName: "Lanthanum-140", Element: "La", MassNumber: 140, HalfLife: "1.68 d", Category: "fission", GammaLinesKeV: []float64{487.0, 1596.2}},
@@ -229,7 +251,7 @@ var defaultNuclides = []Nuclide{
 	{NuclideID: "Po-210", DisplayName: "Polonium-210", Element: "Po", MassNumber: 210, HalfLife: "138.4 d", Category: "NORM"},
 	{NuclideID: "Ra-226", DisplayName: "Radium-226", Element: "Ra", MassNumber: 226, HalfLife: "1600 y", Category: "NORM", GammaLinesKeV: []float64{186.2}},
 	{NuclideID: "Ra-228", DisplayName: "Radium-228", Element: "Ra", MassNumber: 228, HalfLife: "5.75 y", Category: "NORM"},
-	{NuclideID: "Am-241", DisplayName: "Americium-241", Element: "Am", MassNumber: 241, HalfLife: "432.2 y", Category: "industrial", TypicalSource: "smoke detectors", GammaLinesKeV: []float64{59.5}},
+	{NuclideID: "Am-241", DisplayName: "Americium-241", Element: "Am", MassNumber: 241, HalfLife: "432.2 y", Category: "industrial", TypicalSource: "smoke detectors", AlphaLinesKeV: []float64{5485.6}, GammaLinesKeV: []float64{59.5}},
 	{NuclideID: "Am-243", DisplayName: "Americium-243", Element: "Am", MassNumber: 243, HalfLife: "7370 y", Category: "actinide"},
 	{NuclideID: "Cm-242", DisplayName: "Curium-242", Element: "Cm", MassNumber: 242, HalfLife: "163 d", Category: "actinide"},
 	{NuclideID: "Cm-244", DisplayName: "Curium-244", Element: "Cm", MassNumber: 244, HalfLife: "18.1 y", Category: "actinide"},

--- a/pkg/spectrum/catalog.go
+++ b/pkg/spectrum/catalog.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unicode"
 )
 
 // Nuclide stores isotope metadata independent from vendor format.
@@ -86,11 +87,11 @@ func normalizeNuclideToken(input string) (string, bool) {
 			return "", false
 		}
 		element := strings.Title(parts[0])
-		mass, err := strconv.Atoi(parts[1])
+		mass, metastableSuffix, err := parseMassAndMetastableSuffix(parts[1])
 		if err != nil {
 			return "", false
 		}
-		return fmt.Sprintf("%s-%d", element, mass), true
+		return fmt.Sprintf("%s-%d%s", element, mass, metastableSuffix), true
 	}
 
 	firstDigit := -1
@@ -105,27 +106,106 @@ func normalizeNuclideToken(input string) (string, bool) {
 	}
 
 	if firstDigit == 0 {
-		j := 0
-		for j < len(cleaned) && cleaned[j] >= '0' && cleaned[j] <= '9' {
-			j++
-		}
-		mass, err := strconv.Atoi(cleaned[:j])
+		mass, metastableSuffix, element, err := parseLeadingMassNotation(cleaned)
 		if err != nil {
 			return "", false
 		}
-		element := strings.Title(cleaned[j:])
 		if element == "" {
 			return "", false
 		}
-		return fmt.Sprintf("%s-%d", element, mass), true
+		return fmt.Sprintf("%s-%d%s", element, mass, metastableSuffix), true
 	}
 
 	element := strings.Title(cleaned[:firstDigit])
-	mass, err := strconv.Atoi(cleaned[firstDigit:])
+	mass, metastableSuffix, err := parseMassAndMetastableSuffix(cleaned[firstDigit:])
 	if err != nil {
 		return "", false
 	}
-	return fmt.Sprintf("%s-%d", element, mass), true
+	return fmt.Sprintf("%s-%d%s", element, mass, metastableSuffix), true
+}
+
+func parseMassAndMetastableSuffix(token string) (int, string, error) {
+	if token == "" {
+		return 0, "", fmt.Errorf("empty mass token")
+	}
+
+	digitEnd := 0
+	for digitEnd < len(token) && token[digitEnd] >= '0' && token[digitEnd] <= '9' {
+		digitEnd++
+	}
+	if digitEnd == 0 {
+		return 0, "", fmt.Errorf("missing mass number")
+	}
+
+	mass, err := strconv.Atoi(token[:digitEnd])
+	if err != nil {
+		return 0, "", err
+	}
+	if digitEnd == len(token) {
+		return mass, "", nil
+	}
+
+	suffix := strings.ToLower(token[digitEnd:])
+	if suffix != "m" {
+		return 0, "", fmt.Errorf("unsupported mass suffix")
+	}
+	return mass, suffix, nil
+}
+
+func splitElementAndMetastableSuffix(token string) (string, string, error) {
+	if token == "" {
+		return "", "", fmt.Errorf("empty element token")
+	}
+
+	metastableSuffix := ""
+	elementToken := token
+	if strings.HasSuffix(token, "m") {
+		elementToken = token[:len(token)-1]
+		metastableSuffix = "m"
+	}
+	if elementToken == "" {
+		return "", "", fmt.Errorf("missing element symbol")
+	}
+	for _, symbolRune := range elementToken {
+		if !unicode.IsLetter(symbolRune) {
+			return "", "", fmt.Errorf("invalid element symbol")
+		}
+	}
+
+	return strings.Title(elementToken), metastableSuffix, nil
+}
+
+func parseLeadingMassNotation(token string) (int, string, string, error) {
+	digitEnd := 0
+	for digitEnd < len(token) && token[digitEnd] >= '0' && token[digitEnd] <= '9' {
+		digitEnd++
+	}
+	if digitEnd == 0 || digitEnd == len(token) {
+		return 0, "", "", fmt.Errorf("invalid leading mass notation")
+	}
+
+	metastableSuffix := ""
+	elementStart := digitEnd
+	if token[elementStart] == 'm' {
+		metastableSuffix = "m"
+		elementStart++
+		if elementStart == len(token) {
+			return 0, "", "", fmt.Errorf("missing element symbol")
+		}
+	}
+
+	mass, err := strconv.Atoi(token[:digitEnd])
+	if err != nil {
+		return 0, "", "", err
+	}
+	element, extraMetastableSuffix, err := splitElementAndMetastableSuffix(token[elementStart:])
+	if err != nil {
+		return 0, "", "", err
+	}
+	if metastableSuffix == "" {
+		metastableSuffix = extraMetastableSuffix
+	}
+	return mass, metastableSuffix, element, nil
 }
 
 var defaultNuclides = []Nuclide{

--- a/pkg/spectrum/catalog.go
+++ b/pkg/spectrum/catalog.go
@@ -1,0 +1,266 @@
+package spectrum
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Nuclide stores isotope metadata independent from vendor format.
+type Nuclide struct {
+	NuclideID     string
+	DisplayName   string
+	Element       string
+	MassNumber    int
+	HalfLife      string
+	DecaySeries   string
+	Category      string
+	TypicalSource string
+	GammaLinesKeV []float64
+}
+
+// DefaultCatalog returns a broad catalog with natural chains, NORM and key artificial isotopes.
+func DefaultCatalog() []Nuclide {
+	out := make([]Nuclide, 0, len(defaultNuclides))
+	out = append(out, defaultNuclides...)
+	sort.Slice(out, func(i, j int) bool { return out[i].NuclideID < out[j].NuclideID })
+	return out
+}
+
+// FindNuclide normalizes common spellings: "Cs-137", "137Cs", "tritium".
+func FindNuclide(input string) (Nuclide, bool) {
+	normalized, ok := normalizeNuclideToken(input)
+	if !ok {
+		return Nuclide{}, false
+	}
+	for _, nuclide := range defaultNuclides {
+		if nuclide.NuclideID == normalized {
+			return nuclide, true
+		}
+	}
+	return Nuclide{}, false
+}
+
+func normalizeNuclideToken(input string) (string, bool) {
+	trimmed := strings.ToLower(strings.TrimSpace(input))
+	if trimmed == "" {
+		return "", false
+	}
+	aliases := map[string]string{
+		"tritium":      "H-3",
+		"radiocarbon":  "C-14",
+		"potassium-40": "K-40",
+		"radon":        "Rn-222",
+	}
+	if alias, ok := aliases[trimmed]; ok {
+		return alias, true
+	}
+
+	cleaned := strings.NewReplacer(" ", "", "_", "", "–", "-", ".", "").Replace(trimmed)
+	if strings.Contains(cleaned, "-") {
+		parts := strings.Split(cleaned, "-")
+		if len(parts) != 2 {
+			return "", false
+		}
+		element := strings.Title(parts[0])
+		mass, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return "", false
+		}
+		return fmt.Sprintf("%s-%d", element, mass), true
+	}
+
+	firstDigit := -1
+	for i, r := range cleaned {
+		if r >= '0' && r <= '9' {
+			firstDigit = i
+			break
+		}
+	}
+	if firstDigit == -1 {
+		return "", false
+	}
+
+	if firstDigit == 0 {
+		j := 0
+		for j < len(cleaned) && cleaned[j] >= '0' && cleaned[j] <= '9' {
+			j++
+		}
+		mass, err := strconv.Atoi(cleaned[:j])
+		if err != nil {
+			return "", false
+		}
+		element := strings.Title(cleaned[j:])
+		if element == "" {
+			return "", false
+		}
+		return fmt.Sprintf("%s-%d", element, mass), true
+	}
+
+	element := strings.Title(cleaned[:firstDigit])
+	mass, err := strconv.Atoi(cleaned[firstDigit:])
+	if err != nil {
+		return "", false
+	}
+	return fmt.Sprintf("%s-%d", element, mass), true
+}
+
+var defaultNuclides = []Nuclide{
+	{NuclideID: "H-3", DisplayName: "Tritium", Element: "H", MassNumber: 3, HalfLife: "12.32 y", Category: "cosmogenic", TypicalSource: "water, tritium signs"},
+	{NuclideID: "C-14", DisplayName: "Carbon-14", Element: "C", MassNumber: 14, HalfLife: "5730 y", Category: "cosmogenic"},
+	{NuclideID: "K-40", DisplayName: "Potassium-40", Element: "K", MassNumber: 40, HalfLife: "1.248e9 y", Category: "NORM", TypicalSource: "fertilizers, food, concrete", GammaLinesKeV: []float64{1460.8}},
+	{NuclideID: "Rb-87", DisplayName: "Rubidium-87", Element: "Rb", MassNumber: 87, HalfLife: "4.88e10 y", Category: "NORM"},
+	{NuclideID: "La-138", DisplayName: "Lanthanum-138", Element: "La", MassNumber: 138, HalfLife: "1.02e11 y", Category: "NORM", GammaLinesKeV: []float64{1435.8}},
+	{NuclideID: "Sm-147", DisplayName: "Samarium-147", Element: "Sm", MassNumber: 147, HalfLife: "1.06e11 y", Category: "NORM"},
+	{NuclideID: "Lu-176", DisplayName: "Lutetium-176", Element: "Lu", MassNumber: 176, HalfLife: "3.78e10 y", Category: "NORM", GammaLinesKeV: []float64{88.3, 202.9, 306.8}},
+	{NuclideID: "Re-187", DisplayName: "Rhenium-187", Element: "Re", MassNumber: 187, HalfLife: "4.12e10 y", Category: "NORM"},
+	{NuclideID: "In-115", DisplayName: "Indium-115", Element: "In", MassNumber: 115, HalfLife: "4.41e14 y", Category: "NORM"},
+	{NuclideID: "V-50", DisplayName: "Vanadium-50", Element: "V", MassNumber: 50, HalfLife: "1.4e17 y", Category: "NORM"},
+	{NuclideID: "Bi-209", DisplayName: "Bismuth-209", Element: "Bi", MassNumber: 209, HalfLife: "1.9e19 y", Category: "NORM"},
+
+	// Thorium-232 decay series (4n)
+	{NuclideID: "Th-232", DisplayName: "Thorium-232", Element: "Th", MassNumber: 232, HalfLife: "1.405e10 y", DecaySeries: "Th-232", Category: "NORM", TypicalSource: "monazite sands, welding electrodes"},
+	{NuclideID: "Ra-228", DisplayName: "Radium-228", Element: "Ra", MassNumber: 228, HalfLife: "5.75 y", DecaySeries: "Th-232", Category: "NORM"},
+	{NuclideID: "Ac-228", DisplayName: "Actinium-228", Element: "Ac", MassNumber: 228, HalfLife: "6.15 h", DecaySeries: "Th-232", Category: "NORM", GammaLinesKeV: []float64{338.3, 911.2, 969.0}},
+	{NuclideID: "Th-228", DisplayName: "Thorium-228", Element: "Th", MassNumber: 228, HalfLife: "1.91 y", DecaySeries: "Th-232", Category: "NORM"},
+	{NuclideID: "Ra-224", DisplayName: "Radium-224", Element: "Ra", MassNumber: 224, HalfLife: "3.66 d", DecaySeries: "Th-232", Category: "NORM"},
+	{NuclideID: "Rn-220", DisplayName: "Radon-220", Element: "Rn", MassNumber: 220, HalfLife: "55.6 s", DecaySeries: "Th-232", Category: "NORM"},
+	{NuclideID: "Po-216", DisplayName: "Polonium-216", Element: "Po", MassNumber: 216, HalfLife: "0.145 s", DecaySeries: "Th-232", Category: "NORM"},
+	{NuclideID: "Pb-212", DisplayName: "Lead-212", Element: "Pb", MassNumber: 212, HalfLife: "10.64 h", DecaySeries: "Th-232", Category: "NORM", GammaLinesKeV: []float64{238.6}},
+	{NuclideID: "Bi-212", DisplayName: "Bismuth-212", Element: "Bi", MassNumber: 212, HalfLife: "60.6 min", DecaySeries: "Th-232", Category: "NORM", GammaLinesKeV: []float64{727.3}},
+	{NuclideID: "Tl-208", DisplayName: "Thallium-208", Element: "Tl", MassNumber: 208, HalfLife: "3.05 min", DecaySeries: "Th-232", Category: "NORM", GammaLinesKeV: []float64{583.2, 2614.5}},
+	{NuclideID: "Po-212", DisplayName: "Polonium-212", Element: "Po", MassNumber: 212, HalfLife: "0.3 us", DecaySeries: "Th-232", Category: "NORM"},
+	{NuclideID: "Po-208", DisplayName: "Polonium-208", Element: "Po", MassNumber: 208, HalfLife: "2.9 y", DecaySeries: "Th-232", Category: "NORM"},
+	{NuclideID: "Pb-208", DisplayName: "Lead-208", Element: "Pb", MassNumber: 208, HalfLife: "stable", DecaySeries: "Th-232", Category: "stable-end"},
+
+	// Uranium-238 decay series (4n+2)
+	{NuclideID: "U-238", DisplayName: "Uranium-238", Element: "U", MassNumber: 238, HalfLife: "4.468e9 y", DecaySeries: "U-238", Category: "NORM", TypicalSource: "granite, phosphogypsum"},
+	{NuclideID: "Th-234", DisplayName: "Thorium-234", Element: "Th", MassNumber: 234, HalfLife: "24.1 d", DecaySeries: "U-238", Category: "NORM"},
+	{NuclideID: "Pa-234m", DisplayName: "Protactinium-234m", Element: "Pa", MassNumber: 234, HalfLife: "1.17 min", DecaySeries: "U-238", Category: "NORM"},
+	{NuclideID: "U-234", DisplayName: "Uranium-234", Element: "U", MassNumber: 234, HalfLife: "2.455e5 y", DecaySeries: "U-238", Category: "NORM"},
+	{NuclideID: "Th-230", DisplayName: "Thorium-230", Element: "Th", MassNumber: 230, HalfLife: "75380 y", DecaySeries: "U-238", Category: "NORM"},
+	{NuclideID: "Ra-226", DisplayName: "Radium-226", Element: "Ra", MassNumber: 226, HalfLife: "1600 y", DecaySeries: "U-238", Category: "NORM", GammaLinesKeV: []float64{186.2}},
+	{NuclideID: "Rn-222", DisplayName: "Radon-222", Element: "Rn", MassNumber: 222, HalfLife: "3.82 d", DecaySeries: "U-238", Category: "NORM", TypicalSource: "indoor air"},
+	{NuclideID: "Po-218", DisplayName: "Polonium-218", Element: "Po", MassNumber: 218, HalfLife: "3.1 min", DecaySeries: "U-238", Category: "NORM"},
+	{NuclideID: "Pb-214", DisplayName: "Lead-214", Element: "Pb", MassNumber: 214, HalfLife: "26.8 min", DecaySeries: "U-238", Category: "NORM", GammaLinesKeV: []float64{295.2, 351.9}},
+	{NuclideID: "Bi-214", DisplayName: "Bismuth-214", Element: "Bi", MassNumber: 214, HalfLife: "19.9 min", DecaySeries: "U-238", Category: "NORM", GammaLinesKeV: []float64{609.3, 1120.3, 1764.5}},
+	{NuclideID: "Po-214", DisplayName: "Polonium-214", Element: "Po", MassNumber: 214, HalfLife: "164 us", DecaySeries: "U-238", Category: "NORM"},
+	{NuclideID: "Pb-210", DisplayName: "Lead-210", Element: "Pb", MassNumber: 210, HalfLife: "22.3 y", DecaySeries: "U-238", Category: "NORM", GammaLinesKeV: []float64{46.5}},
+	{NuclideID: "Bi-210", DisplayName: "Bismuth-210", Element: "Bi", MassNumber: 210, HalfLife: "5.01 d", DecaySeries: "U-238", Category: "NORM"},
+	{NuclideID: "Po-210", DisplayName: "Polonium-210", Element: "Po", MassNumber: 210, HalfLife: "138.4 d", DecaySeries: "U-238", Category: "NORM"},
+	{NuclideID: "Pb-206", DisplayName: "Lead-206", Element: "Pb", MassNumber: 206, HalfLife: "stable", DecaySeries: "U-238", Category: "stable-end"},
+
+	// Uranium-235 / actinium series (4n+3)
+	{NuclideID: "U-235", DisplayName: "Uranium-235", Element: "U", MassNumber: 235, HalfLife: "7.04e8 y", DecaySeries: "U-235", Category: "NORM"},
+	{NuclideID: "Th-231", DisplayName: "Thorium-231", Element: "Th", MassNumber: 231, HalfLife: "25.5 h", DecaySeries: "U-235", Category: "NORM"},
+	{NuclideID: "Pa-231", DisplayName: "Protactinium-231", Element: "Pa", MassNumber: 231, HalfLife: "32760 y", DecaySeries: "U-235", Category: "NORM"},
+	{NuclideID: "Ac-227", DisplayName: "Actinium-227", Element: "Ac", MassNumber: 227, HalfLife: "21.8 y", DecaySeries: "U-235", Category: "NORM"},
+	{NuclideID: "Th-227", DisplayName: "Thorium-227", Element: "Th", MassNumber: 227, HalfLife: "18.7 d", DecaySeries: "U-235", Category: "NORM"},
+	{NuclideID: "Ra-223", DisplayName: "Radium-223", Element: "Ra", MassNumber: 223, HalfLife: "11.4 d", DecaySeries: "U-235", Category: "NORM"},
+	{NuclideID: "Rn-219", DisplayName: "Radon-219", Element: "Rn", MassNumber: 219, HalfLife: "3.96 s", DecaySeries: "U-235", Category: "NORM"},
+	{NuclideID: "Po-215", DisplayName: "Polonium-215", Element: "Po", MassNumber: 215, HalfLife: "1.78 ms", DecaySeries: "U-235", Category: "NORM"},
+	{NuclideID: "Pb-211", DisplayName: "Lead-211", Element: "Pb", MassNumber: 211, HalfLife: "36.1 min", DecaySeries: "U-235", Category: "NORM"},
+	{NuclideID: "Bi-211", DisplayName: "Bismuth-211", Element: "Bi", MassNumber: 211, HalfLife: "2.14 min", DecaySeries: "U-235", Category: "NORM"},
+	{NuclideID: "Tl-207", DisplayName: "Thallium-207", Element: "Tl", MassNumber: 207, HalfLife: "4.77 min", DecaySeries: "U-235", Category: "NORM"},
+	{NuclideID: "Pb-207", DisplayName: "Lead-207", Element: "Pb", MassNumber: 207, HalfLife: "stable", DecaySeries: "U-235", Category: "stable-end"},
+
+	// Neptunium series (4n+1)
+	{NuclideID: "Np-237", DisplayName: "Neptunium-237", Element: "Np", MassNumber: 237, HalfLife: "2.14e6 y", DecaySeries: "Np-237", Category: "artificial"},
+	{NuclideID: "Pa-233", DisplayName: "Protactinium-233", Element: "Pa", MassNumber: 233, HalfLife: "27 d", DecaySeries: "Np-237", Category: "artificial"},
+	{NuclideID: "U-233", DisplayName: "Uranium-233", Element: "U", MassNumber: 233, HalfLife: "1.592e5 y", DecaySeries: "Np-237", Category: "artificial"},
+	{NuclideID: "Th-229", DisplayName: "Thorium-229", Element: "Th", MassNumber: 229, HalfLife: "7932 y", DecaySeries: "Np-237", Category: "artificial"},
+	{NuclideID: "Ra-225", DisplayName: "Radium-225", Element: "Ra", MassNumber: 225, HalfLife: "14.9 d", DecaySeries: "Np-237", Category: "artificial"},
+	{NuclideID: "Ac-225", DisplayName: "Actinium-225", Element: "Ac", MassNumber: 225, HalfLife: "10 d", DecaySeries: "Np-237", Category: "medical"},
+	{NuclideID: "Fr-221", DisplayName: "Francium-221", Element: "Fr", MassNumber: 221, HalfLife: "4.8 min", DecaySeries: "Np-237", Category: "artificial"},
+	{NuclideID: "At-217", DisplayName: "Astatine-217", Element: "At", MassNumber: 217, HalfLife: "32 ms", DecaySeries: "Np-237", Category: "artificial"},
+	{NuclideID: "Bi-213", DisplayName: "Bismuth-213", Element: "Bi", MassNumber: 213, HalfLife: "45.6 min", DecaySeries: "Np-237", Category: "medical", GammaLinesKeV: []float64{440.5}},
+	{NuclideID: "Po-213", DisplayName: "Polonium-213", Element: "Po", MassNumber: 213, HalfLife: "4.2 us", DecaySeries: "Np-237", Category: "artificial"},
+	{NuclideID: "Tl-209", DisplayName: "Thallium-209", Element: "Tl", MassNumber: 209, HalfLife: "2.2 min", DecaySeries: "Np-237", Category: "artificial"},
+	{NuclideID: "Pb-209", DisplayName: "Lead-209", Element: "Pb", MassNumber: 209, HalfLife: "3.25 h", DecaySeries: "Np-237", Category: "artificial"},
+	{NuclideID: "Bi-209m", DisplayName: "Bismuth-209m", Element: "Bi", MassNumber: 209, HalfLife: "stable", DecaySeries: "Np-237", Category: "stable-end"},
+
+	// Common environmental and industrial isotopes
+	{NuclideID: "Be-7", DisplayName: "Beryllium-7", Element: "Be", MassNumber: 7, HalfLife: "53.2 d", Category: "cosmogenic", GammaLinesKeV: []float64{477.6}},
+	{NuclideID: "Na-22", DisplayName: "Sodium-22", Element: "Na", MassNumber: 22, HalfLife: "2.6 y", Category: "industrial", GammaLinesKeV: []float64{511.0, 1274.5}},
+	{NuclideID: "Na-24", DisplayName: "Sodium-24", Element: "Na", MassNumber: 24, HalfLife: "15 h", Category: "reactor", GammaLinesKeV: []float64{1368.6, 2754.0}},
+	{NuclideID: "Co-57", DisplayName: "Cobalt-57", Element: "Co", MassNumber: 57, HalfLife: "271.8 d", Category: "calibration", GammaLinesKeV: []float64{122.1, 136.5}},
+	{NuclideID: "Co-58", DisplayName: "Cobalt-58", Element: "Co", MassNumber: 58, HalfLife: "70.9 d", Category: "activation", GammaLinesKeV: []float64{810.8}},
+	{NuclideID: "Co-60", DisplayName: "Cobalt-60", Element: "Co", MassNumber: 60, HalfLife: "5.27 y", Category: "industrial", GammaLinesKeV: []float64{1173.2, 1332.5}},
+	{NuclideID: "Zn-65", DisplayName: "Zinc-65", Element: "Zn", MassNumber: 65, HalfLife: "244 d", Category: "activation", GammaLinesKeV: []float64{1115.5}},
+	{NuclideID: "Se-75", DisplayName: "Selenium-75", Element: "Se", MassNumber: 75, HalfLife: "119.8 d", Category: "industrial", GammaLinesKeV: []float64{136.0, 264.7}},
+	{NuclideID: "Kr-85", DisplayName: "Krypton-85", Element: "Kr", MassNumber: 85, HalfLife: "10.7 y", Category: "reprocessing"},
+	{NuclideID: "Sr-89", DisplayName: "Strontium-89", Element: "Sr", MassNumber: 89, HalfLife: "50.5 d", Category: "medical"},
+	{NuclideID: "Sr-90", DisplayName: "Strontium-90", Element: "Sr", MassNumber: 90, HalfLife: "28.8 y", Category: "fallout"},
+	{NuclideID: "Y-90", DisplayName: "Yttrium-90", Element: "Y", MassNumber: 90, HalfLife: "64 h", Category: "medical"},
+	{NuclideID: "Zr-95", DisplayName: "Zirconium-95", Element: "Zr", MassNumber: 95, HalfLife: "64 d", Category: "fission", GammaLinesKeV: []float64{724.2, 756.7}},
+	{NuclideID: "Nb-95", DisplayName: "Niobium-95", Element: "Nb", MassNumber: 95, HalfLife: "35 d", Category: "fission", GammaLinesKeV: []float64{765.8}},
+	{NuclideID: "Mo-99", DisplayName: "Molybdenum-99", Element: "Mo", MassNumber: 99, HalfLife: "66 h", Category: "medical", GammaLinesKeV: []float64{739.5}},
+	{NuclideID: "Tc-99m", DisplayName: "Technetium-99m", Element: "Tc", MassNumber: 99, HalfLife: "6 h", Category: "medical", GammaLinesKeV: []float64{140.5}},
+	{NuclideID: "Ru-103", DisplayName: "Ruthenium-103", Element: "Ru", MassNumber: 103, HalfLife: "39.3 d", Category: "fission", GammaLinesKeV: []float64{497.1}},
+	{NuclideID: "Ru-106", DisplayName: "Ruthenium-106", Element: "Ru", MassNumber: 106, HalfLife: "373.6 d", Category: "fission"},
+	{NuclideID: "Ag-110m", DisplayName: "Silver-110m", Element: "Ag", MassNumber: 110, HalfLife: "249.8 d", Category: "fission", GammaLinesKeV: []float64{657.8, 884.7, 937.5}},
+	{NuclideID: "Cd-109", DisplayName: "Cadmium-109", Element: "Cd", MassNumber: 109, HalfLife: "462 d", Category: "calibration", GammaLinesKeV: []float64{88.0}},
+	{NuclideID: "Sb-124", DisplayName: "Antimony-124", Element: "Sb", MassNumber: 124, HalfLife: "60.2 d", Category: "activation", GammaLinesKeV: []float64{602.7, 1690.9}},
+	{NuclideID: "Sb-125", DisplayName: "Antimony-125", Element: "Sb", MassNumber: 125, HalfLife: "2.76 y", Category: "fission", GammaLinesKeV: []float64{427.9, 600.6}},
+	{NuclideID: "I-123", DisplayName: "Iodine-123", Element: "I", MassNumber: 123, HalfLife: "13.2 h", Category: "medical", GammaLinesKeV: []float64{159.0}},
+	{NuclideID: "I-125", DisplayName: "Iodine-125", Element: "I", MassNumber: 125, HalfLife: "59.4 d", Category: "medical", GammaLinesKeV: []float64{35.5}},
+	{NuclideID: "I-129", DisplayName: "Iodine-129", Element: "I", MassNumber: 129, HalfLife: "1.57e7 y", Category: "fission"},
+	{NuclideID: "I-131", DisplayName: "Iodine-131", Element: "I", MassNumber: 131, HalfLife: "8.02 d", Category: "fission", GammaLinesKeV: []float64{364.5, 637.0}},
+	{NuclideID: "Cs-134", DisplayName: "Cesium-134", Element: "Cs", MassNumber: 134, HalfLife: "2.06 y", Category: "reactor", GammaLinesKeV: []float64{569.3, 604.7, 795.8, 801.9}},
+	{NuclideID: "Cs-136", DisplayName: "Cesium-136", Element: "Cs", MassNumber: 136, HalfLife: "13.2 d", Category: "reactor", GammaLinesKeV: []float64{818.5, 1048.1}},
+	{NuclideID: "Cs-137", DisplayName: "Cesium-137", Element: "Cs", MassNumber: 137, HalfLife: "30.1 y", Category: "fallout", GammaLinesKeV: []float64{661.7}},
+	{NuclideID: "Ba-133", DisplayName: "Barium-133", Element: "Ba", MassNumber: 133, HalfLife: "10.5 y", Category: "calibration", GammaLinesKeV: []float64{81.0, 356.0, 383.8}},
+	{NuclideID: "Ba-140", DisplayName: "Barium-140", Element: "Ba", MassNumber: 140, HalfLife: "12.8 d", Category: "fission", GammaLinesKeV: []float64{537.3}},
+	{NuclideID: "La-140", DisplayName: "Lanthanum-140", Element: "La", MassNumber: 140, HalfLife: "1.68 d", Category: "fission", GammaLinesKeV: []float64{487.0, 1596.2}},
+	{NuclideID: "Ce-141", DisplayName: "Cerium-141", Element: "Ce", MassNumber: 141, HalfLife: "32.5 d", Category: "fission", GammaLinesKeV: []float64{145.4}},
+	{NuclideID: "Ce-144", DisplayName: "Cerium-144", Element: "Ce", MassNumber: 144, HalfLife: "284.9 d", Category: "fission"},
+	{NuclideID: "Pr-144", DisplayName: "Praseodymium-144", Element: "Pr", MassNumber: 144, HalfLife: "17.3 min", Category: "fission", GammaLinesKeV: []float64{696.5, 1489.0}},
+	{NuclideID: "Eu-152", DisplayName: "Europium-152", Element: "Eu", MassNumber: 152, HalfLife: "13.5 y", Category: "calibration", GammaLinesKeV: []float64{121.8, 244.7, 344.3, 778.9, 964.1, 1408.0}},
+	{NuclideID: "Eu-154", DisplayName: "Europium-154", Element: "Eu", MassNumber: 154, HalfLife: "8.6 y", Category: "fission", GammaLinesKeV: []float64{723.3, 873.2, 1004.7, 1274.4}},
+	{NuclideID: "Eu-155", DisplayName: "Europium-155", Element: "Eu", MassNumber: 155, HalfLife: "4.76 y", Category: "fission", GammaLinesKeV: []float64{86.5, 105.3}},
+	{NuclideID: "Gd-153", DisplayName: "Gadolinium-153", Element: "Gd", MassNumber: 153, HalfLife: "240 d", Category: "calibration", GammaLinesKeV: []float64{97.4, 103.2}},
+	{NuclideID: "Tb-160", DisplayName: "Terbium-160", Element: "Tb", MassNumber: 160, HalfLife: "72.3 d", Category: "activation", GammaLinesKeV: []float64{879.4, 966.2}},
+	{NuclideID: "Ir-192", DisplayName: "Iridium-192", Element: "Ir", MassNumber: 192, HalfLife: "73.8 d", Category: "industrial", GammaLinesKeV: []float64{295.9, 308.5, 316.5, 468.1, 604.4}},
+	{NuclideID: "Au-198", DisplayName: "Gold-198", Element: "Au", MassNumber: 198, HalfLife: "2.69 d", Category: "activation", GammaLinesKeV: []float64{411.8}},
+	{NuclideID: "Hg-203", DisplayName: "Mercury-203", Element: "Hg", MassNumber: 203, HalfLife: "46.6 d", Category: "activation", GammaLinesKeV: []float64{279.2}},
+	{NuclideID: "Tl-201", DisplayName: "Thallium-201", Element: "Tl", MassNumber: 201, HalfLife: "73 h", Category: "medical", GammaLinesKeV: []float64{135.3, 167.4}},
+	{NuclideID: "Pb-203", DisplayName: "Lead-203", Element: "Pb", MassNumber: 203, HalfLife: "51.9 h", Category: "medical", GammaLinesKeV: []float64{279.2}},
+	{NuclideID: "Po-210", DisplayName: "Polonium-210", Element: "Po", MassNumber: 210, HalfLife: "138.4 d", Category: "NORM"},
+	{NuclideID: "Ra-226", DisplayName: "Radium-226", Element: "Ra", MassNumber: 226, HalfLife: "1600 y", Category: "NORM", GammaLinesKeV: []float64{186.2}},
+	{NuclideID: "Ra-228", DisplayName: "Radium-228", Element: "Ra", MassNumber: 228, HalfLife: "5.75 y", Category: "NORM"},
+	{NuclideID: "Am-241", DisplayName: "Americium-241", Element: "Am", MassNumber: 241, HalfLife: "432.2 y", Category: "industrial", TypicalSource: "smoke detectors", GammaLinesKeV: []float64{59.5}},
+	{NuclideID: "Am-243", DisplayName: "Americium-243", Element: "Am", MassNumber: 243, HalfLife: "7370 y", Category: "actinide"},
+	{NuclideID: "Cm-242", DisplayName: "Curium-242", Element: "Cm", MassNumber: 242, HalfLife: "163 d", Category: "actinide"},
+	{NuclideID: "Cm-244", DisplayName: "Curium-244", Element: "Cm", MassNumber: 244, HalfLife: "18.1 y", Category: "actinide"},
+	{NuclideID: "Pu-238", DisplayName: "Plutonium-238", Element: "Pu", MassNumber: 238, HalfLife: "87.7 y", Category: "actinide"},
+	{NuclideID: "Pu-239", DisplayName: "Plutonium-239", Element: "Pu", MassNumber: 239, HalfLife: "24110 y", Category: "actinide", GammaLinesKeV: []float64{129.3}},
+	{NuclideID: "Pu-240", DisplayName: "Plutonium-240", Element: "Pu", MassNumber: 240, HalfLife: "6561 y", Category: "actinide"},
+	{NuclideID: "Pu-241", DisplayName: "Plutonium-241", Element: "Pu", MassNumber: 241, HalfLife: "14.3 y", Category: "actinide"},
+	{NuclideID: "Pu-242", DisplayName: "Plutonium-242", Element: "Pu", MassNumber: 242, HalfLife: "3.75e5 y", Category: "actinide"},
+	{NuclideID: "Np-239", DisplayName: "Neptunium-239", Element: "Np", MassNumber: 239, HalfLife: "2.36 d", Category: "reactor", GammaLinesKeV: []float64{106.1, 228.2}},
+	{NuclideID: "Cf-252", DisplayName: "Californium-252", Element: "Cf", MassNumber: 252, HalfLife: "2.65 y", Category: "neutron source"},
+
+	// Heavy transuranics for completeness envelope.
+	{NuclideID: "Bk-249", DisplayName: "Berkelium-249", Element: "Bk", MassNumber: 249, HalfLife: "330 d", Category: "transuranic"},
+	{NuclideID: "Es-254", DisplayName: "Einsteinium-254", Element: "Es", MassNumber: 254, HalfLife: "276 d", Category: "transuranic"},
+	{NuclideID: "Fm-257", DisplayName: "Fermium-257", Element: "Fm", MassNumber: 257, HalfLife: "100 d", Category: "transuranic"},
+	{NuclideID: "Md-258", DisplayName: "Mendelevium-258", Element: "Md", MassNumber: 258, HalfLife: "51.5 d", Category: "transuranic"},
+	{NuclideID: "No-259", DisplayName: "Nobelium-259", Element: "No", MassNumber: 259, HalfLife: "58 min", Category: "transuranic"},
+	{NuclideID: "Lr-262", DisplayName: "Lawrencium-262", Element: "Lr", MassNumber: 262, HalfLife: "3.6 h", Category: "transuranic"},
+	{NuclideID: "Rf-267", DisplayName: "Rutherfordium-267", Element: "Rf", MassNumber: 267, HalfLife: "1.3 h", Category: "superheavy"},
+	{NuclideID: "Db-268", DisplayName: "Dubnium-268", Element: "Db", MassNumber: 268, HalfLife: "29 h", Category: "superheavy"},
+	{NuclideID: "Sg-271", DisplayName: "Seaborgium-271", Element: "Sg", MassNumber: 271, HalfLife: "2.4 min", Category: "superheavy"},
+	{NuclideID: "Bh-270", DisplayName: "Bohrium-270", Element: "Bh", MassNumber: 270, HalfLife: "61 s", Category: "superheavy"},
+	{NuclideID: "Hs-277", DisplayName: "Hassium-277", Element: "Hs", MassNumber: 277, HalfLife: "11 min", Category: "superheavy"},
+	{NuclideID: "Mt-278", DisplayName: "Meitnerium-278", Element: "Mt", MassNumber: 278, HalfLife: "8 s", Category: "superheavy"},
+	{NuclideID: "Ds-281", DisplayName: "Darmstadtium-281", Element: "Ds", MassNumber: 281, HalfLife: "10 s", Category: "superheavy"},
+	{NuclideID: "Rg-282", DisplayName: "Roentgenium-282", Element: "Rg", MassNumber: 282, HalfLife: "2.1 min", Category: "superheavy"},
+	{NuclideID: "Cn-285", DisplayName: "Copernicium-285", Element: "Cn", MassNumber: 285, HalfLife: "29 s", Category: "superheavy"},
+	{NuclideID: "Nh-286", DisplayName: "Nihonium-286", Element: "Nh", MassNumber: 286, HalfLife: "20 s", Category: "superheavy"},
+	{NuclideID: "Fl-289", DisplayName: "Flerovium-289", Element: "Fl", MassNumber: 289, HalfLife: "2.6 s", Category: "superheavy"},
+	{NuclideID: "Mc-290", DisplayName: "Moscovium-290", Element: "Mc", MassNumber: 290, HalfLife: "0.65 s", Category: "superheavy"},
+	{NuclideID: "Lv-293", DisplayName: "Livermorium-293", Element: "Lv", MassNumber: 293, HalfLife: "61 ms", Category: "superheavy"},
+	{NuclideID: "Ts-294", DisplayName: "Tennessine-294", Element: "Ts", MassNumber: 294, HalfLife: "21 ms", Category: "superheavy"},
+	{NuclideID: "Og-294", DisplayName: "Oganesson-294", Element: "Og", MassNumber: 294, HalfLife: "0.69 ms", Category: "superheavy"},
+}

--- a/pkg/spectrum/driver_radiacode.go
+++ b/pkg/spectrum/driver_radiacode.go
@@ -1,0 +1,96 @@
+package spectrum
+
+import (
+	"encoding/xml"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// RadiacodeXMLDriver parses ResultDataFile XML exports.
+type RadiacodeXMLDriver struct{}
+
+func (RadiacodeXMLDriver) Name() string { return "radiacode-xml" }
+
+func (RadiacodeXMLDriver) CanParse(raw []byte) bool {
+	return byteContainsFold(raw, "<ResultDataFile") && byteContainsFold(raw, "<EnergySpectrum")
+}
+
+func (RadiacodeXMLDriver) Parse(raw []byte) (SpectrumMeasurement, error) {
+	var document radiacodeResultDataFile
+	if err := xml.Unmarshal(raw, &document); err != nil {
+		return SpectrumMeasurement{}, fmt.Errorf("xml unmarshal: %w", err)
+	}
+	if len(document.ResultDataList.Items) == 0 {
+		return SpectrumMeasurement{}, fmt.Errorf("empty ResultData list")
+	}
+
+	entry := document.ResultDataList.Items[0]
+	if len(entry.EnergySpectrum.Spectrum.Data) == 0 {
+		return SpectrumMeasurement{}, fmt.Errorf("empty spectrum data")
+	}
+	if len(entry.EnergySpectrum.EnergyCalibration.Coefficients.Values) < 2 {
+		return SpectrumMeasurement{}, fmt.Errorf("insufficient calibration coefficients")
+	}
+
+	startTime, err := parseXMLTime(entry.StartTime)
+	if err != nil {
+		return SpectrumMeasurement{}, err
+	}
+	endTime, err := parseXMLTime(entry.EndTime)
+	if err != nil {
+		return SpectrumMeasurement{}, err
+	}
+
+	return SpectrumMeasurement{
+		Format:         "radiacode-xml",
+		DeviceName:     strings.TrimSpace(entry.DeviceConfigReference.Name),
+		DeviceSerial:   strings.TrimSpace(entry.EnergySpectrum.SerialNumber),
+		StartTime:      startTime,
+		EndTime:        endTime,
+		MeasurementSec: entry.EnergySpectrum.MeasurementTime,
+		Channels:       append([]float64(nil), entry.EnergySpectrum.Spectrum.Data...),
+		Coefficients:   append([]float64(nil), entry.EnergySpectrum.EnergyCalibration.Coefficients.Values...),
+	}, nil
+}
+
+type radiacodeResultDataFile struct {
+	XMLName        xml.Name            `xml:"ResultDataFile"`
+	ResultDataList radiacodeResultList `xml:"ResultDataList"`
+}
+
+type radiacodeResultList struct {
+	Items []radiacodeResultItem `xml:"ResultData"`
+}
+
+type radiacodeResultItem struct {
+	DeviceConfigReference struct {
+		Name string `xml:"Name"`
+	} `xml:"DeviceConfigReference"`
+	StartTime      string `xml:"StartTime"`
+	EndTime        string `xml:"EndTime"`
+	EnergySpectrum struct {
+		SerialNumber      string `xml:"SerialNumber"`
+		MeasurementTime   int64  `xml:"MeasurementTime"`
+		EnergyCalibration struct {
+			Coefficients struct {
+				Values []float64 `xml:"Coefficient"`
+			} `xml:"Coefficients"`
+		} `xml:"EnergyCalibration"`
+		Spectrum struct {
+			Data []float64 `xml:"DataPoint"`
+		} `xml:"Spectrum"`
+	} `xml:"EnergySpectrum"`
+}
+
+func parseXMLTime(raw string) (time.Time, error) {
+	trimmed := strings.TrimSpace(raw)
+	layouts := []string{time.RFC3339, "2006-01-02T15:04:05"}
+	for _, layout := range layouts {
+		parsedTime, err := time.Parse(layout, trimmed)
+		if err == nil {
+			return parsedTime.UTC(), nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("parse time %q", raw)
+}

--- a/pkg/spectrum/drivers.go
+++ b/pkg/spectrum/drivers.go
@@ -1,0 +1,36 @@
+package spectrum
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// Driver parses one concrete spectrum format into the shared model.
+type Driver interface {
+	Name() string
+	CanParse(raw []byte) bool
+	Parse(raw []byte) (SpectrumMeasurement, error)
+}
+
+// ParseWithKnownDrivers tries built-in drivers in order.
+func ParseWithKnownDrivers(raw []byte) (SpectrumMeasurement, error) {
+	for _, driver := range builtInDrivers() {
+		if !driver.CanParse(raw) {
+			continue
+		}
+		measurement, err := driver.Parse(raw)
+		if err != nil {
+			return SpectrumMeasurement{}, fmt.Errorf("parse with %s: %w", driver.Name(), err)
+		}
+		return measurement, nil
+	}
+	return SpectrumMeasurement{}, fmt.Errorf("unsupported spectrum format")
+}
+
+func builtInDrivers() []Driver {
+	return []Driver{RadiacodeXMLDriver{}}
+}
+
+func byteContainsFold(haystack []byte, needle string) bool {
+	return bytes.Contains(bytes.ToLower(haystack), bytes.ToLower([]byte(needle)))
+}

--- a/pkg/spectrum/model.go
+++ b/pkg/spectrum/model.go
@@ -31,20 +31,32 @@ type Peak struct {
 
 // IsotopeHit keeps a matched isotope candidate with confidence score.
 type IsotopeHit struct {
-	Name       string
-	NuclideID  string
-	EnergyKeV  float64
-	PeakEnergy float64
-	DeltaKeV   float64
-	Confidence float64
-	Series     string
+	Name          string
+	NuclideID     string
+	RadiationType string
+	EnergyKeV     float64
+	PeakEnergy    float64
+	DeltaKeV      float64
+	Confidence    float64
+	Series        string
+}
+
+// CompositeHit describes a mixed-spectrum hypothesis where multiple nuclides
+// explain one measured peak set.
+type CompositeHit struct {
+	NuclideIDs   []string
+	Coverage     float64
+	ResidualKeV  float64
+	TotalScore   float64
+	MatchedPeaks int
 }
 
 // Analysis bundles parsed spectrum and lookup results.
 type Analysis struct {
-	Measurement   SpectrumMeasurement
-	DetectedPeaks []Peak
-	Isotopes      []IsotopeHit
+	Measurement     SpectrumMeasurement
+	DetectedPeaks   []Peak
+	Isotopes        []IsotopeHit
+	CompositeModels []CompositeHit
 }
 
 // MarkerMatch reports which marker is closest in time to the spectrum window.

--- a/pkg/spectrum/model.go
+++ b/pkg/spectrum/model.go
@@ -51,12 +51,24 @@ type CompositeHit struct {
 	MatchedPeaks int
 }
 
+// SpectrumComponent keeps a coarse-grained component estimate that is stable
+// on low-resolution detectors. We intentionally model families (K-40, U/Ra,
+// Th-series, etc.) rather than claiming exact isotope fractions.
+type SpectrumComponent struct {
+	ComponentID      string
+	DisplayName      string
+	Contribution     float64
+	MatchedLines     int
+	AverageLineError float64
+}
+
 // Analysis bundles parsed spectrum and lookup results.
 type Analysis struct {
 	Measurement     SpectrumMeasurement
 	DetectedPeaks   []Peak
 	Isotopes        []IsotopeHit
 	CompositeModels []CompositeHit
+	Components      []SpectrumComponent
 }
 
 // MarkerMatch reports which marker is closest in time to the spectrum window.

--- a/pkg/spectrum/model.go
+++ b/pkg/spectrum/model.go
@@ -62,6 +62,18 @@ type SpectrumComponent struct {
 	AverageLineError float64
 }
 
+// GroupCheck tracks whether a practical isotope group has enough line evidence
+// to be considered confirmed on low-resolution detectors.
+type GroupCheck struct {
+	GroupID      string
+	DisplayName  string
+	MatchedLines []float64
+	MissingLines []float64
+	Confidence   float64
+	IsConfirmed  bool
+	Comment      string
+}
+
 // Analysis bundles parsed spectrum and lookup results.
 type Analysis struct {
 	Measurement     SpectrumMeasurement
@@ -69,6 +81,8 @@ type Analysis struct {
 	Isotopes        []IsotopeHit
 	CompositeModels []CompositeHit
 	Components      []SpectrumComponent
+	GroupChecks     []GroupCheck
+	Explanation     string
 }
 
 // MarkerMatch reports which marker is closest in time to the spectrum window.

--- a/pkg/spectrum/model.go
+++ b/pkg/spectrum/model.go
@@ -1,0 +1,56 @@
+package spectrum
+
+import "time"
+
+// MarkerTimePoint keeps the minimum track fields needed to link a spectrum to map points.
+type MarkerTimePoint struct {
+	Date int64
+	Lat  float64
+	Lon  float64
+}
+
+// SpectrumMeasurement is the common model produced by all instrument drivers.
+// Keeping one shape lets isotope analysis stay device-agnostic.
+type SpectrumMeasurement struct {
+	Format         string
+	DeviceName     string
+	DeviceSerial   string
+	StartTime      time.Time
+	EndTime        time.Time
+	MeasurementSec int64
+	Channels       []float64
+	Coefficients   []float64
+}
+
+// Peak describes one identified spectral peak candidate.
+type Peak struct {
+	Channel int
+	Energy  float64
+	Counts  float64
+}
+
+// IsotopeHit keeps a matched isotope candidate with confidence score.
+type IsotopeHit struct {
+	Name       string
+	NuclideID  string
+	EnergyKeV  float64
+	PeakEnergy float64
+	DeltaKeV   float64
+	Confidence float64
+	Series     string
+}
+
+// Analysis bundles parsed spectrum and lookup results.
+type Analysis struct {
+	Measurement   SpectrumMeasurement
+	DetectedPeaks []Peak
+	Isotopes      []IsotopeHit
+}
+
+// MarkerMatch reports which marker is closest in time to the spectrum window.
+type MarkerMatch struct {
+	Marker             MarkerTimePoint
+	AbsoluteDeltaSec   int64
+	WithinWindow       bool
+	WithinWindowMargin bool
+}

--- a/pkg/spectrum/radiacode.go
+++ b/pkg/spectrum/radiacode.go
@@ -1,0 +1,4 @@
+package spectrum
+
+// This file intentionally keeps package entrypoint names stable.
+// The implementation lives in driver_radiacode.go and analysis.go.

--- a/pkg/spectrum/radiacode_test.go
+++ b/pkg/spectrum/radiacode_test.go
@@ -140,4 +140,10 @@ func TestRadiationTypesAndCompositeModel(t *testing.T) {
 	if analysis.Components[0].Contribution <= 0 {
 		t.Fatalf("expected non-zero leading component contribution")
 	}
+	if len(analysis.GroupChecks) == 0 {
+		t.Fatalf("expected practical group checks")
+	}
+	if analysis.Explanation == "" {
+		t.Fatalf("expected plain-language explanation")
+	}
 }

--- a/pkg/spectrum/radiacode_test.go
+++ b/pkg/spectrum/radiacode_test.go
@@ -90,3 +90,33 @@ func TestFindNuclideAlias(t *testing.T) {
 		t.Fatalf("expected normalized Cs-137, got %+v", nuclide)
 	}
 }
+
+func TestRadiationTypesAndCompositeModel(t *testing.T) {
+	measurement := SpectrumMeasurement{
+		Coefficients: []float64{0, 1},
+		Channels:     make([]float64, 1700),
+	}
+	measurement.Channels[59] = 10 // Am-241 gamma 59.5
+	measurement.Channels[60] = 1
+	measurement.Channels[661] = 9 // Cs-137 gamma 661.7
+	measurement.Channels[662] = 1
+	measurement.Channels[1460] = 8 // K-40 gamma 1460.8 (clipped by channel size in this synthetic test)
+
+	analysis := AnalyzeMeasurement(measurement)
+	if len(analysis.Isotopes) == 0 {
+		t.Fatalf("expected isotope hits")
+	}
+	foundGamma := false
+	for _, hit := range analysis.Isotopes {
+		if hit.RadiationType == "gamma" {
+			foundGamma = true
+			break
+		}
+	}
+	if !foundGamma {
+		t.Fatalf("expected gamma radiation type in hits")
+	}
+	if len(analysis.CompositeModels) == 0 {
+		t.Fatalf("expected composite models for mixed spectrum")
+	}
+}

--- a/pkg/spectrum/radiacode_test.go
+++ b/pkg/spectrum/radiacode_test.go
@@ -89,6 +89,21 @@ func TestFindNuclideAlias(t *testing.T) {
 	if !ok || nuclide.NuclideID != "Cs-137" {
 		t.Fatalf("expected normalized Cs-137, got %+v", nuclide)
 	}
+
+	nuclide, ok = FindNuclide("Tc-99m")
+	if !ok || nuclide.NuclideID != "Tc-99m" {
+		t.Fatalf("expected normalized Tc-99m, got %+v", nuclide)
+	}
+
+	nuclide, ok = FindNuclide("99mTc")
+	if !ok || nuclide.NuclideID != "Tc-99m" {
+		t.Fatalf("expected normalized 99mTc -> Tc-99m, got %+v", nuclide)
+	}
+
+	nuclide, ok = FindNuclide("Pa-234m")
+	if !ok || nuclide.NuclideID != "Pa-234m" {
+		t.Fatalf("expected normalized Pa-234m, got %+v", nuclide)
+	}
 }
 
 func TestRadiationTypesAndCompositeModel(t *testing.T) {

--- a/pkg/spectrum/radiacode_test.go
+++ b/pkg/spectrum/radiacode_test.go
@@ -134,4 +134,10 @@ func TestRadiationTypesAndCompositeModel(t *testing.T) {
 	if len(analysis.CompositeModels) == 0 {
 		t.Fatalf("expected composite models for mixed spectrum")
 	}
+	if len(analysis.Components) == 0 {
+		t.Fatalf("expected coarse component estimation")
+	}
+	if analysis.Components[0].Contribution <= 0 {
+		t.Fatalf("expected non-zero leading component contribution")
+	}
 }

--- a/pkg/spectrum/radiacode_test.go
+++ b/pkg/spectrum/radiacode_test.go
@@ -1,0 +1,92 @@
+package spectrum
+
+import "testing"
+
+func TestAnalyzeRadiacodeXML(t *testing.T) {
+	xmlInput := []byte(`<?xml version="1.0"?>
+<ResultDataFile>
+  <ResultDataList>
+    <ResultData>
+      <DeviceConfigReference><Name>RadiaCode-101</Name></DeviceConfigReference>
+      <StartTime>2026-04-06T16:03:38</StartTime>
+      <EndTime>2026-04-06T16:13:24</EndTime>
+      <EnergySpectrum>
+        <SerialNumber>RC-101-005020</SerialNumber>
+        <MeasurementTime>586</MeasurementTime>
+        <EnergyCalibration>
+          <Coefficients>
+            <Coefficient>-8.075389</Coefficient>
+            <Coefficient>2.5978222</Coefficient>
+            <Coefficient>0.00052667724</Coefficient>
+          </Coefficients>
+        </EnergyCalibration>
+        <Spectrum>
+          <DataPoint>0</DataPoint><DataPoint>3</DataPoint><DataPoint>14</DataPoint><DataPoint>3</DataPoint>
+          <DataPoint>2</DataPoint><DataPoint>10</DataPoint><DataPoint>2</DataPoint><DataPoint>0</DataPoint>
+          <DataPoint>2</DataPoint><DataPoint>12</DataPoint><DataPoint>2</DataPoint><DataPoint>0</DataPoint>
+        </Spectrum>
+      </EnergySpectrum>
+    </ResultData>
+  </ResultDataList>
+</ResultDataFile>`)
+
+	analysis, err := AnalyzeRadiacodeXML(xmlInput)
+	if err != nil {
+		t.Fatalf("AnalyzeRadiacodeXML returned error: %v", err)
+	}
+	if analysis.Measurement.DeviceSerial != "RC-101-005020" {
+		t.Fatalf("unexpected serial: %s", analysis.Measurement.DeviceSerial)
+	}
+	if analysis.Measurement.StartTime.IsZero() || analysis.Measurement.EndTime.IsZero() {
+		t.Fatalf("expected parsed timestamps")
+	}
+	if len(analysis.DetectedPeaks) == 0 {
+		t.Fatalf("expected detected peaks")
+	}
+}
+
+func TestParseWithKnownDrivers(t *testing.T) {
+	xmlInput := []byte(`<ResultDataFile><ResultDataList><ResultData><StartTime>2026-04-06T16:03:38</StartTime><EndTime>2026-04-06T16:13:24</EndTime><EnergySpectrum><SerialNumber>RC-101-005020</SerialNumber><MeasurementTime>586</MeasurementTime><EnergyCalibration><Coefficients><Coefficient>0</Coefficient><Coefficient>1</Coefficient></Coefficients></EnergyCalibration><Spectrum><DataPoint>1</DataPoint><DataPoint>5</DataPoint><DataPoint>1</DataPoint></Spectrum></EnergySpectrum></ResultData></ResultDataList></ResultDataFile>`)
+
+	measurement, err := ParseWithKnownDrivers(xmlInput)
+	if err != nil {
+		t.Fatalf("ParseWithKnownDrivers returned error: %v", err)
+	}
+	if measurement.Format != "radiacode-xml" {
+		t.Fatalf("unexpected format: %s", measurement.Format)
+	}
+}
+
+func TestFindClosestMarkerByTime(t *testing.T) {
+	markers := []MarkerTimePoint{
+		{Date: 1775481600, Lat: 43.27, Lon: 42.49},
+		{Date: 1775482000, Lat: 43.28, Lon: 42.50},
+		{Date: 1775482600, Lat: 43.29, Lon: 42.51},
+	}
+
+	best, ok := FindClosestMarkerByTime(markers, 1775481900, 1775482300, 120)
+	if !ok {
+		t.Fatalf("expected marker match")
+	}
+	if best.Marker.Date != 1775482000 {
+		t.Fatalf("unexpected marker date: %d", best.Marker.Date)
+	}
+	if !best.WithinWindow {
+		t.Fatalf("expected marker to be inside time window")
+	}
+}
+
+func TestFindNuclideAlias(t *testing.T) {
+	nuclide, ok := FindNuclide("tritium")
+	if !ok {
+		t.Fatalf("expected tritium alias")
+	}
+	if nuclide.NuclideID != "H-3" {
+		t.Fatalf("unexpected nuclide id: %s", nuclide.NuclideID)
+	}
+
+	nuclide, ok = FindNuclide("137Cs")
+	if !ok || nuclide.NuclideID != "Cs-137" {
+		t.Fatalf("expected normalized Cs-137, got %+v", nuclide)
+	}
+}

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -8660,6 +8660,30 @@ function centerMapToLocation() {
           panel.appendChild(componentBox);
         }
 
+        const explanationText = String(contextObject.explanation || '').trim();
+        if (explanationText) {
+          const explanationBox = document.createElement('div');
+          explanationBox.style.marginTop = '8px';
+          explanationBox.innerHTML = `<strong>Interpretation:</strong> ${escapeHtml(explanationText)}`;
+          panel.appendChild(explanationBox);
+        }
+
+        const groupChecks = Array.isArray(contextObject.group_checks) ? contextObject.group_checks : [];
+        if (groupChecks.length > 0) {
+          const groupTitle = document.createElement('h4');
+          groupTitle.style.marginTop = '14px';
+          groupTitle.textContent = 'Group confirmation';
+          panel.appendChild(groupTitle);
+          groupChecks.slice(0, 6).forEach(function(groupCheck) {
+            const groupRow = document.createElement('div');
+            groupRow.style.marginTop = '4px';
+            const confidencePercent = Math.round(Number(groupCheck.confidence || 0) * 100);
+            const statusText = groupCheck.isConfirmed ? 'confirmed' : 'not confirmed';
+            groupRow.textContent = `${groupCheck.displayName || groupCheck.groupID}: ${statusText} (${confidencePercent}%)`;
+            panel.appendChild(groupRow);
+          });
+        }
+
         if (contextObject.start_unix && contextObject.end_unix) {
           const timeBox = document.createElement('div');
           timeBox.style.marginTop = '8px';

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -8690,6 +8690,28 @@ function centerMapToLocation() {
           candidateTracks.forEach(function(trackCandidate) {
             const row = document.createElement('div');
             row.style.marginTop = '8px';
+            row.style.border = '1px solid #ddd';
+            row.style.borderRadius = '8px';
+            row.style.padding = '8px';
+
+            const trackMeta = document.createElement('div');
+            const overlapSeconds = Number(trackCandidate.overlapSec || 0);
+            const overlapMinutes = Math.round(overlapSeconds / 60);
+            const centerDeltaSeconds = Number(trackCandidate.centerDeltaSec || 0);
+            const centerDeltaMinutes = Math.round(centerDeltaSeconds / 60);
+            let candidateLabel = `Track ${trackCandidate.trackID}`;
+            if (trackCandidate.trackStartUnix && trackCandidate.trackEndUnix) {
+              candidateLabel += ` · ${formatDateTime(trackCandidate.trackStartUnix)} → ${formatDateTime(trackCandidate.trackEndUnix)}`;
+            }
+            candidateLabel += ` · overlap ${overlapMinutes} min · center delta ${centerDeltaMinutes} min`;
+            trackMeta.textContent = candidateLabel;
+            row.appendChild(trackMeta);
+
+            const actionRow = document.createElement('div');
+            actionRow.style.display = 'flex';
+            actionRow.style.gap = '8px';
+            actionRow.style.marginTop = '6px';
+
             const attachButton = document.createElement('button');
             attachButton.textContent = `Attach to ${trackCandidate.trackID}`;
             attachButton.onclick = function() {
@@ -8702,19 +8724,99 @@ function centerMapToLocation() {
                   startUnix: contextObject.start_unix || 0,
                   endUnix: contextObject.end_unix || 0
                 })
-              }).then(function(response) { return response.json(); })
+              }).then(function(response) {
+                if (!response.ok) {
+                  throw new Error('attach-track failed');
+                }
+                return response.json();
+              })
                 .then(function(payload) {
                   if (payload && payload.status === 'success' && payload.trackURL) {
                     window.location.href = payload.trackURL;
                     return;
                   }
                   updateMarkers(true);
+                })
+                .catch(function() {
+                  alert('Unable to attach spectrum to this track candidate.');
                 });
             };
-            row.appendChild(attachButton);
+            actionRow.appendChild(attachButton);
+
+            const previewButton = document.createElement('button');
+            previewButton.textContent = 'Preview candidate';
+            previewButton.onclick = function() {
+              const hasBounds = Number.isFinite(Number(trackCandidate.minLat)) &&
+                Number.isFinite(Number(trackCandidate.minLon)) &&
+                Number.isFinite(Number(trackCandidate.maxLat)) &&
+                Number.isFinite(Number(trackCandidate.maxLon));
+              if (hasBounds && map) {
+                map.fitBounds([
+                  [Number(trackCandidate.minLat), Number(trackCandidate.minLon)],
+                  [Number(trackCandidate.maxLat), Number(trackCandidate.maxLon)]
+                ]);
+              }
+            };
+            actionRow.appendChild(previewButton);
+
+            row.appendChild(actionRow);
             panel.appendChild(row);
           });
         }
+
+        const manualTrackTitle = document.createElement('h4');
+        manualTrackTitle.style.marginTop = '16px';
+        manualTrackTitle.textContent = 'Attach to specific track ID';
+        panel.appendChild(manualTrackTitle);
+
+        const manualTrackRow = document.createElement('div');
+        manualTrackRow.style.display = 'flex';
+        manualTrackRow.style.gap = '8px';
+        manualTrackRow.style.alignItems = 'center';
+
+        const manualTrackInput = document.createElement('input');
+        manualTrackInput.type = 'text';
+        manualTrackInput.placeholder = 'e.g. safecast-70845';
+        manualTrackInput.style.flex = '1';
+        manualTrackRow.appendChild(manualTrackInput);
+
+        const manualTrackAttachButton = document.createElement('button');
+        manualTrackAttachButton.textContent = 'Attach by track ID';
+        manualTrackAttachButton.onclick = function() {
+          const selectedTrackID = String(manualTrackInput.value || '').trim();
+          if (!selectedTrackID) {
+            alert('Please enter a track ID.');
+            return;
+          }
+          fetch('/api/spectrum/attach-track', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              trackID: selectedTrackID,
+              qualitative: qualitativeSummaryText,
+              startUnix: contextObject.start_unix || 0,
+              endUnix: contextObject.end_unix || 0
+            })
+          })
+          .then(function(response) {
+            if (!response.ok) {
+              throw new Error('attach-track failed');
+            }
+            return response.json();
+          })
+          .then(function(payload) {
+            if (payload && payload.status === 'success' && payload.trackURL) {
+              window.location.href = payload.trackURL;
+              return;
+            }
+            updateMarkers(true);
+          })
+          .catch(function() {
+            alert('Unable to attach spectrum to this track ID.');
+          });
+        };
+        manualTrackRow.appendChild(manualTrackAttachButton);
+        panel.appendChild(manualTrackRow);
 
         const closeButton = document.createElement('button');
         closeButton.style.marginTop = '12px';

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -8652,6 +8652,14 @@ function centerMapToLocation() {
         composition.innerHTML = `<strong>Qualitative isotopes:</strong> ${escapeHtml(qualitativeSummaryText || 'isotopes detected')}`;
         panel.appendChild(composition);
 
+        const componentText = String(contextObject.component_text || '').trim();
+        if (componentText) {
+          const componentBox = document.createElement('div');
+          componentBox.style.marginTop = '8px';
+          componentBox.innerHTML = `<strong>Estimated components:</strong> ${escapeHtml(componentText)}`;
+          panel.appendChild(componentBox);
+        }
+
         if (contextObject.start_unix && contextObject.end_unix) {
           const timeBox = document.createElement('div');
           timeBox.style.marginTop = '8px';

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -5792,6 +5792,10 @@ function createDateRangeSlider(){
     const deviceLabel = deviceName
       ? `<div><strong>${translate('live_marker_device_label')}:</strong> ${escapeHtml(deviceName)}</div>`
       : '';
+    const qualitativeSpectrum = marker.radiation ? String(marker.radiation).trim() : '';
+    const qualitativeBlock = qualitativeSpectrum
+      ? `<div><strong>Spectrum composition:</strong> ${escapeHtml(qualitativeSpectrum)}</div>`
+      : '';
 
     return `
       <div class="custom-tooltip">
@@ -5802,6 +5806,7 @@ function createDateRangeSlider(){
           </a>)
         </div>
         ${deviceLabel}
+        ${qualitativeBlock}
         <div><strong>${translate('speed')}:</strong> ${speedText}</div>
         <div style="margin-top:4px">
           <!-- clicking the link switches to track mode -->
@@ -8374,6 +8379,8 @@ function centerMapToLocation() {
         let completedUploads = 0;
         const totalFiles     = files.length;
         let lastTrackURL     = null;
+        let pendingSpectrumSummary = '';
+        let pendingSpectrumManualPoint = false;
 
         /* Create an XHR for each file but redirect only once */
         [...files].forEach(file => {
@@ -8414,6 +8421,10 @@ function centerMapToLocation() {
                 lastTrackURL               = response.trackURL;   // remember
                 serverProcessing.innerText = translate('processing_complete');
                 serverProcessing.style.color = 'green';
+                if (response.spectrumNeedsManualPoint) {
+                  pendingSpectrumManualPoint = true;
+                  pendingSpectrumSummary = response.spectrumQualitative || 'qualitative composition: isotopes detected';
+                }
               } else if (response.status === 'processing') {
                 lastTrackURL               = null;
                 serverProcessing.innerText = translate('processing_complete');
@@ -8436,6 +8447,8 @@ function centerMapToLocation() {
                 /* redirect to last successfully processed track */
                   if (lastTrackURL) {
                     window.location.href = lastTrackURL;
+                  } else if (pendingSpectrumManualPoint) {
+                    promptSpectrumManualPointSelection(pendingSpectrumSummary);
                   } else {
                     updateMarkers(true);   // keep the map open for background imports
                   }
@@ -8504,6 +8517,15 @@ function centerMapToLocation() {
           rowState.serverProcessing.style.color = '';
         }
 
+        function promptNativeManualSpectrumPlacement(payload) {
+          if (!payload || !payload.spectrumNeedsManualPoint) {
+            return false;
+          }
+          const summary = payload.spectrumQualitative || 'qualitative composition: isotopes detected';
+          promptSpectrumManualPointSelection(summary);
+          return true;
+        }
+
         function finalizeNativeUpload(payload) {
           if (!payload || payload.status === 'cancelled') {
             fileOverlay.style.display = 'none';
@@ -8513,6 +8535,12 @@ function centerMapToLocation() {
             setTimeout(() => {
               fileOverlay.style.display = 'none';
               window.location.href = payload.trackURL;
+            }, 700);
+            return;
+          }
+          if (payload.status === 'success' && promptNativeManualSpectrumPlacement(payload)) {
+            setTimeout(() => {
+              fileOverlay.style.display = 'none';
             }, 700);
             return;
           }
@@ -8589,6 +8617,38 @@ function centerMapToLocation() {
           .catch(() => {
             markGlobalNativeUploadError();
           });
+      }
+
+      function promptSpectrumManualPointSelection(qualitativeSummaryText) {
+        if (!map) {
+          alert('Spectrum uploaded but map is not ready for manual placement.');
+          return;
+        }
+        alert('Spectrum was uploaded but no time-matched track was found. Click one point on the map to save this spectrum.');
+        const clickHandler = function(event) {
+          map.off('click', clickHandler);
+          fetch('/api/spectrum/manual-point', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              lat: event.latlng.lat,
+              lon: event.latlng.lng,
+              qualitative: qualitativeSummaryText
+            })
+          })
+          .then(function(response) { return response.json(); })
+          .then(function(payload) {
+            if (payload && payload.status === 'success' && payload.trackURL) {
+              window.location.href = payload.trackURL;
+              return;
+            }
+            updateMarkers(true);
+          })
+          .catch(function() {
+            updateMarkers(true);
+          });
+        };
+        map.on('click', clickHandler);
       }
     </script>
 

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -8418,12 +8418,13 @@ function centerMapToLocation() {
             if (xhr.status === 200) {
               const response = JSON.parse(xhr.responseText);
               if (response.status === 'success') {
-                lastTrackURL               = response.trackURL;   // remember
+                lastTrackURL               = (response.trackURL && response.trackURL !== '/') ? response.trackURL : null;   // remember
                 serverProcessing.innerText = translate('processing_complete');
                 serverProcessing.style.color = 'green';
                 if (response.spectrumNeedsManualPoint) {
                   pendingSpectrumManualPoint = true;
                   pendingSpectrumSummary = response.spectrumQualitative || 'qualitative composition: isotopes detected';
+                  window.__pendingSpectrumContext = response.spectrumContext || null;
                 }
               } else if (response.status === 'processing') {
                 lastTrackURL               = null;
@@ -8448,7 +8449,7 @@ function centerMapToLocation() {
                   if (lastTrackURL) {
                     window.location.href = lastTrackURL;
                   } else if (pendingSpectrumManualPoint) {
-                    promptSpectrumManualPointSelection(pendingSpectrumSummary);
+                    showSpectrumResultModal(window.__pendingSpectrumContext, pendingSpectrumSummary);
                   } else {
                     updateMarkers(true);   // keep the map open for background imports
                   }
@@ -8522,7 +8523,7 @@ function centerMapToLocation() {
             return false;
           }
           const summary = payload.spectrumQualitative || 'qualitative composition: isotopes detected';
-          promptSpectrumManualPointSelection(summary);
+          showSpectrumResultModal(payload.spectrumContext || null, summary);
           return true;
         }
 
@@ -8531,7 +8532,7 @@ function centerMapToLocation() {
             fileOverlay.style.display = 'none';
             return;
           }
-          if (payload.status === 'success' && payload.trackURL) {
+          if (payload.status === 'success' && payload.trackURL && payload.trackURL !== '/') {
             setTimeout(() => {
               fileOverlay.style.display = 'none';
               window.location.href = payload.trackURL;
@@ -8619,7 +8620,117 @@ function centerMapToLocation() {
           });
       }
 
-      function promptSpectrumManualPointSelection(qualitativeSummaryText) {
+      function showSpectrumResultModal(spectrumContext, qualitativeSummaryText) {
+        const contextObject = (spectrumContext && typeof spectrumContext === 'object') ? spectrumContext : {};
+        const candidateTracks = Array.isArray(contextObject.candidate_tracks) ? contextObject.candidate_tracks : [];
+        const modal = document.createElement('div');
+        modal.style.position = 'fixed';
+        modal.style.left = '0';
+        modal.style.top = '0';
+        modal.style.right = '0';
+        modal.style.bottom = '0';
+        modal.style.zIndex = '99999';
+        modal.style.background = 'rgba(0,0,0,0.55)';
+        modal.style.display = 'flex';
+        modal.style.alignItems = 'center';
+        modal.style.justifyContent = 'center';
+        const panel = document.createElement('div');
+        panel.style.background = '#fff';
+        panel.style.color = '#111';
+        panel.style.maxWidth = '680px';
+        panel.style.width = '92%';
+        panel.style.maxHeight = '80vh';
+        panel.style.overflow = 'auto';
+        panel.style.borderRadius = '12px';
+        panel.style.padding = '16px';
+
+        const title = document.createElement('h3');
+        title.textContent = 'Spectrum analysis result';
+        panel.appendChild(title);
+
+        const composition = document.createElement('div');
+        composition.innerHTML = `<strong>Qualitative isotopes:</strong> ${escapeHtml(qualitativeSummaryText || 'isotopes detected')}`;
+        panel.appendChild(composition);
+
+        if (contextObject.start_unix && contextObject.end_unix) {
+          const timeBox = document.createElement('div');
+          timeBox.style.marginTop = '8px';
+          timeBox.innerHTML = `<strong>Measurement window:</strong> ${escapeHtml(formatDateTime(contextObject.start_unix))} → ${escapeHtml(formatDateTime(contextObject.end_unix))}`;
+          panel.appendChild(timeBox);
+        }
+
+        const actions = document.createElement('div');
+        actions.style.marginTop = '14px';
+        actions.style.display = 'flex';
+        actions.style.flexWrap = 'wrap';
+        actions.style.gap = '8px';
+
+        const pointButton = document.createElement('button');
+        pointButton.textContent = 'Choose point on map';
+        pointButton.onclick = function() {
+          document.body.removeChild(modal);
+          promptSpectrumManualPointSelection(qualitativeSummaryText, contextObject.start_unix || 0, contextObject.end_unix || 0);
+        };
+        actions.appendChild(pointButton);
+
+        const areaButton = document.createElement('button');
+        areaButton.textContent = 'Select area on map';
+        areaButton.onclick = function() {
+          document.body.removeChild(modal);
+          promptSpectrumAreaSelection(qualitativeSummaryText, contextObject.start_unix || 0, contextObject.end_unix || 0);
+        };
+        actions.appendChild(areaButton);
+        panel.appendChild(actions);
+
+        if (candidateTracks.length > 0) {
+          const listTitle = document.createElement('h4');
+          listTitle.style.marginTop = '16px';
+          listTitle.textContent = 'Possible track candidates';
+          panel.appendChild(listTitle);
+          candidateTracks.forEach(function(trackCandidate) {
+            const row = document.createElement('div');
+            row.style.marginTop = '8px';
+            const attachButton = document.createElement('button');
+            attachButton.textContent = `Attach to ${trackCandidate.trackID}`;
+            attachButton.onclick = function() {
+              fetch('/api/spectrum/attach-track', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                  trackID: trackCandidate.trackID,
+                  qualitative: qualitativeSummaryText,
+                  startUnix: contextObject.start_unix || 0,
+                  endUnix: contextObject.end_unix || 0
+                })
+              }).then(function(response) { return response.json(); })
+                .then(function(payload) {
+                  if (payload && payload.status === 'success' && payload.trackURL) {
+                    window.location.href = payload.trackURL;
+                    return;
+                  }
+                  updateMarkers(true);
+                });
+            };
+            row.appendChild(attachButton);
+            panel.appendChild(row);
+          });
+        }
+
+        const closeButton = document.createElement('button');
+        closeButton.style.marginTop = '12px';
+        closeButton.textContent = 'Close';
+        closeButton.onclick = function() {
+          if (document.body.contains(modal)) {
+            document.body.removeChild(modal);
+          }
+          updateMarkers(true);
+        };
+        panel.appendChild(closeButton);
+        modal.appendChild(panel);
+        document.body.appendChild(modal);
+      }
+
+      function promptSpectrumManualPointSelection(qualitativeSummaryText, startUnix, endUnix) {
         if (!map) {
           alert('Spectrum uploaded but map is not ready for manual placement.');
           return;
@@ -8633,7 +8744,9 @@ function centerMapToLocation() {
             body: JSON.stringify({
               lat: event.latlng.lat,
               lon: event.latlng.lng,
-              qualitative: qualitativeSummaryText
+              qualitative: qualitativeSummaryText,
+              startUnix: startUnix || 0,
+              endUnix: endUnix || 0
             })
           })
           .then(function(response) { return response.json(); })
@@ -8649,6 +8762,42 @@ function centerMapToLocation() {
           });
         };
         map.on('click', clickHandler);
+      }
+
+      function promptSpectrumAreaSelection(qualitativeSummaryText, startUnix, endUnix) {
+        if (!map) {
+          alert('Map is not ready for area selection.');
+          return;
+        }
+        alert('Click two points on the map to define area rectangle.');
+        let firstPoint = null;
+        const areaClickHandler = function(event) {
+          if (!firstPoint) {
+            firstPoint = event.latlng;
+            return;
+          }
+          map.off('click', areaClickHandler);
+          const minLat = Math.min(firstPoint.lat, event.latlng.lat);
+          const maxLat = Math.max(firstPoint.lat, event.latlng.lat);
+          const minLon = Math.min(firstPoint.lng, event.latlng.lng);
+          const maxLon = Math.max(firstPoint.lng, event.latlng.lng);
+          fetch('/api/spectrum/attach-area', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              minLat: minLat,
+              minLon: minLon,
+              maxLat: maxLat,
+              maxLon: maxLon,
+              qualitative: qualitativeSummaryText,
+              startUnix: startUnix || 0,
+              endUnix: endUnix || 0
+            })
+          }).then(function(response) { return response.json(); })
+            .then(function() { updateMarkers(true); })
+            .catch(function() { updateMarkers(true); });
+        };
+        map.on('click', areaClickHandler);
       }
     </script>
 

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -8446,13 +8446,13 @@ function centerMapToLocation() {
               setTimeout(() => {
                 fileOverlay.style.display = 'none';
                 /* redirect to last successfully processed track */
-                  if (lastTrackURL) {
-                    window.location.href = lastTrackURL;
-                  } else if (pendingSpectrumManualPoint) {
-                    showSpectrumResultModal(window.__pendingSpectrumContext, pendingSpectrumSummary);
-                  } else {
-                    updateMarkers(true);   // keep the map open for background imports
-                  }
+                if (pendingSpectrumManualPoint) {
+                  showSpectrumResultModal(window.__pendingSpectrumContext, pendingSpectrumSummary);
+                } else if (lastTrackURL) {
+                  window.location.href = lastTrackURL;
+                } else {
+                  updateMarkers(true);   // keep the map open for background imports
+                }
               }, 700);
             }
           };
@@ -8532,16 +8532,16 @@ function centerMapToLocation() {
             fileOverlay.style.display = 'none';
             return;
           }
+          if (payload.status === 'success' && promptNativeManualSpectrumPlacement(payload)) {
+            setTimeout(() => {
+              fileOverlay.style.display = 'none';
+            }, 700);
+            return;
+          }
           if (payload.status === 'success' && payload.trackURL && payload.trackURL !== '/') {
             setTimeout(() => {
               fileOverlay.style.display = 'none';
               window.location.href = payload.trackURL;
-            }, 700);
-            return;
-          }
-          if (payload.status === 'success' && promptNativeManualSpectrumPlacement(payload)) {
-            setTimeout(() => {
-              fileOverlay.style.display = 'none';
             }, 700);
             return;
           }


### PR DESCRIPTION
### Motivation
- Introduce a single, vendor-agnostic spectrum analysis pipeline so isotope detection and catalog lookup can be reused across instrument formats. 
- Provide a first concrete parser for Radiacode XML exports while keeping drivers isolated and extensible. 

### Description
- Add a new `pkg/spectrum` package with a shared model (`model.go`) for `SpectrumMeasurement`, `Peak`, `IsotopeHit`, and `Analysis`. 
- Implement a generic driver interface and discovery (`drivers.go`) and include a `RadiacodeXMLDriver` (`driver_radiacode.go`) that parses RadiaCode ResultDataFile XML into the shared model. 
- Add analysis code (`analysis.go`) for peak finding, isotope matching against a catalog, helper `FindClosestMarkerByTime`, and compatibility entrypoints `AnalyzeRadiacodeXML` and `AnalyzeWithKnownDrivers`. 
- Ship a broad built-in isotope catalog (`catalog.go`) with common natural chains, environmental/fallout/industrial isotopes and heavier transuranics, plus normalization and lookup helpers. 
- Keep package entrypoint names stable via `radiacode.go` and add unit tests in `radiacode_test.go`. 
- Update `README.md` to document the universal isotope catalog and spectrum drivers. 

### Testing
- Ran `go test ./pkg/spectrum` which executed `TestAnalyzeRadiacodeXML`, `TestParseWithKnownDrivers`, `TestFindClosestMarkerByTime`, and `TestFindNuclideAlias`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9db92d7a88332b8a436ca15a208aa)