### PR TITLE
Move map cache/stats panel to bottom-right for all screen sizes

### DIFF
--- a/public_html/map.html
+++ b/public_html/map.html
@@ -319,9 +319,10 @@ body, html {
 
         #mapCacheStatus {
           position: absolute;
-          top: var(--cache-status-top, 62px);
-          left: 50%;
-          transform: translateX(-50%);
+          bottom: 10px;
+          right: 10px;
+          left: auto;
+          transform: none;
           background: var(--overlay-bg);
           border: var(--legend-border);
           border-radius: 14px;
@@ -375,14 +376,9 @@ body, html {
           margin-left: 6px;
         }
 
-        /* Keep cache status away from crowded top controls on narrow phone screens. */
+        /* Keep cache status compact on narrow phone screens. */
         @media (max-width: 767px) {
           #mapCacheStatus {
-            top: auto;
-            bottom: 10px;
-            left: auto;
-            right: 10px;
-            transform: none;
             min-width: 0;
             width: fit-content;
             max-width: min(88vw, 560px);
@@ -2826,16 +2822,8 @@ function applyTopOverlayLayoutByRuntimeMode() {
   if (!rootNode) {
     return;
   }
-  const desktopMode = !!window.desktopWebViewMode;
-  if (desktopMode) {
-    rootNode.style.setProperty('--short-link-top', '56px');
-    rootNode.style.setProperty('--cache-status-top', '62px');
-    return;
-  }
-  // Keep short URL close to the title in web mode and move cache status below it
-  // so both controls remain clickable and never overlap.
+  // Keep short URL close to the top title area in both desktop webview and browser mode.
   rootNode.style.setProperty('--short-link-top', '56px');
-  rootNode.style.setProperty('--cache-status-top', '86px');
 }
 
 const mapCacheLabelFallbacks = {

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -376,6 +376,16 @@ body, html {
           margin-left: 6px;
         }
 
+        /* Keep bottom-right controls stacked vertically above the cache status card. */
+        #legend {
+          bottom: calc(20px + var(--bottom-controls-offset, 0px)) !important;
+          z-index: 1060 !important;
+        }
+
+        #themeToggle {
+          bottom: calc(140px + var(--bottom-controls-offset, 0px));
+        }
+
         /* Keep cache status compact on narrow phone screens. */
         @media (max-width: 767px) {
           #mapCacheStatus {
@@ -391,15 +401,6 @@ body, html {
             font-size: var(--font-size-xs);
             white-space: normal;
             overflow-wrap: anywhere;
-          }
-
-          #legend {
-            bottom: calc(20px + var(--mobile-cache-offset, 0px)) !important;
-            z-index: 1060 !important;
-          }
-
-          #themeToggle {
-            bottom: calc(140px + var(--mobile-cache-offset, 0px));
           }
         }
 
@@ -3385,18 +3386,14 @@ function splitCacheStatusSegmentsIntoBalancedLines(segmentEntries, forcedSecondL
   return [firstLineSegments.join(' · '), secondLineSegments.join(' · ')];
 }
 
