### PR TITLE
Stabilize stable-release publishing step in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -373,7 +373,15 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: bin-desktop-${{ matrix.goos }}-${{ matrix.goarch }}-${{ matrix.desktop_variant }}
-          path: dist/
+          path: |
+            dist/chicha-isotope-map_${{ matrix.goos }}_${{ matrix.goarch }}_desktop*
+
+      - name: Upload desktop icon artifact (single copy for release assets)
+        if: runner.os == 'Windows' && matrix.goarch == 'amd64'
+        uses: actions/upload-artifact@v4
+        with:
+          name: bin-desktop-icon-windows
+          path: dist/windows-desktop-icon.ico
 
   build_desktop_macos_universal:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/stable-release') || contains(join(github.event.commits.*.message, ' || '), 'stable release') || contains(join(github.event.commits.*.message, ' || '), 'Stable Release')
@@ -488,6 +496,9 @@ jobs:
     needs: [build_portable, build_duckdb, build_desktop, build_desktop_macos_universal]
     runs-on: ubuntu-22.04
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
### Motivation
- Prevent intermittent failures in the `release` job where the release notes file is missing and duplicate Windows icon assets cause GitHub Release asset delete errors.

### Description
- Add `actions/checkout@v4` to the `release` job so `.github/release/stable-release.md` is present when `softprops/action-gh-release@v2` runs.
- Narrow desktop artifact uploads to only release binaries/archives using `dist/chicha-isotope-map_*_desktop*` instead of uploading the whole `dist/` directory.
- Upload the Windows icon `dist/windows-desktop-icon.ico` as a single artifact only for `Windows` + `amd64` to avoid duplicate asset names during publishing.
- Preserve existing release behavior (`tag_name: stable-release`, `overwrite_files: true`, `softprops/action-gh-release@v2`) while making the asset set deterministic.

### Testing
- Ran `git diff --check` which reported no whitespace or patch errors.
- Confirmed workflow edits by searching for `actions/checkout@v4`, the narrowed upload pattern, and the single icon artifact step using repository search commands; checks passed.
- No end-to-end CI run was executed as part of this patch; recommend triggering a `stable release` workflow run to validate end-to-end publishing behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb4d00250c8332b23574507d05ebe4)