### PR TITLE
docs: align central README downloads with Stable Release flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,90 +16,82 @@ Radiacode, AtomFast, BGeigie Safecast devices supported.
 </div>
 
 
-## Desktop app (GUI)
+## Downloads (Stable Release)
 
-Best for personal local use.
+Use the **Stable Release** channel so one constant link always points to the newest binaries built from commits containing `stable release`.
 
-### Download
-- [Desktop for Windows (amd64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_windows_amd64_desktop.exe)
-- [Desktop for Windows (arm64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_windows_arm64_desktop.exe)
-- [Desktop for Windows (amd64, zip)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_windows_amd64_desktop.zip)
-- [Desktop for Windows (arm64, zip)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_windows_arm64_desktop.zip)
-- [Desktop for macOS Apple Silicon (arm64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_darwin_arm64_desktop)
-- [Desktop for macOS Intel (amd64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_darwin_amd64_desktop)
-- [Desktop for Linux (amd64, Mint 21 / Ubuntu 22.04, zip)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64_desktop_gtk40.zip)
-- [Desktop for Linux (amd64, Mint 22 / Ubuntu 24.04+, zip)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64_desktop_gtk41.zip)
-- [Desktop for Linux (arm64, Mint 21 / Ubuntu 22.04, zip)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_arm64_desktop_gtk40.zip)
-- [Desktop for Linux (arm64, Mint 22 / Ubuntu 24.04+, zip)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_arm64_desktop_gtk41.zip)
+- **Smart download page (recommended):** https://matveynator.github.io/chicha-isotope-map/
+- **Stable Release tag (all artifacts):** https://github.com/matveynator/chicha-isotope-map/releases/tag/stable-release
 
-### Run
+### Desktop app (GUI)
+
+Pick your OS first, then architecture.
+
+| OS | Architecture / Variant | Artifact |
+|---|---|---|
+| macOS | Universal (Intel + Apple Silicon) | [chicha-isotope-map_darwin_universal_desktop.dmg](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_darwin_universal_desktop.dmg) |
+| Windows | amd64 | [chicha-isotope-map_windows_amd64_desktop.zip](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_windows_amd64_desktop.zip) |
+| Windows | arm64 | [chicha-isotope-map_windows_arm64_desktop.zip](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_windows_arm64_desktop.zip) |
+| Linux GTK 4.0 (Ubuntu 22.04 / Mint 21.x) | amd64 | [chicha-isotope-map_linux_amd64_desktop_gtk40.zip](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64_desktop_gtk40.zip) |
+| Linux GTK 4.0 (Ubuntu 22.04 / Mint 21.x) | arm64 | [chicha-isotope-map_linux_arm64_desktop_gtk40.zip](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_arm64_desktop_gtk40.zip) |
+| Linux GTK 4.1 (Ubuntu 24.04+ / Mint 22+) | amd64 | [chicha-isotope-map_linux_amd64_desktop_gtk41.zip](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64_desktop_gtk41.zip) |
+| Linux GTK 4.1 (Ubuntu 24.04+ / Mint 22+) | arm64 | [chicha-isotope-map_linux_arm64_desktop_gtk41.zip](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_arm64_desktop_gtk41.zip) |
+
+### Server binaries (self-hosted)
+
+| OS | Architecture | Artifact |
+|---|---|---|
+| Linux | amd64 | [chicha-isotope-map_linux_amd64](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64) |
+| Linux | arm64 | [chicha-isotope-map_linux_arm64](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_arm64) |
+| Windows | amd64 | [chicha-isotope-map_windows_amd64.exe](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_windows_amd64.exe) |
+| Windows | arm64 | [chicha-isotope-map_windows_arm64.exe](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_windows_arm64.exe) |
+| macOS | amd64 | [chicha-isotope-map_darwin_amd64](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_darwin_amd64) |
+| macOS | arm64 | [chicha-isotope-map_darwin_arm64](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_darwin_arm64) |
+| FreeBSD | amd64 / arm64 | [Stable Release assets](https://github.com/matveynator/chicha-isotope-map/releases/tag/stable-release) |
+| OpenBSD | amd64 / arm64 | [Stable Release assets](https://github.com/matveynator/chicha-isotope-map/releases/tag/stable-release) |
+
+### Quick run
+
 Windows:
-1. Download `.exe` directly (or `.zip` if your browser/security policy blocks direct `.exe` downloads)
-2. Double click
-3. If SmartScreen appears: **More info → Run anyway**
+1. Download a `.zip` desktop build (or `.exe` server build).
+2. Extract if needed.
+3. Run the binary. If SmartScreen appears: **More info → Run anyway**.
 
-macOS:
+macOS (server binary example):
 ```bash
-chmod +x ./chicha-isotope-map_darwin_*_desktop
-./chicha-isotope-map_darwin_*_desktop
+chmod +x ./chicha-isotope-map_darwin_*
+./chicha-isotope-map_darwin_*
 ```
 
-Linux:
+Linux desktop (GTK 4.1 amd64 example):
 ```bash
 curl -fL https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64_desktop_gtk41.zip -o chicha-isotope-map-desktop.zip
 unzip chicha-isotope-map-desktop.zip
 chmod +x ./chicha-isotope-map_linux_amd64_desktop_gtk41
 ./chicha-isotope-map_linux_amd64_desktop_gtk41
 ```
-Linux desktop release now ships as a regular executable binary in a `.zip` archive.
-Use `*_gtk40` for Ubuntu 22.04 / Mint 21 and `*_gtk41` for Ubuntu 24.04+ / Mint 22 (both amd64 and arm64).
 
-### Build desktop from source
-
-Desktop WebView builds require CGO.
-
-macOS/Linux:
+Linux server quick install:
 ```bash
-CGO_ENABLED=1 go build -tags desktop .
-./chicha-isotope-map -desktop
+sudo curl -fL https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64 -o /usr/local/bin/chicha-isotope-map
+sudo chmod +x /usr/local/bin/chicha-isotope-map
+/usr/local/bin/chicha-isotope-map
 ```
-
-Server-only binary (no embedded desktop window):
-```bash
-CGO_ENABLED=0 go build .
-./chicha-isotope-map
-```
-
-### Screenshots:
-
-<img width="100%" alt="desktop placeholder 1" src="https://github.com/user-attachments/assets/617a0ced-4280-41c2-9320-de1cfd33a61f" />
-<img width="100%" alt="desktop placeholder 2" src="https://github.com/user-attachments/assets/13256b23-744d-4d02-a26c-ae9aef5b0d87" />
+Open: http://localhost:8765
 
 ---
 
-## Server version (self-hosted)
+## Program screenshots
 
-### Quick start (Linux)
-```bash
-sudo curl -fL https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64 -o /usr/local/bin/chicha-isotope-map; chmod +x /usr/local/bin/chicha-isotope-map; /usr/local/bin/chicha-isotope-map;
-```
-Open: [http://localhost:8765](http://localhost:8765)
+Screenshots are taken from the official stable download page:
 
-### Other server binaries
-- [Server for Windows (amd64)](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_windows_amd64.exe)
-- [Server for macOS arm64](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_darwin_arm64)
-- [Server for macOS amd64](https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_darwin_amd64)
-- [All release assets (FreeBSD/OpenBSD/arm64/etc)](https://github.com/matveynator/chicha-isotope-map/releases/tag/stable-release)
-
-### Public HTTPS domain
-```bash
-./chicha-isotope-map -domain your-domain.example
-```
-Ports 80/443 must be open.
+![macOS desktop preview](https://matveynator.github.io/chicha-isotope-map/chicha-isotope-map-macosx-universal.png)
+![Windows desktop preview](https://matveynator.github.io/chicha-isotope-map/windows-osm-light.png)
+![Linux desktop preview](https://matveynator.github.io/chicha-isotope-map/linux-amd64-desktop.png)
 
 ---
 
-## Advanced flags and PostgreSQL
+## Configuration and deployment
 
 ### Useful flags
 - `-port 8765`
@@ -123,12 +115,33 @@ Ports 80/443 must be open.
   -port 8765
 ```
 
+### Public HTTPS domain
+```bash
+./chicha-isotope-map -domain your-domain.example
+```
+Ports `80/443` must be open.
+
 ### Preload real tracks once
 ```bash
 ./chicha-isotope-map -import-tgz-url https://pelora.org/api/json/weekly.tgz
 ```
 
+### Build from source
 
+Desktop WebView builds require CGO.
+
+```bash
+CGO_ENABLED=1 go build -tags desktop .
+./chicha-isotope-map -desktop
+```
+
+Server-only binary (no embedded desktop window):
+```bash
+CGO_ENABLED=0 go build .
+./chicha-isotope-map
+```
+
+---
 
 ## Universal isotope catalog and spectrum drivers
 
@@ -154,7 +167,7 @@ This gives one universal parser entrypoint and one extensible isotope catalog, w
 
 ---
 
-## History and contributors
+## Acknowledgements
 
 This project was conceived to grant people a clear and immediate understanding of radiation safety in the very places they inhabit—where they reside, labor, cultivate the land, and draw water.
 


### PR DESCRIPTION
### Motivation
- Make it easy for users to find and download the correct binary for their OS/architecture by aligning the central `README.md` with the published Stable Release flow and the dedicated download page. 
- Surface the permanent `stable-release` tag and the smart download page so one constant link always points to the latest official binaries. 
- Replace local placeholder screenshots and scattered download notes with clear, consistent artifacts and a compact configuration/deployment section. 

### Description
- Replaced the old download block with a `Downloads (Stable Release)` section that links to the smart download page and the `stable-release` tag. 
- Added OS / architecture tables for Desktop and Server binaries including separate GTK 4.0 / GTK 4.1 Linux desktop entries and concrete artifact links. 
- Updated quick run instructions for Windows/macOS/Linux and moved build-related details into a `Configuration and deployment` section while preserving the isotope/spectrum functionality docs. 
- Replaced placeholder images with screenshots from `https://matveynator.github.io/chicha-isotope-map/` and renamed `History and contributors` to `Acknowledgements`. 

### Testing
- Ran `git diff --check` which returned clean results. 
- Verified working tree with `git status --short` showing the intended `README.md` modification. 
- Committed the documentation-only change with message `docs: align README downloads with Stable Release page` and no runtime code was changed so no unit tests were required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee9c2d96a483328cc881d8ddb4bbe9)