-function updateMobileControlOffsetsFromCacheStatus() {
+function updateBottomControlOffsetsFromCacheStatus() {
   if (!mapCacheStatusNode) {
     return;
   }
-  if (window.matchMedia('(max-width: 767px)').matches) {
-    const cachePanelHeight = mapCacheStatusNode.offsetHeight || 0;
-    const verticalGap = 12;
-    const offsetValue = Math.max(0, cachePanelHeight + verticalGap);
-    document.documentElement.style.setProperty('--mobile-cache-offset', offsetValue + 'px');
-    return;
-  }
-  document.documentElement.style.setProperty('--mobile-cache-offset', '0px');
+  const cachePanelHeight = mapCacheStatusNode.offsetHeight || 0;
+  const verticalGap = 12;
+  const offsetValue = Math.max(0, cachePanelHeight + verticalGap);
+  document.documentElement.style.setProperty('--bottom-controls-offset', offsetValue + 'px');
 }
 
 async function renderOfflineCacheStatus() {
@@ -3465,7 +3462,7 @@ async function renderOfflineCacheStatus() {
   mapCacheStatusNode.innerHTML =
     `<div class="cache-inline-line">${firstLine}</div>` +
     `<div class="cache-inline-line">${secondLine}</div>`;
-  updateMobileControlOffsetsFromCacheStatus();
+  updateBottomControlOffsetsFromCacheStatus();
   const resetLink = document.getElementById('resetMapCacheLink');
   if (resetLink) {
     resetLink.onclick = function() {
@@ -3482,7 +3479,7 @@ window.addEventListener('offline', function() {
   updateInternetConnectivityState(false);
 });
 window.addEventListener('resize', function() {
-  updateMobileControlOffsetsFromCacheStatus();
+  updateBottomControlOffsetsFromCacheStatus();
 });
 
 L.CachedTileLayer = L.TileLayer.extend({

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -172,13 +172,7 @@ body, html {
 				.leaflet-container .leaflet-control-attribution {
 					font-family: var(--font-family-base);
 					font-size: var(--font-size-xxs);
-				}
-
-				/* Increase font size only on screens wider than 768px (tablets, laptops, desktops) */
-				@media (min-width: 768px) {
-					.leaflet-container .leaflet-control-attribution {
-						font-size: var(--font-size-xs);
-					}
+          line-height: 1.1;
 				}
 
         /* Manual theme overrides */
@@ -319,7 +313,7 @@ body, html {
 
         #mapCacheStatus {
           position: absolute;
-          bottom: 10px;
+          bottom: var(--map-cache-bottom, 10px);
           right: 10px;
           left: auto;
           transform: none;
@@ -378,12 +372,12 @@ body, html {
 
         /* Keep bottom-right controls stacked vertically above the cache status card. */
         #legend {
-          bottom: calc(20px + var(--bottom-controls-offset, 0px)) !important;
+          bottom: var(--legend-bottom, 20px) !important;
           z-index: 1060 !important;
         }
 
         #themeToggle {
-          bottom: calc(140px + var(--bottom-controls-offset, 0px));
+          bottom: var(--theme-toggle-bottom, 140px);
         }
 
         /* Keep cache status compact on narrow phone screens. */
@@ -3386,14 +3380,24 @@ function splitCacheStatusSegmentsIntoBalancedLines(segmentEntries, forcedSecondL
   return [firstLineSegments.join(' · '), secondLineSegments.join(' · ')];
 }
 
-function updateBottomControlOffsetsFromCacheStatus() {
-  if (!mapCacheStatusNode) {
+function updateBottomRightControlStackLayout() {
+  const rootNode = document.documentElement;
+  if (!rootNode || !mapCacheStatusNode) {
     return;
   }
+  const attributionNode = document.querySelector('.leaflet-control-attribution');
+  const legendNode = document.getElementById('legend');
+  const verticalGap = 6;
+  const attributionHeight = attributionNode ? (attributionNode.offsetHeight || 0) : 0;
+  const cacheBottom = attributionHeight + verticalGap;
   const cachePanelHeight = mapCacheStatusNode.offsetHeight || 0;
-  const verticalGap = 12;
-  const offsetValue = Math.max(0, cachePanelHeight + verticalGap);
-  document.documentElement.style.setProperty('--bottom-controls-offset', offsetValue + 'px');
+  const legendBottom = cacheBottom + cachePanelHeight + verticalGap;
+  const legendHeight = legendNode ? (legendNode.offsetHeight || 0) : 0;
+  const themeToggleBottom = legendBottom + legendHeight + verticalGap;
+
+  rootNode.style.setProperty('--map-cache-bottom', Math.max(0, cacheBottom) + 'px');
+  rootNode.style.setProperty('--legend-bottom', Math.max(0, legendBottom) + 'px');
+  rootNode.style.setProperty('--theme-toggle-bottom', Math.max(0, themeToggleBottom) + 'px');
 }
 
 async function renderOfflineCacheStatus() {
@@ -3462,7 +3466,7 @@ async function renderOfflineCacheStatus() {
   mapCacheStatusNode.innerHTML =
     `<div class="cache-inline-line">${firstLine}</div>` +
     `<div class="cache-inline-line">${secondLine}</div>`;
-  updateBottomControlOffsetsFromCacheStatus();
+  updateBottomRightControlStackLayout();
   const resetLink = document.getElementById('resetMapCacheLink');
   if (resetLink) {
     resetLink.onclick = function() {
@@ -3479,7 +3483,7 @@ window.addEventListener('offline', function() {
   updateInternetConnectivityState(false);
 });
 window.addEventListener('resize', function() {
-  updateBottomControlOffsetsFromCacheStatus();
+  updateBottomRightControlStackLayout();
 });
 
 L.CachedTileLayer = L.TileLayer.extend({


### PR DESCRIPTION
### Motivation
- The map offline/cache statistics panel appeared in two locations depending on viewport width which caused inconsistent UX; the intent is to show it only at the bottom where layout is preferred for all screen sizes.

### Description
- Updated CSS for `#mapCacheStatus` to anchor it to the bottom-right (`bottom: 10px; right: 10px`) and removed the top-centered placement and transform adjustments in `public_html/map.html`.
- Simplified the mobile media query so the panel remains compact without duplicating positional rules in `public_html/map.html`.
- Removed the runtime assignment of `--cache-status-top` from `applyTopOverlayLayoutByRuntimeMode()` so the top-placement behavior is no longer toggled at runtime.

### Testing
- Ran `go test ./...` and the test run completed successfully (packages with tests passed; other packages reported no test files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb40a6e6648332a57fb71401da02de)