### PR TITLE
Add Radiacode Bluetooth live-ingest scaffold for web/desktop map

### DIFF
--- a/chicha-isotope-map.go
+++ b/chicha-isotope-map.go
@@ -6129,6 +6129,43 @@ func desktopBluetoothScanHandler(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// desktopBluetoothConnectHandler asks the host Bluetooth stack to establish a
+// connection with a selected device discovered by desktopBluetoothScanHandler.
+func desktopBluetoothConnectHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !isTrustedDesktopAdminRequest(r) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	defer r.Body.Close()
+	var payload struct {
+		Address string `json:"address"`
+	}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 4096)).Decode(&payload); err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+	if strings.TrimSpace(payload.Address) == "" {
+		http.Error(w, "address required", http.StatusBadRequest)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 15*time.Second)
+	defer cancel()
+	if err := desktop.ConnectRadiacodeDevice(ctx, payload.Address); err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+}
+
 func manualSpectrumPointHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", http.MethodPost)
@@ -8382,6 +8419,7 @@ func main() {
 	http.HandleFunc("/upload", uploadHandler)
 	http.HandleFunc("/desktop/upload-native", desktopNativeUploadHandler)
 	http.HandleFunc("/desktop/bluetooth/scan", desktopBluetoothScanHandler)
+	http.HandleFunc("/desktop/bluetooth/connect", desktopBluetoothConnectHandler)
 	http.HandleFunc("/api/spectrum/manual-point", manualSpectrumPointHandler)
 	http.HandleFunc("/api/spectrum/attach-track", attachSpectrumToTrackHandler)
 	http.HandleFunc("/api/spectrum/attach-area", attachSpectrumToAreaHandler)

--- a/chicha-isotope-map.go
+++ b/chicha-isotope-map.go
@@ -6028,6 +6028,77 @@ func uploadHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// radiacodeLivePointHandler accepts realtime points from Web Bluetooth sessions.
+// The endpoint keeps one marker per coordinate (within epsilon) and updates that
+// marker with the highest seen dose/CPS values, which makes hotspot mapping stable
+// during stationary measurements.
+func radiacodeLivePointHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if db == nil {
+		http.Error(w, "database unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
+	defer r.Body.Close()
+	var payload struct {
+		TrackID      string   `json:"trackID"`
+		Date         int64    `json:"date"`
+		Lat          float64  `json:"lat"`
+		Lon          float64  `json:"lon"`
+		DoseRate     float64  `json:"doseRate"`
+		CountRate    float64  `json:"countRate"`
+		Speed        float64  `json:"speed"`
+		DeviceID     string   `json:"deviceID"`
+		DeviceName   string   `json:"deviceName"`
+		Detector     string   `json:"detector"`
+		IsotopeHints []string `json:"isotopeHints"`
+	}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&payload); err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+	if math.IsNaN(payload.Lat) || math.IsNaN(payload.Lon) || payload.Lat < -90 || payload.Lat > 90 || payload.Lon < -180 || payload.Lon > 180 {
+		http.Error(w, "invalid coordinates", http.StatusBadRequest)
+		return
+	}
+	if payload.DoseRate < 0 || payload.CountRate < 0 {
+		http.Error(w, "negative values are not allowed", http.StatusBadRequest)
+		return
+	}
+
+	marker := database.Marker{
+		TrackID:    strings.TrimSpace(payload.TrackID),
+		Date:       payload.Date,
+		Lat:        payload.Lat,
+		Lon:        payload.Lon,
+		DoseRate:   payload.DoseRate,
+		CountRate:  payload.CountRate,
+		Speed:      payload.Speed,
+		Zoom:       0,
+		DeviceID:   strings.TrimSpace(payload.DeviceID),
+		DeviceName: strings.TrimSpace(payload.DeviceName),
+		Detector:   strings.TrimSpace(payload.Detector),
+		Radiation:  strings.Join(payload.IsotopeHints, ", "),
+	}
+
+	savedMarker, err := db.UpsertRadiacodeLivePoint(r.Context(), marker, 1e-6)
+	if err != nil {
+		log.Printf("radiacode live upsert failed: %v", err)
+		http.Error(w, "save failed", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"ok":     true,
+		"marker": savedMarker,
+	})
+}
+
 func manualSpectrumPointHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", http.MethodPost)
@@ -8283,6 +8354,7 @@ func main() {
 	http.HandleFunc("/api/spectrum/manual-point", manualSpectrumPointHandler)
 	http.HandleFunc("/api/spectrum/attach-track", attachSpectrumToTrackHandler)
 	http.HandleFunc("/api/spectrum/attach-area", attachSpectrumToAreaHandler)
+	http.HandleFunc("/api/radiacode/live-point", radiacodeLivePointHandler)
 	http.HandleFunc("/desktop/download-track/", desktopTrackDownloadHandler)
 	http.HandleFunc("/desktop/admin/bootstrap-import", desktopAdminBootstrapImportHandler)
 	http.HandleFunc("/desktop/admin/settings", desktopAdminSettingsHandler)

--- a/chicha-isotope-map.go
+++ b/chicha-isotope-map.go
@@ -6099,6 +6099,36 @@ func radiacodeLivePointHandler(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// desktopBluetoothScanHandler exposes host-side discovery for desktop runtimes
+// where Web Bluetooth is unavailable in the embedded webview. Keeping scan logic
+// in the backend mirrors existing native file-dialog handlers.
+func desktopBluetoothScanHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !isTrustedDesktopAdminRequest(r) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	devices, err := desktop.ScanRadiacodeDevices(ctx)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"ok":      true,
+		"devices": devices,
+	})
+}
+
 func manualSpectrumPointHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		w.Header().Set("Allow", http.MethodPost)
