### PR TITLE
Adjust marker outline to match fill and brighten low-dose green

### DIFF
--- a/public_html/map.html
+++ b/public_html/map.html
@@ -2050,8 +2050,8 @@ body, html {
 
       // Compute marker color from radiation level
       function getGradientColor(doseRate) {
-        if (doseRate <= 0.04) return '#006400'; // Dark green
-        else if (doseRate <= 0.08) return interpolateColor([0, 100, 0], [173, 255, 47], (doseRate - 0.04) / (0.08 - 0.04));
+        if (doseRate <= 0.04) return '#228B22'; // Brighter forest green for low-zoom readability
+        else if (doseRate <= 0.08) return interpolateColor([34, 139, 34], [173, 255, 47], (doseRate - 0.04) / (0.08 - 0.04));
         else if (doseRate <= 0.11) return interpolateColor([173, 255, 47], [255, 255, 0], (doseRate - 0.08) / (0.11 - 0.08));
         else if (doseRate <= 0.20) return interpolateColor([255, 255, 0], [255, 165, 0], (doseRate - 0.11) / (0.20 - 0.11));
         else if (doseRate <= 0.30) return interpolateColor([255, 165, 0], [255, 0, 0], (doseRate - 0.20) / (0.30 - 0.20));
@@ -2079,7 +2079,6 @@ function getRadius(doseRate, zoomLevel) {
   return Math.max(r, 2);                       // prevent tiny circles
 }
 
-const MARKER_CONTRAST_RING_COLOR = '#000000';
 const MARKER_CONTRAST_RING_WIDTH = 0.5;
 
 function createDoseMarkerWithContrastOutline(lat, lon, doseRate, speed, zoomLevel) {
@@ -2092,7 +2091,7 @@ function createDoseMarkerWithContrastOutline(lat, lon, doseRate, speed, zoomLeve
   const doseMarker = L.circleMarker([lat, lon], {
     radius: markerRadius,
     fillColor: markerColor,
-    color: MARKER_CONTRAST_RING_COLOR,
+    color: markerColor,
     weight: MARKER_CONTRAST_RING_WIDTH,
     opacity: 1,
     fillOpacity: markerFillOpacity


### PR DESCRIPTION
### Motivation
- Remove the distracting black contrast ring on dose markers by making the stroke match the marker fill so markers render as a single, consistent color at map zooms. 
- Improve visibility of low-dose green on small/low zooms by brightening the base green so green markers don't appear nearly black.

### Description
- Changed the lowest-dose color in `getGradientColor` from `'#006400'` to `'#228B22'` and adjusted the first interpolation start to `[34, 139, 34]` for a brighter forest green. 
- Removed use of the separate `MARKER_CONTRAST_RING_COLOR` and set the circle marker `color` option to `markerColor` so the outline uses the same color as the fill while keeping the same stroke width via `MARKER_CONTRAST_RING_WIDTH`. 
- File modified: `public_html/map.html`.

### Testing
- Ran the full Go test suite with `go test ./...` and the run completed successfully (package tests that exist passed; other packages reported no test files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb5f4628688332bae00b5d4e4de98d)