### PR TITLE
ci: upgrade release workflow actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "${{ matrix.goversion }}"
           cache: false
@@ -96,7 +96,7 @@ jobs:
                    -o "dist/$bin"
 
       - name: Upload portable artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: bin-${{ matrix.goos }}-${{ matrix.goarch }}
           path: dist/
@@ -115,12 +115,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # --- macOS нативно ---
       - name: Set up Go (macOS)
         if: matrix.in_container == false
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "${{ matrix.goversion }}"
           cache: false
@@ -150,7 +150,7 @@ jobs:
                    -o "dist/${BIN}"
 
       - name: Upload duckdb artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: bin-${{ matrix.target }}
           path: dist/
@@ -178,10 +178,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "${{ matrix.goversion }}"
           cache: false
@@ -368,7 +368,7 @@ jobs:
           Compress-Archive -Path "dist/$bin" -DestinationPath "dist/chicha-isotope-map_${{ matrix.goos }}_${{ matrix.goarch }}_desktop.zip" -Force
 
       - name: Upload desktop artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: bin-desktop-${{ matrix.goos }}-${{ matrix.goarch }}-${{ matrix.desktop_variant }}
           path: |
@@ -376,7 +376,7 @@ jobs:
 
       - name: Upload desktop icon artifact (single copy for release assets)
         if: runner.os == 'Windows' && matrix.goarch == 'amd64'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: bin-desktop-icon-windows
           path: dist/windows-desktop-icon.ico
@@ -387,10 +387,10 @@ jobs:
     runs-on: macos-14
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download macOS desktop artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           pattern: bin-desktop-darwin-*
           merge-multiple: true
@@ -483,7 +483,7 @@ jobs:
             "${DMG_PATH}"
 
       - name: Upload macOS universal desktop artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: bin-desktop-darwin-universal
           path: |
@@ -496,15 +496,15 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: dist-raw/
 
       - name: Publish GitHub Release (stable tag)
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
### Motivation
- Remove noisy deprecation warnings emitted by runners when Actions targeting Node 20 are force-run on Node 24. 
- Prevent the same warnings from flooding logs across the large release matrix of platforms and jobs.

### Description
- Bumped usages in ` .github/workflows/release.yml` to Node 24-compatible majors: `actions/checkout@v4` → `actions/checkout@v6`, `actions/setup-go@v5` → `actions/setup-go@v6`, `actions/upload-artifact@v4` → `actions/upload-artifact@v5`, `actions/download-artifact@v4` → `actions/download-artifact@v5`, and `softprops/action-gh-release@v2` → `softprops/action-gh-release@v3`.
- Applied the replacements across all release-related jobs (`build_portable`, `build_duckdb`, `build_desktop`, `build_desktop_macos_universal`, and `release`).
- No step logic, environment variables, or build commands were changed aside from the action major versions.
- The only file modified is ` .github/workflows/release.yml`.

### Testing
- Ran `rg -n "actions/(checkout|setup-go|upload-artifact|download-artifact)|softprops/action-gh-release" .github/workflows` to confirm all `uses:` entries now reference the updated majors and observed the new versions. 
- Ran `git diff --check` to ensure there are no whitespace or formatting issues and it returned clean. 
- Inspected the updated workflow snippet with `nl -ba .github/workflows/release.yml | sed -n '40,520p'` to spot-check the changes and confirmed replacements in the listed jobs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb55cc81d483329db723c28d26c4fd)