@@ -8351,6 +8381,7 @@ func main() {
 	http.HandleFunc("/licenses/", licenseHandler)
 	http.HandleFunc("/upload", uploadHandler)
 	http.HandleFunc("/desktop/upload-native", desktopNativeUploadHandler)
+	http.HandleFunc("/desktop/bluetooth/scan", desktopBluetoothScanHandler)
 	http.HandleFunc("/api/spectrum/manual-point", manualSpectrumPointHandler)
 	http.HandleFunc("/api/spectrum/attach-track", attachSpectrumToTrackHandler)
 	http.HandleFunc("/api/spectrum/attach-area", attachSpectrumToAreaHandler)

--- a/pkg/database/radiacode_live.go
+++ b/pkg/database/radiacode_live.go
@@ -1,0 +1,116 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+)
+
+// UpsertRadiacodeLivePoint keeps a single marker per coordinate and track while
+// preserving the maximum dose and CPS values observed for that location.
+//
+// We intentionally keep the SQL portable (database/sql placeholders only), so
+// the same logic works across SQLite, DuckDB, PostgreSQL, and ClickHouse-backed
+// paths without driver-specific UPSERT syntax.
+func (db *Database) UpsertRadiacodeLivePoint(ctx context.Context, marker Marker, epsilon float64) (Marker, error) {
+	if db == nil || db.DB == nil {
+		return Marker{}, fmt.Errorf("database unavailable")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if epsilon <= 0 {
+		epsilon = 1e-6
+	}
+	if marker.TrackID == "" {
+		marker.TrackID = fmt.Sprintf("radiacode-live-%d", time.Now().UTC().Unix())
+	}
+	if marker.Date <= 0 {
+		marker.Date = time.Now().UTC().Unix()
+	}
+	marker.Zoom = 0
+
+	var result Marker
+	err := db.withSerializedConnectionFor(ctx, WorkloadRealtime, func(runCtx context.Context, conn *sql.DB) error {
+		queryExisting := `
+SELECT id, doseRate, countRate, radiation
+FROM markers
+WHERE trackID = ? AND zoom = 0
+  AND lat BETWEEN ? AND ?
+  AND lon BETWEEN ? AND ?
+ORDER BY ABS(lat - ?) + ABS(lon - ?)
+LIMIT 1`
+		updateQuery := `
+UPDATE markers
+SET doseRate = ?, countRate = ?, date = ?, radiation = ?
+WHERE id = ?`
+		if db.Driver == "pgx" {
+			queryExisting = `
+SELECT id, doseRate, countRate, radiation
+FROM markers
+WHERE trackID = $1 AND zoom = 0
+  AND lat BETWEEN $2 AND $3
+  AND lon BETWEEN $4 AND $5
+ORDER BY ABS(lat - $6) + ABS(lon - $7)
+LIMIT 1`
+			updateQuery = `
+UPDATE markers
+SET doseRate = $1, countRate = $2, date = $3, radiation = $4
+WHERE id = $5`
+		}
+		row := conn.QueryRowContext(runCtx, queryExisting,
+			marker.TrackID,
+			marker.Lat-epsilon,
+			marker.Lat+epsilon,
+			marker.Lon-epsilon,
+			marker.Lon+epsilon,
+			marker.Lat,
+			marker.Lon,
+		)
+
+		var existingID int64
+		var existingDose float64
+		var existingCount float64
+		var existingRadiation sql.NullString
+		err := row.Scan(&existingID, &existingDose, &existingCount, &existingRadiation)
+		if err != nil {
+			if err != sql.ErrNoRows {
+				return fmt.Errorf("query existing radiacode point: %w", err)
+			}
+			if marker.ID == 0 {
+				marker.ID = <-db.idGenerator
+			}
+			if saveErr := db.SaveMarkerAtomic(runCtx, conn, marker, db.Driver); saveErr != nil {
+				return fmt.Errorf("insert radiacode point: %w", saveErr)
+			}
+			result = marker
+			return nil
+		}
+
+		updatedDose := math.Max(existingDose, marker.DoseRate)
+		updatedCount := math.Max(existingCount, marker.CountRate)
+		updatedRadiation := strings.TrimSpace(marker.Radiation)
+		if updatedRadiation == "" && existingRadiation.Valid {
+			updatedRadiation = existingRadiation.String
+		}
+
+		_, err = conn.ExecContext(runCtx, updateQuery, updatedDose, updatedCount, marker.Date, updatedRadiation, existingID)
+		if err != nil {
+			return fmt.Errorf("update radiacode point: %w", err)
+		}
+
+		result = marker
+		result.ID = existingID
+		result.DoseRate = updatedDose
+		result.CountRate = updatedCount
+		result.Radiation = updatedRadiation
+		return nil
+	})
+	if err != nil {
+		return Marker{}, err
+	}
+	return result, nil
+}

--- a/pkg/desktop/bluetooth_scan.go
+++ b/pkg/desktop/bluetooth_scan.go
@@ -1,0 +1,131 @@
+package desktop
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// BluetoothDevice keeps the minimal discovery payload exposed to the UI.
+type BluetoothDevice struct {
+	Name    string `json:"name"`
+	Address string `json:"address"`
+}
+
+// ScanRadiacodeDevices discovers nearby or known Bluetooth devices and returns
+// only Radiacode-like entries. The implementation uses small OS-native commands
+// so server builds avoid heavy BLE dependencies.
+func ScanRadiacodeDevices(ctx context.Context) ([]BluetoothDevice, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	var (
+		rawOutput string
+		err       error
+	)
+
+	switch runtime.GOOS {
+	case "linux":
+		rawOutput, err = runCommand(ctx, "bluetoothctl", "devices")
+	case "darwin":
+		rawOutput, err = runCommand(ctx, "system_profiler", "SPBluetoothDataType")
+	case "windows":
+		rawOutput, err = runCommand(ctx, "powershell", "-NoProfile", "-Command", "Get-PnpDevice -Class Bluetooth | Select-Object FriendlyName,InstanceId | Format-Table -HideTableHeaders")
+	default:
+		return nil, fmt.Errorf("bluetooth scan unsupported on %s", runtime.GOOS)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	switch runtime.GOOS {
+	case "linux":
+		return parseLinuxBluetoothctlDevices(rawOutput), nil
+	case "darwin":
+		return parseDarwinSystemProfiler(rawOutput), nil
+	case "windows":
+		return parseWindowsPnp(rawOutput), nil
+	default:
+		return nil, nil
+	}
+}
+
+func runCommand(ctx context.Context, name string, args ...string) (string, error) {
+	command := exec.CommandContext(ctx, name, args...)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("%s failed: %w (%s)", name, err, strings.TrimSpace(string(output)))
+	}
+	return string(output), nil
+}
+
+func parseLinuxBluetoothctlDevices(raw string) []BluetoothDevice {
+	devices := make([]BluetoothDevice, 0)
+	scanner := bufio.NewScanner(strings.NewReader(raw))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !strings.HasPrefix(line, "Device ") {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) < 3 {
+			continue
+		}
+		address := strings.TrimSpace(parts[1])
+		name := strings.TrimSpace(strings.Join(parts[2:], " "))
+		if !isRadiacodeDeviceName(name) {
+			continue
+		}
+		devices = append(devices, BluetoothDevice{Name: name, Address: address})
+	}
+	return devices
+}
+
+func parseDarwinSystemProfiler(raw string) []BluetoothDevice {
+	devices := make([]BluetoothDevice, 0)
+	scanner := bufio.NewScanner(strings.NewReader(raw))
+	currentName := ""
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasSuffix(line, ":") && isRadiacodeDeviceName(strings.TrimSuffix(line, ":")) {
+			currentName = strings.TrimSpace(strings.TrimSuffix(line, ":"))
+			devices = append(devices, BluetoothDevice{Name: currentName})
+			continue
+		}
+		if currentName == "" || !strings.HasPrefix(strings.ToLower(line), "address:") {
+			continue
+		}
+		address := strings.TrimSpace(strings.TrimPrefix(line, "Address:"))
+		address = strings.TrimSpace(strings.TrimPrefix(address, "address:"))
+		if len(devices) > 0 {
+			devices[len(devices)-1].Address = address
+		}
+		currentName = ""
+	}
+	return devices
+}
+
+func parseWindowsPnp(raw string) []BluetoothDevice {
+	devices := make([]BluetoothDevice, 0)
+	scanner := bufio.NewScanner(strings.NewReader(raw))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || !isRadiacodeDeviceName(line) {
+			continue
+		}
+		devices = append(devices, BluetoothDevice{Name: line})
+	}
+	return devices
+}
+
+func isRadiacodeDeviceName(name string) bool {
+	nameLower := strings.ToLower(strings.TrimSpace(name))
+	if nameLower == "" {
+		return false
+	}
+	return strings.Contains(nameLower, "radiacode") || strings.HasPrefix(nameLower, "rc-") || strings.Contains(nameLower, "radiacode 101") || strings.Contains(nameLower, "radiacode 102") || strings.Contains(nameLower, "radiacode 103") || strings.Contains(nameLower, "radiacode 110") || strings.Contains(nameLower, "radiacode zero")
+}

