### PR TITLE
docs(ru): add autostart service scripts for Linux and BSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,142 @@ sudo chmod +x /usr/local/bin/chicha-isotope-map
 ```
 Open: http://localhost:8765
 
+### Autostart service scripts (copy/paste)
+The commands below follow the stable download page conventions (Linux systemd setup and FreeBSD/OpenBSD quick install) and use stable-release artifact names.
+
+#### Linux + systemd (amd64)
+```bash
+sudo bash -c 'set -euo pipefail
+curl -fL https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64 -o /usr/local/bin/chicha-isotope-map
+chmod +x /usr/local/bin/chicha-isotope-map
+cat >/etc/systemd/system/chicha-isotope-map.service <<"UNIT"
+[Unit]
+Description=Chicha Isotope Map
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/chicha-isotope-map -port 8765
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+systemctl daemon-reload
+systemctl enable --now chicha-isotope-map
+systemctl status --no-pager chicha-isotope-map || true'
+```
+
+#### Linux + systemd (arm64)
+```bash
+sudo bash -c 'set -euo pipefail
+curl -fL https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_arm64 -o /usr/local/bin/chicha-isotope-map
+chmod +x /usr/local/bin/chicha-isotope-map
+cat >/etc/systemd/system/chicha-isotope-map.service <<"UNIT"
+[Unit]
+Description=Chicha Isotope Map
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/chicha-isotope-map -port 8765
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+systemctl daemon-reload
+systemctl enable --now chicha-isotope-map
+systemctl status --no-pager chicha-isotope-map || true'
+```
+
+#### FreeBSD (rc.d, amd64/arm64)
+```bash
+# amd64: change URL to *_arm64 for arm64 hosts
+sudo sh -c 'set -eu
+fetch -o /usr/local/bin/chicha-isotope-map https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_freebsd_amd64
+chmod +x /usr/local/bin/chicha-isotope-map
+cat >/usr/local/etc/rc.d/chicha_isotope_map <<"RC"
+#!/bin/sh
+# PROVIDE: chicha_isotope_map
+# REQUIRE: NETWORKING
+# KEYWORD: shutdown
+
+. /etc/rc.subr
+
+name="chicha_isotope_map"
+rcvar="${name}_enable"
+command="/usr/local/bin/chicha-isotope-map"
+command_args="-port 8765 >> /var/log/chicha-isotope-map.log 2>&1"
+pidfile="/var/run/${name}.pid"
+
+load_rc_config $name
+: ${chicha_isotope_map_enable:=NO}
+
+run_rc_command "$1"
+RC
+chmod +x /usr/local/etc/rc.d/chicha_isotope_map
+sysrc chicha_isotope_map_enable=YES
+service chicha_isotope_map start'
+```
+
+#### OpenBSD (rc.d, amd64/arm64)
+```bash
+# amd64: change URL to *_arm64 for arm64 hosts
+sudo sh -c 'set -eu
+ftp -o /usr/local/bin/chicha-isotope-map https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_openbsd_amd64
+chmod +x /usr/local/bin/chicha-isotope-map
+cat >/etc/rc.d/chicha_isotope_map <<"RC"
+#!/bin/ksh
+
+daemon="/usr/local/bin/chicha-isotope-map"
+daemon_flags="-port 8765"
+
+. /etc/rc.d/rc.subr
+
+rc_bg=YES
+rc_cmd $1
+RC
+chmod +x /etc/rc.d/chicha_isotope_map
+rcctl enable chicha_isotope_map
+rcctl start chicha_isotope_map'
+```
+
+#### NetBSD (rc.d, amd64/arm64)
+```bash
+# Build binary on NetBSD first (replace GOARCH with arm64 when needed):
+# GOOS=netbsd GOARCH=amd64 go build -o chicha-isotope-map .
+
+sudo sh -c 'set -eu
+install -m 0755 ./chicha-isotope-map /usr/pkg/bin/chicha-isotope-map
+cat >/etc/rc.d/chicha_isotope_map <<"RC"
+#!/bin/sh
+# PROVIDE: chicha_isotope_map
+# REQUIRE: NETWORKING
+# KEYWORD: shutdown
+
+. /etc/rc.subr
+
+name="chicha_isotope_map"
+rcvar=$name
+command="/usr/pkg/bin/chicha-isotope-map"
+command_args="-port 8765"
+pidfile="/var/run/${name}.pid"
+
+load_rc_config $name
+: ${chicha_isotope_map:=NO}
+
+run_rc_command "$1"
+RC
+chmod +x /etc/rc.d/chicha_isotope_map
+if ! grep -q '^chicha_isotope_map=YES' /etc/rc.conf; then echo chicha_isotope_map=YES >> /etc/rc.conf; fi
+service chicha_isotope_map start'
+```
+
 ---
 
 ## Program screenshots

--- a/doc/README_RU.md
+++ b/doc/README_RU.md
@@ -77,6 +77,143 @@
    ```
 3. Откройте [http://localhost:8765](http://localhost:8765) — карта уже работает.
 
+### 🔧 Автозапуск: готовые скрипты (Linux, FreeBSD, OpenBSD, NetBSD)
+Ниже — copy/paste варианты под **stable-release**. Основано на официальной странице загрузки проекта: Linux systemd setup, FreeBSD/OpenBSD quick install и стабильные имена бинарников.
+
+#### Linux + systemd (amd64)
+```bash
+sudo bash -c 'set -euo pipefail
+curl -fL https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_amd64 -o /usr/local/bin/chicha-isotope-map
+chmod +x /usr/local/bin/chicha-isotope-map
+cat >/etc/systemd/system/chicha-isotope-map.service <<"UNIT"
+[Unit]
+Description=Chicha Isotope Map
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/chicha-isotope-map -port 8765
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+systemctl daemon-reload
+systemctl enable --now chicha-isotope-map
+systemctl status --no-pager chicha-isotope-map || true'
+```
+
+#### Linux + systemd (arm64)
+```bash
+sudo bash -c 'set -euo pipefail
+curl -fL https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_linux_arm64 -o /usr/local/bin/chicha-isotope-map
+chmod +x /usr/local/bin/chicha-isotope-map
+cat >/etc/systemd/system/chicha-isotope-map.service <<"UNIT"
+[Unit]
+Description=Chicha Isotope Map
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/chicha-isotope-map -port 8765
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+systemctl daemon-reload
+systemctl enable --now chicha-isotope-map
+systemctl status --no-pager chicha-isotope-map || true'
+```
+
+#### FreeBSD (rc.d, amd64/arm64)
+```bash
+# amd64: замените URL на *_arm64 если у вас arm64
+sudo sh -c 'set -eu
+fetch -o /usr/local/bin/chicha-isotope-map https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_freebsd_amd64
+chmod +x /usr/local/bin/chicha-isotope-map
+cat >/usr/local/etc/rc.d/chicha_isotope_map <<"RC"
+#!/bin/sh
+# PROVIDE: chicha_isotope_map
+# REQUIRE: NETWORKING
+# KEYWORD: shutdown
+
+. /etc/rc.subr
+
+name="chicha_isotope_map"
+rcvar="${name}_enable"
+command="/usr/local/bin/chicha-isotope-map"
+command_args="-port 8765 >> /var/log/chicha-isotope-map.log 2>&1"
+pidfile="/var/run/${name}.pid"
+
+load_rc_config $name
+: ${chicha_isotope_map_enable:=NO}
+
+run_rc_command "$1"
+RC
+chmod +x /usr/local/etc/rc.d/chicha_isotope_map
+sysrc chicha_isotope_map_enable=YES
+service chicha_isotope_map start'
+```
+
+#### OpenBSD (rc.d, amd64/arm64)
+```bash
+# amd64: замените URL на *_arm64 если у вас arm64
+sudo sh -c 'set -eu
+ftp -o /usr/local/bin/chicha-isotope-map https://github.com/matveynator/chicha-isotope-map/releases/download/stable-release/chicha-isotope-map_openbsd_amd64
+chmod +x /usr/local/bin/chicha-isotope-map
+cat >/etc/rc.d/chicha_isotope_map <<"RC"
+#!/bin/ksh
+
+daemon="/usr/local/bin/chicha-isotope-map"
+daemon_flags="-port 8765"
+
+. /etc/rc.d/rc.subr
+
+rc_bg=YES
+rc_cmd $1
+RC
+chmod +x /etc/rc.d/chicha_isotope_map
+rcctl enable chicha_isotope_map
+rcctl start chicha_isotope_map'
+```
+
+#### NetBSD (rc.d, amd64/arm64)
+```bash
+# В релизах нет отдельного netbsd артефакта, поэтому соберите бинарник на NetBSD:
+# GOOS=netbsd GOARCH=amd64 go build -o chicha-isotope-map .
+# (или GOARCH=arm64)
+
+sudo sh -c 'set -eu
+install -m 0755 ./chicha-isotope-map /usr/pkg/bin/chicha-isotope-map
+cat >/etc/rc.d/chicha_isotope_map <<"RC"
+#!/bin/sh
+# PROVIDE: chicha_isotope_map
+# REQUIRE: NETWORKING
+# KEYWORD: shutdown
+
+. /etc/rc.subr
+
+name="chicha_isotope_map"
+rcvar=$name
+command="/usr/pkg/bin/chicha-isotope-map"
+command_args="-port 8765"
+pidfile="/var/run/${name}.pid"
+
+load_rc_config $name
+: ${chicha_isotope_map:=NO}
+
+run_rc_command "$1"
+RC
+chmod +x /etc/rc.d/chicha_isotope_map
+if ! grep -q '^chicha_isotope_map=YES' /etc/rc.conf; then echo chicha_isotope_map=YES >> /etc/rc.conf; fi
+service chicha_isotope_map start'
+```
+
 Минимальная настройка (по желанию):
 - `-port 8765` — порт для локального запуска.
 - `-domain maps.example.org` — подключить домен и HTTPS (потребуются 80/443).


### PR DESCRIPTION
### Motivation
- Provide clear copy/paste instructions so users can install and enable the `chicha-isotope-map` server as an autostart service on Linux (`systemd`) and BSD (`rc.d`) systems for common architectures. 
- Cover both `amd64` and `arm64` Linux builds and give concrete download links that match the `stable-release` artifacts referenced in the project README. 
- Offer quick, low-friction setup options for FreeBSD, OpenBSD and NetBSD to help operators bring a public or local node online with minimal manual editing.

### Description
- Added a new section `### 🔧 Автозапуск: готовые скрипты (Linux, FreeBSD, OpenBSD, NetBSD)` to `doc/README_RU.md` containing copy/paste installation snippets. 
- Included `systemd` unit creation, binary download and `systemctl enable --now` steps for Linux `amd64` and `arm64` using the `stable-release` artifacts. 
- Added `rc.d` startup scripts and enabling instructions for FreeBSD and OpenBSD that download the matching stable binary and configure the service. 
- Added a NetBSD `rc.d` flow with a note to build the binary locally when no NetBSD artifact is published and commands to install and enable the service.

### Testing
- Verified the documentation diff with `git diff -- doc/README_RU.md` which showed the inserted autostart section and code blocks and the check succeeded. 
- Verified repository state with `git status --short` and committed the change with `git add` + `git commit -m "docs(ru): add autostart service scripts for Linux and BSD"`, both of which succeeded. 
- Inspected the updated file rendering via `nl -ba doc/README_RU.md` and command outputs used during editing (scripted insertion), and those checks completed without errors; no runtime tests were required for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee9f33d82c8332a90e32dd1e56f021)