### PR TITLE
Limit Stable Release workflow to main + CI reliability fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,23 +3,24 @@ name: Stable Release
 on:
   push:
     branches:
-      - '**'
-    tags:
-      - stable-release
+      - main
   workflow_dispatch:
 
-# Run automatically for commits containing "stable release" (any commit in the push),
-# or for explicit stable-release tag pushes / manual dispatch.
+# Run automatically only for pushes to main where at least one commit message
+# contains "stable release" (case variants below), or via manual dispatch.
 
 permissions:
   contents: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 # ---------- PORTABLE: всё без CGO и без DuckDB ----------
 jobs:
   # GitHub-hosted Debian runners are unavailable, so Linux-hosted jobs use Ubuntu 22.04 LTS
   # as the closest stable base with broad package compatibility.
   build_portable:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/stable-release') || contains(join(github.event.commits.*.message, ' || '), 'stable release') || contains(join(github.event.commits.*.message, ' || '), 'Stable Release')
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main' && (contains(join(github.event.commits.*.message, ' || '), 'stable release') || contains(join(github.event.commits.*.message, ' || '), 'Stable Release')))
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -50,8 +51,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "${{ matrix.goversion }}"
-          cache: true
-          cache-dependency-path: go.sum
+          cache: false
 
       - name: go mod tidy (POSIX)
         if: runner.os != 'Windows'
@@ -103,7 +103,7 @@ jobs:
 
 # ---------- DUCKDB: Linux/amd64 (glibc 2.28) в контейнере + macOS (amd64/arm64) ----------
   build_duckdb:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/stable-release') || contains(join(github.event.commits.*.message, ' || '), 'stable release') || contains(join(github.event.commits.*.message, ' || '), 'Stable Release')
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main' && (contains(join(github.event.commits.*.message, ' || '), 'stable release') || contains(join(github.event.commits.*.message, ' || '), 'Stable Release')))
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -123,8 +123,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "${{ matrix.goversion }}"
-          cache: true
-          cache-dependency-path: go.sum
+          cache: false
 
       - name: go mod tidy (macOS)
         if: matrix.in_container == false
@@ -158,7 +157,7 @@ jobs:
 
 # ---------- DESKTOP WEBVIEW: macOS / Linux / Windows ----------
   build_desktop:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/stable-release') || contains(join(github.event.commits.*.message, ' || '), 'stable release') || contains(join(github.event.commits.*.message, ' || '), 'Stable Release')
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main' && (contains(join(github.event.commits.*.message, ' || '), 'stable release') || contains(join(github.event.commits.*.message, ' || '), 'Stable Release')))
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -185,8 +184,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "${{ matrix.goversion }}"
-          cache: true
-          cache-dependency-path: go.sum
+          cache: false
 
       - name: Install desktop libs (Linux)
         if: runner.os == 'Linux'
@@ -384,7 +382,7 @@ jobs:
           path: dist/windows-desktop-icon.ico
 
   build_desktop_macos_universal:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/stable-release') || contains(join(github.event.commits.*.message, ' || '), 'stable release') || contains(join(github.event.commits.*.message, ' || '), 'Stable Release')
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main' && (contains(join(github.event.commits.*.message, ' || '), 'stable release') || contains(join(github.event.commits.*.message, ' || '), 'Stable Release')))
     needs: [build_desktop]
     runs-on: macos-14
     steps:
@@ -476,8 +474,9 @@ jobs:
           ln -s /Applications "${DMG_STAGING_DIR}/Applications"
 
           rm -f "${DMG_PATH}"
+          # Use a unique temporary volume name per run to avoid collisions with previously mounted volumes on shared runners.
           hdiutil create \
-            -volname "Chicha Isotope Map" \
+            -volname "Chicha Isotope Map ${{ github.run_id }}-${{ github.run_attempt }}" \
             -srcfolder "${DMG_STAGING_DIR}" \
             -ov \
             -format UDZO \
@@ -492,7 +491,7 @@ jobs:
             dist/chicha-isotope-map_darwin_universal_desktop.dmg
 
   release:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/stable-release') || contains(join(github.event.commits.*.message, ' || '), 'stable release') || contains(join(github.event.commits.*.message, ' || '), 'Stable Release')
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main' && (contains(join(github.event.commits.*.message, ' || '), 'stable release') || contains(join(github.event.commits.*.message, ' || '), 'Stable Release')))
     needs: [build_portable, build_duckdb, build_desktop, build_desktop_macos_universal]
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
### Motivation

- Prevent accidental stable releases by restricting the workflow to pushes on the `main` branch that include a commit message containing `stable release`, or manual dispatch.
- Force JavaScript actions to use Node 24 runtime to avoid compatibility issues.
- Reduce flaky or problematic cache behavior for `actions/setup-go` on hosted runners. 
- Avoid DMG name collisions on shared macOS runners by using a unique temporary volume name per run.

### Description

- Change workflow trigger from all branches/tags to `push` on `main` and refine job `if` expressions to require `github.event_name == 'workflow_dispatch'` or `(github.event_name == 'push' && github.ref == 'refs/heads/main' && (contains(join(github.event.commits.*.message, ' || '), 'stable release') || contains(join(github.event.commits.*.message, ' || '), 'Stable Release')))`. 
- Remove tag-based automatic trigger for `stable-release` and require commit message match or manual dispatch. 
- Add repository-level environment variable `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'`.
- Disable `actions/setup-go` caching by setting `cache: false` in multiple jobs. 
- Make DMG creation use a unique volume name by appending `${{ github.run_id }}-${{ github.run_attempt }}` to the `-volname` parameter to prevent collisions on shared runners.

### Testing

- No automated CI jobs were executed as part of this change because only the workflow YAML was modified. No automated tests were run against repository code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb51010d2c8332b9bba3a19ed1feb3)