--- a/pkg/desktop/bluetooth_scan.go
+++ b/pkg/desktop/bluetooth_scan.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+	"time"
 )
 
 // BluetoothDevice keeps the minimal discovery payload exposed to the UI.
@@ -15,43 +16,155 @@ type BluetoothDevice struct {
 	Address string `json:"address"`
 }
 
-// ScanRadiacodeDevices discovers nearby or known Bluetooth devices and returns
-// only Radiacode-like entries. The implementation uses small OS-native commands
-// so server builds avoid heavy BLE dependencies.
+// ScanRadiacodeDevices performs an active discovery where possible and returns
+// only Radiacode-like devices.
 func ScanRadiacodeDevices(ctx context.Context) ([]BluetoothDevice, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 
-	var (
-		rawOutput string
-		err       error
-	)
-
 	switch runtime.GOOS {
 	case "linux":
-		rawOutput, err = runCommand(ctx, "bluetoothctl", "devices")
+		return scanRadiacodeLinuxActive(ctx)
 	case "darwin":
-		rawOutput, err = runCommand(ctx, "system_profiler", "SPBluetoothDataType")
+		return scanRadiacodeDarwin(ctx)
 	case "windows":
-		rawOutput, err = runCommand(ctx, "powershell", "-NoProfile", "-Command", "Get-PnpDevice -Class Bluetooth | Select-Object FriendlyName,InstanceId | Format-Table -HideTableHeaders")
+		return scanRadiacodeWindows(ctx)
 	default:
 		return nil, fmt.Errorf("bluetooth scan unsupported on %s", runtime.GOOS)
 	}
+}
+
+// ConnectRadiacodeDevice asks the host Bluetooth stack to connect to the device.
+func ConnectRadiacodeDevice(ctx context.Context, address string) error {
+	address = strings.TrimSpace(address)
+	if address == "" {
+		return fmt.Errorf("empty bluetooth address")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	switch runtime.GOOS {
+	case "linux":
+		output, err := runCommand(ctx, "bluetoothctl", "connect", address)
+		if err != nil {
+			return err
+		}
+		if !strings.Contains(strings.ToLower(output), "connection successful") {
+			return fmt.Errorf("connect failed: %s", strings.TrimSpace(output))
+		}
+		return nil
+	case "darwin", "windows":
+		return fmt.Errorf("native bluetooth connect is not implemented on %s yet; use Chrome/Edge Web Bluetooth", runtime.GOOS)
+	default:
+		return fmt.Errorf("bluetooth connect unsupported on %s", runtime.GOOS)
+	}
+}
+
+func scanRadiacodeLinuxActive(ctx context.Context) ([]BluetoothDevice, error) {
+	scanCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	output, err := runCommand(scanCtx, "bluetoothctl", "--timeout", "8", "scan", "on")
+	if err != nil {
+		return nil, err
+	}
+	_, _ = runCommand(context.Background(), "bluetoothctl", "scan", "off")
+
+	radiacodeDevices := parseLinuxScanOutput(output)
+	if len(radiacodeDevices) > 0 {
+		return radiacodeDevices, nil
+	}
+
+	fallbackOutput, fallbackErr := runCommand(ctx, "bluetoothctl", "devices")
+	if fallbackErr != nil {
+		return nil, fallbackErr
+	}
+	return parseLinuxKnownDevices(fallbackOutput), nil
+}
+
+func parseLinuxScanOutput(raw string) []BluetoothDevice {
+	deviceByAddress := make(map[string]BluetoothDevice)
+	scanner := bufio.NewScanner(strings.NewReader(raw))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !(strings.Contains(line, "[NEW] Device") || strings.Contains(line, "[CHG] Device") || strings.HasPrefix(line, "Device ")) {
+			continue
+		}
+		address, name := splitAddressAndName(line)
+		if address == "" || !isRadiacodeDeviceName(name) {
+			continue
+		}
+		deviceByAddress[address] = BluetoothDevice{Name: name, Address: address}
+	}
+	return mapValues(deviceByAddress)
+}
+
+func parseLinuxKnownDevices(raw string) []BluetoothDevice {
+	deviceByAddress := make(map[string]BluetoothDevice)
+	scanner := bufio.NewScanner(strings.NewReader(raw))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !strings.HasPrefix(line, "Device ") {
+			continue
+		}
+		address, name := splitAddressAndName(line)
+		if address == "" || !isRadiacodeDeviceName(name) {
+			continue
+		}
+		deviceByAddress[address] = BluetoothDevice{Name: name, Address: address}
+	}
+	return mapValues(deviceByAddress)
+}
+
+func scanRadiacodeDarwin(ctx context.Context) ([]BluetoothDevice, error) {
+	output, err := runCommand(ctx, "system_profiler", "SPBluetoothDataType")
 	if err != nil {
 		return nil, err
 	}
 
-	switch runtime.GOOS {
-	case "linux":
-		return parseLinuxBluetoothctlDevices(rawOutput), nil
-	case "darwin":
-		return parseDarwinSystemProfiler(rawOutput), nil
-	case "windows":
-		return parseWindowsPnp(rawOutput), nil
-	default:
-		return nil, nil
+	devices := make([]BluetoothDevice, 0)
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	currentName := ""
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasSuffix(line, ":") {
+			candidateName := strings.TrimSpace(strings.TrimSuffix(line, ":"))
+			if isRadiacodeDeviceName(candidateName) {
+				currentName = candidateName
+				devices = append(devices, BluetoothDevice{Name: candidateName})
+			}
+			continue
+		}
+		if currentName == "" || !strings.HasPrefix(strings.ToLower(line), "address:") {
+			continue
+		}
+		address := strings.TrimSpace(line[len("Address:"):])
+		if len(devices) > 0 {
+			devices[len(devices)-1].Address = address
+		}
+		currentName = ""
 	}
+	return devices, nil
+}
+
+func scanRadiacodeWindows(ctx context.Context) ([]BluetoothDevice, error) {
+	output, err := runCommand(ctx, "powershell", "-NoProfile", "-Command", "Get-PnpDevice -Class Bluetooth | Select-Object FriendlyName | Format-Table -HideTableHeaders")
+	if err != nil {
+		return nil, err
+	}
+
+	devices := make([]BluetoothDevice, 0)
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	for scanner.Scan() {
+		name := strings.TrimSpace(scanner.Text())
+		if !isRadiacodeDeviceName(name) {
+			continue
+		}
+		devices = append(devices, BluetoothDevice{Name: name})
+	}
+	return devices, nil
 }
 
 func runCommand(ctx context.Context, name string, args ...string) (string, error) {
@@ -63,61 +176,30 @@ func runCommand(ctx context.Context, name string, args ...string) (string, error
 	return string(output), nil
 }
 
-func parseLinuxBluetoothctlDevices(raw string) []BluetoothDevice {
-	devices := make([]BluetoothDevice, 0)
-	scanner := bufio.NewScanner(strings.NewReader(raw))
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if !strings.HasPrefix(line, "Device ") {
-			continue
-		}
-		parts := strings.Fields(line)
-		if len(parts) < 3 {
-			continue
-		}
-		address := strings.TrimSpace(parts[1])
-		name := strings.TrimSpace(strings.Join(parts[2:], " "))
-		if !isRadiacodeDeviceName(name) {
-			continue
-		}
-		devices = append(devices, BluetoothDevice{Name: name, Address: address})
+func splitAddressAndName(line string) (string, string) {
+	parts := strings.Fields(line)
+	if len(parts) < 3 {
+		return "", ""
 	}
-	return devices
+	addressIndex := -1
+	for index := 0; index < len(parts); index++ {
+		if strings.Count(parts[index], ":") == 5 {
+			addressIndex = index
+			break
+		}
+	}
+	if addressIndex == -1 || addressIndex+1 >= len(parts) {
+		return "", ""
+	}
+	address := strings.TrimSpace(parts[addressIndex])
+	name := strings.TrimSpace(strings.Join(parts[addressIndex+1:], " "))
+	return address, name
 }
 
-func parseDarwinSystemProfiler(raw string) []BluetoothDevice {
-	devices := make([]BluetoothDevice, 0)
-	scanner := bufio.NewScanner(strings.NewReader(raw))
-	currentName := ""
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if strings.HasSuffix(line, ":") && isRadiacodeDeviceName(strings.TrimSuffix(line, ":")) {
-			currentName = strings.TrimSpace(strings.TrimSuffix(line, ":"))
-			devices = append(devices, BluetoothDevice{Name: currentName})
-			continue
-		}
-		if currentName == "" || !strings.HasPrefix(strings.ToLower(line), "address:") {
-			continue
-		}
-		address := strings.TrimSpace(strings.TrimPrefix(line, "Address:"))
-		address = strings.TrimSpace(strings.TrimPrefix(address, "address:"))
-		if len(devices) > 0 {
-			devices[len(devices)-1].Address = address
-		}
-		currentName = ""
-	}
-	return devices
-}
-
-func parseWindowsPnp(raw string) []BluetoothDevice {
-	devices := make([]BluetoothDevice, 0)
-	scanner := bufio.NewScanner(strings.NewReader(raw))
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || !isRadiacodeDeviceName(line) {
-			continue
-		}
-		devices = append(devices, BluetoothDevice{Name: line})
+func mapValues(deviceByAddress map[string]BluetoothDevice) []BluetoothDevice {
+	devices := make([]BluetoothDevice, 0, len(deviceByAddress))
+	for _, device := range deviceByAddress {
+		devices = append(devices, device)
 	}
 	return devices
 }

--- a/pkg/desktop/bluetooth_scan.go
+++ b/pkg/desktop/bluetooth_scan.go
@@ -3,6 +3,7 @@ package desktop
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os/exec"
 	"runtime"
@@ -55,8 +56,10 @@ func ConnectRadiacodeDevice(ctx context.Context, address string) error {
 			return fmt.Errorf("connect failed: %s", strings.TrimSpace(output))
 		}
 		return nil
-	case "darwin", "windows":
-		return fmt.Errorf("native bluetooth connect is not implemented on %s yet; use Chrome/Edge Web Bluetooth", runtime.GOOS)
+	case "darwin":
+		return connectRadiacodeDarwin(ctx, address)
+	case "windows":
+		return fmt.Errorf("native bluetooth connect is not implemented on windows yet; use Chrome/Edge Web Bluetooth")
 	default:
 		return fmt.Errorf("bluetooth connect unsupported on %s", runtime.GOOS)
 	}
@@ -119,8 +122,16 @@ func parseLinuxKnownDevices(raw string) []BluetoothDevice {
 }
 
 func scanRadiacodeDarwin(ctx context.Context) ([]BluetoothDevice, error) {
+	blueutilDevices, blueutilErr := scanRadiacodeDarwinBlueutil(ctx)
+	if blueutilErr == nil && len(blueutilDevices) > 0 {
+		return blueutilDevices, nil
+	}
+
 	output, err := runCommand(ctx, "system_profiler", "SPBluetoothDataType")
 	if err != nil {
+		if blueutilErr != nil {
+			return nil, fmt.Errorf("blueutil scan failed: %v; system_profiler scan failed: %w", blueutilErr, err)
+		}
 		return nil, err
 	}
 
@@ -147,6 +158,42 @@ func scanRadiacodeDarwin(ctx context.Context) ([]BluetoothDevice, error) {
 		currentName = ""
 	}
 	return devices, nil
+}
+
+func scanRadiacodeDarwinBlueutil(ctx context.Context) ([]BluetoothDevice, error) {
+	output, err := runCommand(ctx, "blueutil", "--inquiry", "8", "--format", "json")
+	if err != nil {
+		return nil, err
+	}
+	var records []map[string]any
+	if err := json.Unmarshal([]byte(output), &records); err != nil {
+		return nil, fmt.Errorf("parse blueutil inquiry json: %w", err)
+	}
+
+	devices := make([]BluetoothDevice, 0, len(records))
+	for _, record := range records {
+		name, _ := record["name"].(string)
+		address, _ := record["address"].(string)
+		if !isRadiacodeDeviceName(name) {
+			continue
+		}
+		devices = append(devices, BluetoothDevice{Name: strings.TrimSpace(name), Address: strings.TrimSpace(address)})
+	}
+	return devices, nil
+}
+
+func connectRadiacodeDarwin(ctx context.Context, address string) error {
+	if _, err := runCommand(ctx, "blueutil", "--connect", address); err != nil {
+		return fmt.Errorf("blueutil connect failed (install blueutil via brew for desktop bridge): %w", err)
+	}
+	statusOutput, statusErr := runCommand(ctx, "blueutil", "--is-connected", address)
+	if statusErr != nil {
+		return nil
+	}
+	if strings.TrimSpace(statusOutput) != "1" {
+		return fmt.Errorf("blueutil reported not connected")
+	}
+	return nil
 }
 
 func scanRadiacodeWindows(ctx context.Context) ([]BluetoothDevice, error) {

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -9502,9 +9502,34 @@ function centerMapToLocation() {
     if (!response.ok) throw new Error('save failed with HTTP ' + response.status);
   }
 
+  async function scanRadiacodeDevicesViaDesktopBridge() {
+    const response = await fetch('/desktop/bluetooth/scan');
+    if (!response.ok) throw new Error('desktop scan failed with HTTP ' + response.status);
+    const payload = await response.json();
+    const discoveredDevices = Array.isArray(payload.devices) ? payload.devices : [];
+    if (!discoveredDevices.length) {
+      alert('Desktop Bluetooth scan finished: Radiacode devices not found.');
+      return;
+    }
+    const lines = discoveredDevices.map(function(discoveredDevice, index) {
+      const nameText = discoveredDevice && discoveredDevice.name ? String(discoveredDevice.name) : 'unknown name';
+      const addressText = discoveredDevice && discoveredDevice.address ? String(discoveredDevice.address) : 'unknown address';
+      return String(index + 1) + '. ' + nameText + ' [' + addressText + ']';
+    });
+    alert('Desktop Bluetooth scan found:\\n' + lines.join('\\n') + '\\n\\nNext step: select a device in native desktop bridge (planned in next patch).');
+  }
+
   async function connectRadiacodeBluetoothAndStream() {
+    if (!window.isSecureContext && location.hostname !== 'localhost' && location.hostname !== '127.0.0.1') {
+      alert('Web Bluetooth requires HTTPS (secure context).');
+      return;
+    }
     if (!navigator.bluetooth) {
-      alert('Web Bluetooth is not available in this runtime.');
+      if (window.desktopWebViewMode) {
+        await scanRadiacodeDevicesViaDesktopBridge();
+        return;
+      }
+      alert('Web Bluetooth is not available. Open the site over HTTPS or localhost, or use desktop mode with native bridge.');
       return;
     }
 

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -9516,7 +9516,29 @@ function centerMapToLocation() {
       const addressText = discoveredDevice && discoveredDevice.address ? String(discoveredDevice.address) : 'unknown address';
       return String(index + 1) + '. ' + nameText + ' [' + addressText + ']';
     });
-    alert('Desktop Bluetooth scan found:\\n' + lines.join('\\n') + '\\n\\nNext step: select a device in native desktop bridge (planned in next patch).');
+    const selectedNumberText = prompt('Desktop Bluetooth scan found:\\n' + lines.join('\\n') + '\\n\\nEnter device number to connect:');
+    if (!selectedNumberText) return;
+    const selectedIndex = Number.parseInt(String(selectedNumberText), 10) - 1;
+    if (!Number.isInteger(selectedIndex) || selectedIndex < 0 || selectedIndex >= discoveredDevices.length) {
+      alert('Invalid device number.');
+      return;
+    }
+    const selectedDevice = discoveredDevices[selectedIndex];
+    const selectedAddress = selectedDevice && selectedDevice.address ? String(selectedDevice.address) : '';
+    if (!selectedAddress) {
+      alert('Selected device does not have an address.');
+      return;
+    }
+    const connectResponse = await fetch('/desktop/bluetooth/connect', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({address: selectedAddress})
+    });
+    if (!connectResponse.ok) {
+      const errorText = await connectResponse.text();
+      throw new Error('desktop connect failed: ' + errorText);
+    }
+    alert('Connected to ' + (selectedDevice.name || selectedAddress) + '.\\nIf the device sends notifications via Web Bluetooth-compatible stack, markers will appear as data arrives.');
   }
 
   async function connectRadiacodeBluetoothAndStream() {

--- a/public_html/map.html
+++ b/public_html/map.html
@@ -1672,6 +1672,8 @@ body, html {
         <img src="/static/images/marker-icon-2x.png" alt="Locate" style="width:20px;">
       </button>
       <br>
+      <button id="radiacodeBluetoothButton" class="locate-btn" type="button" aria-label="Radiacode Bluetooth">📶</button>
+      <br>
       {{if not .DesktopWebView}}
         <!-- Small QR button under geolocate -->
         <button id="qrButton" class="qr-btn" aria-label="{{translate "qr_button_tooltip"}}">
@@ -9471,7 +9473,100 @@ function centerMapToLocation() {
     }
   });
 
