### PR TITLE
stable release: restore release trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,8 @@ on:
       - completed
   workflow_dispatch:
 
-# A stable release is built only from a main-branch commit that passed Security.
+# A stable release is built only from a main-branch commit whose subject starts
+# with "stable release" and that passed Security.
 
 permissions:
   contents: write
@@ -55,7 +56,8 @@ jobs:
             exit 0
           fi
           subject="$(git show -s --format=%s "${RELEASE_COMMIT}")"
-          if [ "${subject}" = "stable release" ]; then
+          shopt -s nocasematch
+          if [[ "${subject}" =~ ^stable[[:space:]]+release([[:space:]:_-]|$) ]]; then
             echo "publish=true" >> "${GITHUB_OUTPUT}"
           else
             echo "publish=false" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
Fix the release marker regression introduced by the security-gated workflow.

- accept subjects beginning with `stable release`
- preserve the requirement that Security succeeds on a push to `main`
- keep manual dispatch behavior unchanged

Validated with positive and negative marker cases, YAML parsing, `git diff --check`, and `go test ./...`.