### PR TITLE
Restrict Stable Release workflow to main pushes with 'stable release' and reduce CI noise

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,23 +3,24 @@ name: Stable Release
 on:
   push:
     branches:
-      - '**'
-    tags:
-      - stable-release
+      - main
   workflow_dispatch:
 
-# Run automatically for commits containing "stable release" (any commit in the push),
-# or for explicit stable-release tag pushes / manual dispatch.
+# Run automatically only for pushes to main where at least one commit message
+# contains "stable release" (case variants below), or via manual dispatch.
 
 permissions:
   contents: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 # ---------- PORTABLE: всё без CGO и без DuckDB ----------
 jobs:
   # GitHub-hosted Debian runners are unavailable, so Linux-hosted jobs use Ubuntu 22.04 LTS
   # as the closest stable base with broad package compatibility.
   build_portable:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/stable-release') || contains(join(github.event.commits.*.message, ' || '), 'stable release') || contains(join(github.event.commits.*.message, ' || '), 'Stable Release')
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main' && (contains(join(github.event.commits.*.message, ' || '), 'stable release') || contains(join(github.event.commits.*.message, ' || '), 'Stable Release')))
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -50,8 +51,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "${{ matrix.goversion }}"
-          cache: true
-          cache-dependency-path: go.sum
+          cache: false
 
       - name: go mod tidy (POSIX)
         if: runner.os != 'Windows'
@@ -103,7 +103,7 @@ jobs:
 
 # ---------- DUCKDB: Linux/amd64 (glibc 2.28) в контейнере + macOS (amd64/arm64) ----------
   build_duckdb:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/stable-release') || contains(join(github.event.commits.*.message, ' || '), 'stable release') || contains(join(github.event.commits.*.message, ' || '), 'Stable Release')
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main' && (contains(join(github.event.commits.*.message, ' || '), 'stable release') || contains(join(github.event.commits.*.message, ' || '), 'Stable Release')))
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -123,8 +123,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "${{ matrix.goversion }}"
-          cache: true
-          cache-dependency-path: go.sum
+          cache: false
 
       - name: go mod tidy (macOS)
         if: matrix.in_container == false
@@ -158,7 +157,7 @@ jobs:
 
 # ---------- DESKTOP WEBVIEW: macOS / Linux / Windows ----------
   build_desktop:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/stable-release') || contains(join(github.event.commits.*.message, ' || '), 'stable release') || contains(join(github.event.commits.*.message, ' || '), 'Stable Release')
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main' && (contains(join(github.event.commits.*.message, ' || '), 'stable release') || contains(join(github.event.commits.*.message, ' || '), 'Stable Release')))
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -185,8 +184,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "${{ matrix.goversion }}"
-          cache: true
-          cache-dependency-path: go.sum
+          cache: false
 
       - name: Install desktop libs (Linux)
         if: runner.os == 'Linux'
@@ -384,7 +382,7 @@ jobs:
           path: dist/windows-desktop-icon.ico
 
   build_desktop_macos_universal:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/stable-release') || contains(join(github.event.commits.*.message, ' || '), 'stable release') || contains(join(github.event.commits.*.message, ' || '), 'Stable Release')
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main' && (contains(join(github.event.commits.*.message, ' || '), 'stable release') || contains(join(github.event.commits.*.message, ' || '), 'Stable Release')))
     needs: [build_desktop]
     runs-on: macos-14
     steps:
@@ -492,7 +490,7 @@ jobs:
             dist/chicha-isotope-map_darwin_universal_desktop.dmg
 
   release:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/stable-release') || contains(join(github.event.commits.*.message, ' || '), 'stable release') || contains(join(github.event.commits.*.message, ' || '), 'Stable Release')
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main' && (contains(join(github.event.commits.*.message, ' || '), 'stable release') || contains(join(github.event.commits.*.message, ' || '), 'Stable Release')))
     needs: [build_portable, build_duckdb, build_desktop, build_desktop_macos_universal]
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
### Motivation
- Prevent accidental release pipeline runs from PR or feature-branch pushes that contain the words `stable release` in commit messages. 
- Reduce repetitive CI warnings about Node.js 20 deprecation and artifact cache restore failures that clutter logs. 

### Description
- Change workflow trigger to `push` on `main` only and remove the broad `**` branch pattern and tag auto-trigger. 
- Require each release job `if` condition to be `workflow_dispatch` OR a `push` to `refs/heads/main` with a commit message containing `stable release` / `Stable Release`. 
- Add repository-level env `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'` to opt runners to Node.js 24 and silence node deprecation notices. 
- Disable `actions/setup-go` cache (`cache: false`) where used to avoid repeated non-fatal `tar` restore warnings in matrix jobs. 

### Testing
- Ran `git diff --check` to validate patch formatting and it succeeded. 
- Committed the change and verified working tree status with `git status --short` which showed a clean state after commit. 
- Attempted YAML validation via Python `yaml` load but `PyYAML` was not available in the environment, so full programmatic YAML linting was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb51010d2c8332b9bba3a19ed1feb3)