+  const radiacodeBluetoothModel = { activeTrackID: '', connectedDeviceName: '', connectedDeviceID: '' };
+  const radiacodeServiceUUID = 'e63215e5-7003-49d8-96b0-b024798fb901';
+  const radiacodeWriteUUID = 'e63215e6-7003-49d8-96b0-b024798fb901';
+  const radiacodeNotifyUUID = 'e63215e7-7003-49d8-96b0-b024798fb901';
+
+  function ensureRadiacodeTrackID() {
+    if (radiacodeBluetoothModel.activeTrackID) return radiacodeBluetoothModel.activeTrackID;
+    radiacodeBluetoothModel.activeTrackID = 'radiacode-live-' + String(Date.now());
+    return radiacodeBluetoothModel.activeTrackID;
+  }
+
+  function inferIsotopeHintsFromSpectrumPayload(rawPayloadHex) {
+    const payloadHex = String(rawPayloadHex || '').toLowerCase();
+    const isotopeHints = [];
+    if (payloadHex.includes('0662')) isotopeHints.push('Cs-137 (possible)');
+    if (payloadHex.includes('1173') || payloadHex.includes('1332')) isotopeHints.push('Co-60 (possible)');
+    if (payloadHex.includes('0609')) isotopeHints.push('Bi-214 (possible)');
+    return isotopeHints;
+  }
+
+  async function pushRadiacodePointToServer(pointPayload) {
+    const response = await fetch('/api/radiacode/live-point', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify(pointPayload)
+    });
+    if (!response.ok) throw new Error('save failed with HTTP ' + response.status);
+  }
+
+  async function connectRadiacodeBluetoothAndStream() {
+    if (!navigator.bluetooth) {
+      alert('Web Bluetooth is not available in this runtime.');
+      return;
+    }
+
+    const radiacodeDevice = await navigator.bluetooth.requestDevice({
+      filters: [{namePrefix: 'RadiaCode'}, {namePrefix: 'Radiacode'}, {namePrefix: 'RC-'}],
+      optionalServices: [radiacodeServiceUUID]
+    });
+    const gattServer = await radiacodeDevice.gatt.connect();
+    const radiacodeService = await gattServer.getPrimaryService(radiacodeServiceUUID);
+    const notifyCharacteristic = await radiacodeService.getCharacteristic(radiacodeNotifyUUID);
+    const writeCharacteristic = await radiacodeService.getCharacteristic(radiacodeWriteUUID);
+
+    radiacodeBluetoothModel.connectedDeviceName = radiacodeDevice.name || 'RadiaCode';
+    radiacodeBluetoothModel.connectedDeviceID = radiacodeDevice.id || '';
+    const activeTrackID = ensureRadiacodeTrackID();
+
+    notifyCharacteristic.addEventListener('characteristicvaluechanged', async function(event) {
+      const bytes = [];
+      const valueBuffer = event.target.value;
+      for (let offset = 0; offset < valueBuffer.byteLength; offset++) bytes.push(valueBuffer.getUint8(offset));
+      const payloadHex = bytes.map(function(currentByte) { return currentByte.toString(16).padStart(2, '0'); }).join('');
+      const doseRate = bytes.length >= 2 ? ((bytes[0] | (bytes[1] << 8)) / 100) : 0;
+      const countRate = bytes.length >= 4 ? (bytes[2] | (bytes[3] << 8)) : 0;
+
+      let geoposition;
+      try {
+        geoposition = await new Promise(function(resolve, reject) {
+          navigator.geolocation.getCurrentPosition(resolve, reject, {enableHighAccuracy: true, timeout: 5000});
+        });
+      } catch (geolocationError) {
+        return;
+      }
+
+      await pushRadiacodePointToServer({
+        trackID: activeTrackID,
+        date: Math.floor(Date.now() / 1000),
+        lat: geoposition.coords.latitude,
+        lon: geoposition.coords.longitude,
+        doseRate: doseRate,
+        countRate: countRate,
+        deviceID: radiacodeBluetoothModel.connectedDeviceID,
+        deviceName: radiacodeBluetoothModel.connectedDeviceName,
+        detector: radiacodeBluetoothModel.connectedDeviceName,
+        isotopeHints: inferIsotopeHintsFromSpectrumPayload(payloadHex)
+      });
+    });
+
+    await notifyCharacteristic.startNotifications();
+    await writeCharacteristic.writeValue(new Uint8Array([0x07, 0x00, 0x01, 0xff, 0x12, 0xff]));
+  }
+
   (function(){
+    var btButton = document.getElementById('radiacodeBluetoothButton');
+    if (btButton) {
+      btButton.addEventListener('click', function() {
+        connectRadiacodeBluetoothAndStream().catch(function(connectError) {
+          console.error('Radiacode Bluetooth connect failed', connectError);
+          alert('Radiacode Bluetooth error: ' + connectError.message);
+        });
+      });
+    }
+
     var el = document.getElementById('legend');
     if (el) {
       el.addEventListener('click', openLegendModal);


### PR DESCRIPTION
### Motivation
- Provide Web/desktop support for streaming Radiacode dosimeters so users can discover/connect devices and record live radiation tracks on the map. 
- Persist realtime points in a way that keeps the highest observed dose and CPS for each location to produce stable hotspot markers.
- Reuse community Radiacode Bluetooth conventions as a starting point while keeping the implementation portable across supported SQL backends.

### Description
- Adds a new HTTP endpoint `POST /api/radiacode/live-point` which validates incoming realtime payloads, builds a `database.Marker` and returns the saved marker JSON. 
- Implements `Database.UpsertRadiacodeLivePoint` in `pkg/database/radiacode_live.go` which finds a nearby zoom-0 marker for the same track (within `epsilon`), inserts if missing, or updates the existing row using `max(doseRate)` and `max(countRate)`; SQL uses driver-aware placeholders (`?` vs `$n`) so it stays portable. 
- Wires the new handler into main routing so the endpoint is available to web and desktop modes (`chicha-isotope-map.go`). 
- Adds a Bluetooth control button (`📶`) to the map UI and a Web Bluetooth pipeline in `public_html/map.html` that: discovers Radiacode-like devices by name prefixes, connects to community-known service/characteristic UUIDs, starts notifications, reads notification frames, pairs each notification with a geolocation lookup, heuristically infers crude isotope hints from payload patterns, and posts live points to `/api/radiacode/live-point`. 
- Keeps realtime DB writes serialized by using the existing `WorkloadRealtime` lane to avoid mutexes and preserve ordering; initial payload decoding and isotope inference are intentionally lightweight scaffolds to be replaced by a full Radiacode frame parser later.

### Testing
- Ran code formatting: `gofmt -w chicha-isotope-map.go pkg/database/radiacode_live.go` (applied). 
- Ran unit tests / package checks with `go test ./...` and there were no failing tests.
- Smoke-validated compile and local registration of new routes; further runtime integration (BLE end-to-end) and protocol-level spectrum parsing are recommended as follow-up work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee367775148332a8fc3d4424a588a5)